### PR TITLE
Findbugs Fail on Error

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,8 +24,12 @@ import com.typesafe.sbt.pgp.PgpKeys._
 import com.typesafe.sbt.rjs.Import._
 import com.typesafe.sbt.web.Import._
 import com.typesafe.sbt.web.js.JS
-import de.johoop.findbugs4sbt.FindBugs._
-import de.johoop.findbugs4sbt.{Effort, Priority, ReportType}
+//import uk.co.josephearl.sbt.findbugs._
+//import uk.co.josephearl.sbt.findbugs.FindBugsPlugin._
+import uk.co.josephearl.sbt.findbugs.FindBugsPlugin.autoImport._
+//import uk.co.josephearl.sbt.findbugs.FindBugsEffort._
+//import uk.co.josephearl.sbt.findbugs.FindBugsPriority
+//import uk.co.josephearl.sbt.findbugs.FindBugsReportType
 import play.routes.compiler.InjectedRoutesGenerator
 import play.sbt.PlayImport.PlayKeys._
 import play.sbt.routes.RoutesKeys.routesGenerator
@@ -43,7 +47,7 @@ object ApplicationBuild extends Build {
     val akkaVersion = "2.4.2"
     val jacksonVersion = "2.7.3"
 
-    val s = findbugsSettings ++ CheckstyleSettings.checkstyleTask ++ aspectjSettings
+    val s = CheckstyleSettings.checkstyleTask ++ aspectjSettings
 
     val appDependencies = Seq(
       "cglib" % "cglib" % "3.2.1",
@@ -285,10 +289,11 @@ object ApplicationBuild extends Build {
     sonatypeProfileName := "com.arpnetworking",
 
       // Findbugs
-      findbugsReportType := Some(ReportType.Html),
+      findbugsFailOnError := true,
+      findbugsReportType := Some(FindBugsReportType.Xml),
       findbugsReportPath := Some(target.value / "findbugs" / "findbugs.html"),
-      findbugsPriority := Priority.Low,
-      findbugsEffort := Effort.Maximum,
+      findbugsPriority := FindBugsPriority.Low,
+      findbugsEffort := FindBugsEffort.Maximum,
       findbugsExcludeFilters := Some(
         <FindBugsFilter>
           <Match>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 // The SBT Community repository
 resolvers += "SBT Community repository" at "http://dl.bintray.com/sbt/sbt-plugin-releases/"
 
-addSbtPlugin("de.johoop" %% "findbugs4sbt" % "1.4.0")
+addSbtPlugin("uk.co.josephearl" % "sbt-findbugs" % "2.4.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.10.3")
 


### PR DESCRIPTION
Switched Findbugs plugins to https://github.com/JosephEarl/sbt-findbugs and enabled fail on error.

This addresses #30.

```
[ville:metrics-portal (master|✚2)]$ ./activator findbugs
[info] Loading project definition from /Users/ville/Workspace/ArpNetworking/metrics-portal/project
[info] Compiling 1 Scala source to /Users/ville/Workspace/ArpNetworking/metrics-portal/project/target/scala-2.10/sbt-0.13/classes...
[info] Set current project to metrics-portal (in build file:/Users/ville/Workspace/ArpNetworking/metrics-portal/)
[error] Warnings generated: 1
[error] SIC_INNER_SHOULD_BE_STATIC_ANON found in controllers/ProxyController.java:67: priority 3 category PERFORMANCE
[error] Class controllers.ProxyController$1 found in controllers/ProxyController.java:67-72
[error] 1 issue(s) found in FindBugs report: /Users/ville/Workspace/ArpNetworking/metrics-portal/target/findbugs/findbugs.html
```