### PR TITLE
Fix dragging graphs under config dialog

### DIFF
--- a/public/html/GraphViewModel.html
+++ b/public/html/GraphViewModel.html
@@ -32,54 +32,54 @@
                         <div align="right">
                             <a class="config" align="right" data-toggle="modal" data-bind="attr:{'href': '#modal_'+id}" data-backdrop="true">Configure</a>
                         </div>
-                        <div data-bind="attr:{'id': 'modal_'+id}" class="modal fade" role="dialog">
-                            <div class=modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h4><span class="fa fa-cog"></span> Configure Graph</h4>
+                    </div>
+                </div>
+                <div data-bind="attr:{'id': 'modal_'+id}" class="modal fade" role="dialog">
+                    <div class=modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h4><span class="fa fa-cog"></span> Configure Graph</h4>
+                            </div>
+                            <div class="modal-body" style="height:200px">
+                                <div class="col-sm-6"><h5>Graph Types</h5>
+                                    <input type="radio" value="line" data-bind="checked: graphType, attr:{'id': 'lines_'+id}">
+                                    <label data-bind="attr:{'for': 'lines_'+id}">
+                                        Line Graph
+                                    </label><br>
+                                    <input type="radio" value="bar" data-bind="checked: graphType, attr:{'id': 'bars_'+id}">
+                                    <label data-bind="attr:{'for': 'bars_'+id}">
+                                        Bar Graph
+                                    </label><br>
+                                    <input type="radio" value="area" data-bind="checked: graphType, attr:{'id': 'area_'+id}">
+                                    <label data-bind="attr:{'for': 'area_'+id}">
+                                        Area Graph
+                                    </label><br>
+                                    <input type="radio" value="scatter" data-bind="checked: graphType, attr:{'id': 'scatter_'+id}">
+                                    <label data-bind="attr:{'for': 'scatter_'+id}">
+                                        Scatter Graph
+                                    </label>
+                                </div>
+                                <div class="col-sm-6"><h5>Graph Options</h5>
+                                    <div data-bind="visible: graphType()=='line'">
+                                        <input type="checkbox" data-bind="checked: renderDots, attr:{'id': 'dots_'+id}">
+                                        <label data-bind="attr:{'for': 'dots_'+id}">
+                                            <i class="fa fa-square-o" data-bind="visible: !renderDots()"></i>
+                                            <i class="fa fa-check-square-o" data-bind="visible: renderDots()"></i>
+                                            Show Dots
+                                        </label><br>
                                     </div>
-                                    <div class="modal-body" style="height:200px">
-                                        <div class="col-sm-6"><h5>Graph Types</h5>
-                                            <input type="radio" value="line" data-bind="checked: graphType, attr:{'id': 'lines_'+id}">
-                                            <label data-bind="attr:{'for': 'lines_'+id}">
-                                                Line Graph
-                                            </label><br>
-                                            <input type="radio" value="bar" data-bind="checked: graphType, attr:{'id': 'bars_'+id}">
-                                            <label data-bind="attr:{'for': 'bars_'+id}">
-                                                Bar Graph
-                                            </label><br>
-                                            <input type="radio" value="area" data-bind="checked: graphType, attr:{'id': 'area_'+id}">
-                                            <label data-bind="attr:{'for': 'area_'+id}">
-                                                Area Graph
-                                            </label><br>
-                                            <input type="radio" value="scatter" data-bind="checked: graphType, attr:{'id': 'scatter_'+id}">
-                                            <label data-bind="attr:{'for': 'scatter_'+id}">
-                                                Scatter Graph
-                                            </label>
-                                        </div>
-                                        <div class="col-sm-6"><h5>Graph Options</h5>
-                                            <div data-bind="visible: graphType()=='line'">
-                                                <input type="checkbox" data-bind="checked: renderDots, attr:{'id': 'dots_'+id}">
-                                                <label data-bind="attr:{'for': 'dots_'+id}">
-                                                    <i class="fa fa-square-o" data-bind="visible: !renderDots()"></i>
-                                                    <i class="fa fa-check-square-o" data-bind="visible: renderDots()"></i>
-                                                    Show Dots
-                                                </label><br>
-                                            </div>
-                                            <div data-bind="visible: graphType()=='bar'">
-                                                <input type="checkbox" data-bind="checked: renderStacked, attr:{'id': 'stacked_'+id}">
-                                                <label data-bind="attr:{'for': 'stacked_'+id}">
-                                                    <i class="fa fa-square-o" data-bind="visible: !renderStacked()"></i>
-                                                    <i class="fa fa-check-square-o" data-bind="visible: renderStacked()"></i>
-                                                    Show Stacked
-                                                </label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                    <div data-bind="visible: graphType()=='bar'">
+                                        <input type="checkbox" data-bind="checked: renderStacked, attr:{'id': 'stacked_'+id}">
+                                        <label data-bind="attr:{'for': 'stacked_'+id}">
+                                            <i class="fa fa-square-o" data-bind="visible: !renderStacked()"></i>
+                                            <i class="fa fa-check-square-o" data-bind="visible: renderStacked()"></i>
+                                            Show Stacked
+                                        </label>
                                     </div>
                                 </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Make the config modal a sibling of the sortable graph instead of a child.  This makes it so that the draggable handle is below the modal.