### PR TITLE
Assert typeahead's dependency on jquery in RequireJS config.

### DIFF
--- a/app/assets/javascripts/start_app.ts
+++ b/app/assets/javascripts/start_app.ts
@@ -63,6 +63,9 @@ requirejs.config({
         },
         'bootstrap' : {
             deps : [ 'jquery' ]
+        },
+        'typeahead' : {
+            deps : [ 'jquery']
         }
     }
 });


### PR DESCRIPTION
Fixes #50 