### PR TITLE
Organization support

### DIFF
--- a/app/actors/ClusterShutdownActor.java
+++ b/app/actors/ClusterShutdownActor.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package actors;
+
+import akka.actor.Address;
+import akka.actor.Props;
+import akka.actor.UntypedActor;
+import akka.cluster.Cluster;
+import akka.cluster.ClusterEvent;
+import akka.cluster.Member;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Actor that subscribes to cluster events and triggers a CompletableFuture when it sees itself removed
+ * from the cluster.
+ *
+ * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
+ */
+public class ClusterShutdownActor extends UntypedActor {
+    /**
+     * Creates a {@link Props} for this actor.
+     *
+     * @param shutdownFuture A future to be completed at cluster shutdown.
+     * @return A new Props.
+     */
+    public static Props props(final CompletableFuture<Boolean> shutdownFuture) {
+        return Props.create(ClusterShutdownActor.class, shutdownFuture);
+    }
+
+    /**
+     * Public constructor.
+     *
+     * @param shutdownFuture A future to be completed at cluster shutdown.
+     */
+    public ClusterShutdownActor(final CompletableFuture<Boolean> shutdownFuture) {
+        _shutdownFuture = shutdownFuture;
+
+        final Cluster cluster = Cluster.get(context().system());
+        _selfAddress = cluster.selfAddress();
+        cluster.subscribe(self(), ClusterEvent.initialStateAsEvents(), ClusterEvent.MemberRemoved.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onReceive(final Object message) throws Throwable {
+        if (message instanceof ClusterEvent.MemberRemoved) {
+            final ClusterEvent.MemberRemoved removed = (ClusterEvent.MemberRemoved) message;
+            final Member member = removed.member();
+            if (_selfAddress.equals(member.address())) {
+                _shutdownFuture.complete(Boolean.TRUE);
+            }
+        } else {
+            unhandled(message);
+        }
+    }
+
+    private final CompletableFuture<Boolean> _shutdownFuture;
+    private final Address _selfAddress;
+}

--- a/app/com/arpnetworking/database/h2/triggers/ExpressionsUpdateEtagTrigger.java
+++ b/app/com/arpnetworking/database/h2/triggers/ExpressionsUpdateEtagTrigger.java
@@ -15,6 +15,8 @@
  */
 package com.arpnetworking.database.h2.triggers;
 
+import models.ebean.ExpressionEtags;
+
 /**
  * Trigger to update Etag after every insert, delete or update statement.
  *
@@ -26,6 +28,6 @@ public class ExpressionsUpdateEtagTrigger extends BaseUpdateEtagTrigger {
      * Public no args constructor.
      */
     public ExpressionsUpdateEtagTrigger() {
-        super("portal.expressions_etag_seq");
+        super(ExpressionEtags::incrementEtag, 9);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/alerts/AlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/AlertRepository.java
@@ -17,6 +17,7 @@ package com.arpnetworking.metrics.portal.alerts;
 
 import models.internal.Alert;
 import models.internal.AlertQuery;
+import models.internal.Organization;
 import models.internal.QueryResult;
 
 import java.util.Optional;
@@ -43,16 +44,18 @@ public interface AlertRepository {
      * Get the <code>Alert</code> by identifier.
      *
      * @param identifier The <code>Alert</code> identifier.
+     * @param organization The organization owning the alert.
      * @return The matching <code>Alert</code> if found or <code>Optional.empty()</code>.
      */
-    Optional<Alert> get(final UUID identifier);
+    Optional<Alert> get(UUID identifier, Organization organization);
 
     /**
      * Create a query against the alerts repository.
      *
+     * @param organization Organization to search in.
      * @return Instance of <code>AlertQuery</code>.
      */
-    AlertQuery createQuery();
+    AlertQuery createQuery(Organization organization);
 
     /**
      * Query alerts.
@@ -65,14 +68,16 @@ public interface AlertRepository {
     /**
      * Retrieve the total number of alerts in the repository.
      *
+     * @param organization The organization owning the alerts.
      * @return The total number of alerts.
      */
-    long getAlertCount();
+    long getAlertCount(Organization organization);
 
     /**
      * Add a new alert or update an existing one in the repository.
      *
      * @param alert The alert to add to the repository.
+     * @param organization The organization owning the alert.
      */
-    void addOrUpdateAlert(Alert alert);
+    void addOrUpdateAlert(Alert alert, Organization organization);
 }

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/NoAlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/NoAlertRepository.java
@@ -22,6 +22,7 @@ import com.arpnetworking.steno.LoggerFactory;
 import com.google.inject.Inject;
 import models.internal.Alert;
 import models.internal.AlertQuery;
+import models.internal.Organization;
 import models.internal.QueryResult;
 import models.internal.impl.DefaultAlertQuery;
 import models.internal.impl.DefaultQueryResult;
@@ -68,11 +69,12 @@ public final class NoAlertRepository extends ReadOnlyAbstractAlertRepository {
      * {@inheritDoc}
      */
     @Override
-    public Optional<Alert> get(final UUID identifier) {
+    public Optional<Alert> get(final UUID identifier, final Organization organization) {
         assertIsOpen();
         LOGGER.debug()
                 .setMessage("Getting alert")
                 .addData("identifier", identifier)
+                .addData("organization", organization)
                 .log();
         return Optional.empty();
     }
@@ -81,9 +83,12 @@ public final class NoAlertRepository extends ReadOnlyAbstractAlertRepository {
      * {@inheritDoc}
      */
     @Override
-    public AlertQuery createQuery() {
-        LOGGER.debug().setMessage("Preparing query").log();
-        return new DefaultAlertQuery(this);
+    public AlertQuery createQuery(final Organization organization) {
+        LOGGER.debug()
+                .setMessage("Preparing query")
+                .addData("organization", organization)
+                .log();
+        return new DefaultAlertQuery(this, organization);
     }
 
     /**
@@ -103,9 +108,12 @@ public final class NoAlertRepository extends ReadOnlyAbstractAlertRepository {
      * {@inheritDoc}
      */
     @Override
-    public long getAlertCount() {
+    public long getAlertCount(final Organization organization) {
         assertIsOpen();
-        LOGGER.debug().setMessage("Getting alert count").log();
+        LOGGER.debug()
+                .setMessage("Getting alert count")
+                .addData("organization", organization)
+                .log();
         return 0;
     }
 

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/ReadOnlyAbstractAlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/ReadOnlyAbstractAlertRepository.java
@@ -19,6 +19,7 @@ import com.arpnetworking.metrics.portal.alerts.AlertRepository;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
 import models.internal.Alert;
+import models.internal.Organization;
 
 /**
  * Abstract repository that overrides the write functions for the <code>AlertRepository</code>.
@@ -31,7 +32,7 @@ public abstract class ReadOnlyAbstractAlertRepository implements AlertRepository
      * {@inheritDoc}
      */
     @Override
-    public void addOrUpdateAlert(final Alert alert) {
+    public void addOrUpdateAlert(final Alert alert, final Organization organization) {
         throw new UnsupportedOperationException("This is a read only repository.");
     }
 

--- a/app/com/arpnetworking/metrics/portal/expressions/ExpressionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/expressions/ExpressionRepository.java
@@ -17,6 +17,7 @@ package com.arpnetworking.metrics.portal.expressions;
 
 import models.internal.Expression;
 import models.internal.ExpressionQuery;
+import models.internal.Organization;
 import models.internal.QueryResult;
 
 import java.util.Optional;
@@ -43,16 +44,18 @@ public interface ExpressionRepository {
      * Get the <code>Expression</code> by identifier.
      *
      * @param identifier The <code>Expression</code> identifier.
+     * @param organization The organization owning the expression.
      * @return The matching <code>Expression</code> if found or <code>Optional.empty()</code>.
      */
-    Optional<Expression> get(final UUID identifier);
+    Optional<Expression> get(UUID identifier, Organization organization);
 
     /**
      * Create a query against the expressions repository.
      *
+     * @param organization Organization to search in.
      * @return Instance of <code>ExpressionQuery</code>.
      */
-    ExpressionQuery createQuery();
+    ExpressionQuery createQuery(Organization organization);
 
     /**
      * Query expressions.
@@ -65,14 +68,16 @@ public interface ExpressionRepository {
     /**
      * Retrieve the total number of expressions in the repository.
      *
+     * @param organization The organization owning the expressions.
      * @return The total number of expressions.
      */
-    long getExpressionCount();
+    long getExpressionCount(Organization organization);
 
     /**
      * Add a new expression or update an existing one in the repository.
      *
      * @param expression The expression to add to the repository.
+     * @param organization The organization owning the expression.
      */
-    void addOrUpdateExpression(Expression expression);
+    void addOrUpdateExpression(Expression expression, Organization organization);
 }

--- a/app/com/arpnetworking/metrics/portal/expressions/impl/NoExpressionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/expressions/impl/NoExpressionRepository.java
@@ -22,6 +22,7 @@ import com.arpnetworking.steno.LoggerFactory;
 import com.google.inject.Inject;
 import models.internal.Expression;
 import models.internal.ExpressionQuery;
+import models.internal.Organization;
 import models.internal.QueryResult;
 import models.internal.impl.DefaultExpressionQuery;
 import models.internal.impl.DefaultQueryResult;
@@ -68,11 +69,12 @@ public final class NoExpressionRepository extends ReadOnlyAbstractExpressionRepo
      * {@inheritDoc}
      */
     @Override
-    public Optional<Expression> get(final UUID identifier) {
+    public Optional<Expression> get(final UUID identifier, final Organization organization) {
         assertIsOpen();
         LOGGER.debug()
                 .setMessage("Getting expression")
                 .addData("identifier", identifier)
+                .addData("organization", organization)
                 .log();
         return Optional.empty();
     }
@@ -81,9 +83,12 @@ public final class NoExpressionRepository extends ReadOnlyAbstractExpressionRepo
      * {@inheritDoc}
      */
     @Override
-    public ExpressionQuery createQuery() {
-        LOGGER.debug().setMessage("Preparing query").log();
-        return new DefaultExpressionQuery(this);
+    public ExpressionQuery createQuery(final Organization organization) {
+        LOGGER.debug()
+                .setMessage("Preparing query")
+                .addData("organization", organization)
+                .log();
+        return new DefaultExpressionQuery(this, organization);
     }
 
     /**
@@ -103,9 +108,12 @@ public final class NoExpressionRepository extends ReadOnlyAbstractExpressionRepo
      * {@inheritDoc}
      */
     @Override
-    public long getExpressionCount() {
+    public long getExpressionCount(final Organization organization) {
         assertIsOpen();
-        LOGGER.debug().setMessage("Getting expression count").log();
+        LOGGER.debug()
+                .setMessage("Getting expression count")
+                .addData("organization", organization)
+                .log();
         return 0;
     }
 

--- a/app/com/arpnetworking/metrics/portal/expressions/impl/ReadOnlyAbstractExpressionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/expressions/impl/ReadOnlyAbstractExpressionRepository.java
@@ -19,6 +19,7 @@ import com.arpnetworking.metrics.portal.expressions.ExpressionRepository;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
 import models.internal.Expression;
+import models.internal.Organization;
 
 /**
  * Abstract repository that overrides the write functions for the expression repository.
@@ -31,7 +32,7 @@ public abstract class ReadOnlyAbstractExpressionRepository implements Expression
      * {@inheritDoc}
      */
     @Override
-    public void addOrUpdateExpression(final Expression expression) {
+    public void addOrUpdateExpression(final Expression expression, final Organization organization) {
         throw new UnsupportedOperationException("This is a read only repository.");
     }
 

--- a/app/com/arpnetworking/metrics/portal/hosts/HostRepository.java
+++ b/app/com/arpnetworking/metrics/portal/hosts/HostRepository.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.portal.hosts;
 import models.internal.Host;
 import models.internal.HostQuery;
 import models.internal.MetricsSoftwareState;
+import models.internal.Organization;
 import models.internal.QueryResult;
 
 /**
@@ -43,22 +44,25 @@ public interface HostRepository extends AutoCloseable {
      * Add a new host or update an existing host in the repository.
      *
      * @param host The host to add to the repository.
+     * @param organization The organization owning the host.
      */
-    void addOrUpdateHost(Host host);
+    void addOrUpdateHost(Host host, Organization organization);
 
     /**
      * Remove the host by hostname from the repository.
      *
      * @param hostname The hostname of the host to remove.
+     * @param organization The organization owning the host.
      */
-    void deleteHost(String hostname);
+    void deleteHost(String hostname, Organization organization);
 
     /**
      * Create a query against the hosts repository.
      *
+     * @param organization Organization to search in.
      * @return Instance of <code>HostQuery</code>.
      */
-    HostQuery createQuery();
+    HostQuery createQuery(Organization organization);
 
     /**
      * Query the hosts repository.
@@ -66,21 +70,23 @@ public interface HostRepository extends AutoCloseable {
      * @param query Instance of <code>HostQuery</code>.
      * @return Instance of <code>HostQueryResult</code>.
      */
-    QueryResult<Host> query(final HostQuery query);
+    QueryResult<Host> query(HostQuery query);
 
     /**
      * Retrieve the total number of hosts in the repository.
      *
+     * @param organization The organization owning the hosts.
      * @return The total number of hosts.
      */
-    long getHostCount();
+    long getHostCount(Organization organization);
 
     /**
      * Retrieve the number of hosts with metrics software in the specified
      * state.
      *
      * @param metricsSoftwareState The state to filter on.
+     * @param organization The organization owning the host.
      * @return The number of hosts in the specified state.
      */
-    long getHostCount(MetricsSoftwareState metricsSoftwareState);
+    long getHostCount(MetricsSoftwareState metricsSoftwareState, Organization organization);
 }

--- a/app/com/arpnetworking/metrics/portal/hosts/impl/ForemanHostProvider.java
+++ b/app/com/arpnetworking/metrics/portal/hosts/impl/ForemanHostProvider.java
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import models.internal.Host;
 import models.internal.MetricsSoftwareState;
+import models.internal.Organization;
 import models.internal.impl.DefaultHost;
 import play.Configuration;
 import play.libs.ws.WSClient;
@@ -78,7 +79,7 @@ public final class ForemanHostProvider extends UntypedActor {
                         .setHostname(host.getName())
                         .setMetricsSoftwareState(MetricsSoftwareState.UNKNOWN)
                         .build();
-                _hostRepository.addOrUpdateHost(dh);
+                _hostRepository.addOrUpdateHost(dh, Organization.DEFAULT);
             }
 
             if (response.getTotal() > response.getPage() * response.getPerPage()) {

--- a/app/com/arpnetworking/metrics/portal/hosts/impl/NoHostRepository.java
+++ b/app/com/arpnetworking/metrics/portal/hosts/impl/NoHostRepository.java
@@ -24,6 +24,7 @@ import com.google.inject.Inject;
 import models.internal.Host;
 import models.internal.HostQuery;
 import models.internal.MetricsSoftwareState;
+import models.internal.Organization;
 import models.internal.QueryResult;
 import models.internal.impl.DefaultHostQuery;
 import models.internal.impl.DefaultQueryResult;
@@ -70,11 +71,12 @@ public final class NoHostRepository implements HostRepository {
      * {@inheritDoc}
      */
     @Override
-    public void addOrUpdateHost(final Host host) {
+    public void addOrUpdateHost(final Host host, final Organization organization) {
         assertIsOpen();
         LOGGER.debug()
                 .setMessage("Adding or updating host")
                 .addData("host", host)
+                .addData("organization", organization)
                 .log();
     }
 
@@ -82,11 +84,12 @@ public final class NoHostRepository implements HostRepository {
      * {@inheritDoc}
      */
     @Override
-    public void deleteHost(final String hostname) {
+    public void deleteHost(final String hostname, final Organization organization) {
         assertIsOpen();
         LOGGER.debug()
                 .setMessage("Deleting host")
                 .addData("hostname", hostname)
+                .addData("organization", organization)
                 .log();
     }
 
@@ -95,10 +98,13 @@ public final class NoHostRepository implements HostRepository {
      * {@inheritDoc}
      */
     @Override
-    public HostQuery createQuery() {
+    public HostQuery createQuery(final Organization organization) {
         assertIsOpen();
-        LOGGER.debug().setMessage("Preparing query").log();
-        return new DefaultHostQuery(this);
+        LOGGER.debug()
+                .setMessage("Preparing query")
+                .addData("organization", organization)
+                .log();
+        return new DefaultHostQuery(this, organization);
     }
 
     /**
@@ -118,9 +124,12 @@ public final class NoHostRepository implements HostRepository {
      * {@inheritDoc}
      */
     @Override
-    public long getHostCount() {
+    public long getHostCount(final Organization organization) {
         assertIsOpen();
-        LOGGER.debug().setMessage("Getting host count").log();
+        LOGGER.debug()
+                .setMessage("Getting host count")
+                .addData("organization", organization)
+                .log();
         return 0;
     }
 
@@ -128,11 +137,12 @@ public final class NoHostRepository implements HostRepository {
      * {@inheritDoc}
      */
     @Override
-    public long getHostCount(final MetricsSoftwareState metricsSoftwareState) {
+    public long getHostCount(final MetricsSoftwareState metricsSoftwareState, final Organization organization) {
         assertIsOpen();
         LOGGER.debug()
                 .setMessage("Getting host count in state")
                 .addData("state", metricsSoftwareState)
+                .addData("organization", organization)
                 .log();
         return 0;
     }

--- a/app/com/arpnetworking/metrics/portal/hosts/impl/RandomHostProvider.java
+++ b/app/com/arpnetworking/metrics/portal/hosts/impl/RandomHostProvider.java
@@ -26,6 +26,7 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import models.internal.Host;
 import models.internal.MetricsSoftwareState;
+import models.internal.Organization;
 import models.internal.impl.DefaultHost;
 import org.joda.time.Duration;
 import play.Configuration;
@@ -79,7 +80,7 @@ public final class RandomHostProvider extends UntypedActor {
                         .addData("actor", self())
                         .addData("hostname", newHost.getHostname())
                         .log();
-                _hostRepository.addOrUpdateHost(newHost);
+                _hostRepository.addOrUpdateHost(newHost, Organization.DEFAULT);
                 if (_hostUpdateOne > 0) {
                     final Host updatedHost = new DefaultHost.Builder()
                             .setHostname("test-app" + _hostUpdateOne + ".example.com")
@@ -91,7 +92,7 @@ public final class RandomHostProvider extends UntypedActor {
                             .addData("actor", self())
                             .addData("hostname", updatedHost.getHostname())
                             .log();
-                    _hostRepository.addOrUpdateHost(updatedHost);
+                    _hostRepository.addOrUpdateHost(updatedHost, Organization.DEFAULT);
                 }
                 if (_hostUpdateTwo > 0) {
                     final Host updatedHost = new DefaultHost.Builder()
@@ -104,7 +105,7 @@ public final class RandomHostProvider extends UntypedActor {
                             .addData("actor", self())
                             .addData("hostname", updatedHost.getHostname())
                             .log();
-                    _hostRepository.addOrUpdateHost(updatedHost);
+                    _hostRepository.addOrUpdateHost(updatedHost, Organization.DEFAULT);
                 }
                 if (_hostRemove > 0) {
                     final String deletedHostName = "test-app" + _hostRemove + ".example..com";
@@ -113,7 +114,7 @@ public final class RandomHostProvider extends UntypedActor {
                             .addData("actor", self())
                             .addData("hostname", deletedHostName)
                             .log();
-                    _hostRepository.deleteHost(deletedHostName);
+                    _hostRepository.deleteHost(deletedHostName, Organization.DEFAULT);
                 }
                 ++_hostAdd;
                 ++_hostUpdateOne;

--- a/app/controllers/AlertController.java
+++ b/app/controllers/AlertController.java
@@ -31,6 +31,7 @@ import models.internal.AlertQuery;
 import models.internal.Context;
 import models.internal.NagiosExtension;
 import models.internal.Operator;
+import models.internal.Organization;
 import models.internal.Quantity;
 import models.internal.QueryResult;
 import models.internal.impl.DefaultAlert;
@@ -89,7 +90,7 @@ public class AlertController extends Controller {
         }
 
         try {
-            _alertRepository.addOrUpdateAlert(alert);
+            _alertRepository.addOrUpdateAlert(alert, Organization.DEFAULT);
             // CHECKSTYLE.OFF: IllegalCatch - Convert any exception to 500
         } catch (final Exception e) {
             // CHECKSTYLE.ON: IllegalCatch
@@ -159,7 +160,7 @@ public class AlertController extends Controller {
         }
 
         // Build a host repository query
-        final AlertQuery query = _alertRepository.createQuery()
+        final AlertQuery query = _alertRepository.createQuery(Organization.DEFAULT)
                 .contains(argContains)
                 .context(argContext)
                 .service(argService)
@@ -207,7 +208,7 @@ public class AlertController extends Controller {
      */
     public Result get(final String id) {
         final UUID identifier = UUID.fromString(id);
-        final Optional<Alert> result = _alertRepository.get(identifier);
+        final Optional<Alert> result = _alertRepository.get(identifier, Organization.DEFAULT);
         if (!result.isPresent()) {
             return notFound();
         }
@@ -292,10 +293,12 @@ public class AlertController extends Controller {
 
     private ImmutableMap<String, Object> mergeExtensions(final NagiosExtension nagiosExtension) {
         final ImmutableMap.Builder<String, Object> nagiosMapBuilder = ImmutableMap.builder();
-        nagiosMapBuilder.put(NAGIOS_EXTENSION_SEVERITY_KEY, nagiosExtension.getSeverity());
-        nagiosMapBuilder.put(NAGIOS_EXTENSION_NOTIFY_KEY, nagiosExtension.getNotify());
-        nagiosMapBuilder.put(NAGIOS_EXTENSION_MAX_CHECK_ATTEMPTS_KEY, nagiosExtension.getMaxCheckAttempts());
-        nagiosMapBuilder.put(NAGIOS_EXTENSION_FRESHNESS_THRESHOLD_KEY, nagiosExtension.getFreshnessThreshold().getStandardSeconds());
+        if (nagiosExtension != null) {
+            nagiosMapBuilder.put(NAGIOS_EXTENSION_SEVERITY_KEY, nagiosExtension.getSeverity());
+            nagiosMapBuilder.put(NAGIOS_EXTENSION_NOTIFY_KEY, nagiosExtension.getNotify());
+            nagiosMapBuilder.put(NAGIOS_EXTENSION_MAX_CHECK_ATTEMPTS_KEY, nagiosExtension.getMaxCheckAttempts());
+            nagiosMapBuilder.put(NAGIOS_EXTENSION_FRESHNESS_THRESHOLD_KEY, nagiosExtension.getFreshnessThreshold().getStandardSeconds());
+        }
         return nagiosMapBuilder.build();
     }
 

--- a/app/controllers/ExpressionController.java
+++ b/app/controllers/ExpressionController.java
@@ -27,6 +27,7 @@ import com.google.common.net.HttpHeaders;
 import com.google.inject.Inject;
 import models.internal.Expression;
 import models.internal.ExpressionQuery;
+import models.internal.Organization;
 import models.internal.QueryResult;
 import models.internal.impl.DefaultExpression;
 import models.view.PagedContainer;
@@ -82,7 +83,7 @@ public class ExpressionController extends Controller {
         }
 
         try {
-            _expressionRepository.addOrUpdateExpression(expression);
+            _expressionRepository.addOrUpdateExpression(expression, Organization.DEFAULT);
             // CHECKSTYLE.OFF: IllegalCatch - Convert any exception to 500
         } catch (final Exception e) {
             // CHECKSTYLE.ON: IllegalCatch
@@ -140,7 +141,7 @@ public class ExpressionController extends Controller {
         }
 
         // Build a host repository query
-        final ExpressionQuery query = _expressionRepository.createQuery()
+        final ExpressionQuery query = _expressionRepository.createQuery(Organization.DEFAULT)
                 .contains(argContains)
                 .service(argService)
                 .cluster(argCluster)
@@ -221,7 +222,7 @@ public class ExpressionController extends Controller {
      */
     public Result get(final String id) {
         final UUID identifier = UUID.fromString(id);
-        final Optional<Expression> result = _expressionRepository.get(identifier);
+        final Optional<Expression> result = _expressionRepository.get(identifier, Organization.DEFAULT);
         if (!result.isPresent()) {
             return notFound();
         }

--- a/app/controllers/HostController.java
+++ b/app/controllers/HostController.java
@@ -26,6 +26,7 @@ import com.google.inject.Inject;
 import models.internal.Host;
 import models.internal.HostQuery;
 import models.internal.MetricsSoftwareState;
+import models.internal.Organization;
 import models.internal.QueryResult;
 import models.view.PagedContainer;
 import models.view.Pagination;
@@ -121,7 +122,7 @@ public class HostController extends Controller {
         }
 
         // Build a host repository query
-        final HostQuery query = _hostRepository.createQuery()
+        final HostQuery query = _hostRepository.createQuery(Organization.DEFAULT)
                 .partialHostname(argName)
                 .metricsSoftwareState(argState)
                 .cluster(argCluster)
@@ -141,7 +142,7 @@ public class HostController extends Controller {
 
         final QueryResult<Host> result;
         try {
-            result = query.execute();
+            result = _hostRepository.query(query);
             // CHECKSTYLE.OFF: IllegalCatch - Convert any exception to 500
         } catch (final Exception e) {
             // CHECKSTYLE.ON: IllegalCatch

--- a/app/models/ebean/Alert.java
+++ b/app/models/ebean/Alert.java
@@ -31,6 +31,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Version;
@@ -99,6 +101,10 @@ public class Alert extends Model {
 
     @OneToOne(mappedBy = "alert", cascade = CascadeType.ALL)
     private NagiosExtension nagiosExtension;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "organization")
+    private Organization organization;
 
     public Long getId() {
         return id;
@@ -226,6 +232,14 @@ public class Alert extends Model {
 
     public void setNagiosExtension(final NagiosExtension value) {
         nagiosExtension = value;
+    }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(final Organization organizationValue) {
+        this.organization = organizationValue;
     }
 }
 // CHECKSTYLE.ON: MemberNameCheck

--- a/app/models/ebean/AlertEtags.java
+++ b/app/models/ebean/AlertEtags.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package models.ebean;
+
+import com.avaje.ebean.Model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * Model class to represent alert etag records.
+ *
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ */
+// CHECKSTYLE.OFF: MemberNameCheck
+@Entity
+@Table(name = "alerts_etags", schema = "portal")
+public class AlertEtags extends Model {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "organization")
+    private Organization organization;
+
+    @Column(nullable = false)
+    private long etag;
+
+    /**
+     * Increments an etag record or creates one if it does not exist.
+     *
+     * @param organization the organization
+     */
+    public static void incrementEtag(final Organization organization) {
+        AlertEtags etag = FINDER.setForUpdate(true)
+                .where()
+                .eq("organization", organization)
+                .findUnique();
+        if (etag == null) {
+            etag = new AlertEtags();
+            etag.setOrganization(organization);
+            etag.setEtag(1);
+        } else {
+            etag.setEtag(etag.getEtag() + 1);
+        }
+        etag.save();
+    }
+
+    /**
+     * Looks up an etag value for an organization.
+     *
+     * @param organization the organization
+     * @return the etag value, or 0 if a value does not exist in the table
+     */
+    public static long getEtagByOrganization(final models.internal.Organization organization) {
+        final AlertEtags etag = FINDER.where()
+                .eq("organization.uuid", organization.getId())
+                .findUnique();
+        if (etag != null) {
+            return etag.getEtag();
+        }
+        return 0;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(final Long value) {
+        id = value;
+    }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(final Organization value) {
+        organization = value;
+    }
+
+    public long getEtag() {
+        return etag;
+    }
+
+    public void setEtag(final long value) {
+        etag = value;
+    }
+
+    private static final Finder<Long, AlertEtags> FINDER = new Finder<>(AlertEtags.class);
+}
+// CHECKSTYLE.ON: MemberNameCheck

--- a/app/models/ebean/ExpressionEtags.java
+++ b/app/models/ebean/ExpressionEtags.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package models.ebean;
+
+import com.avaje.ebean.Model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * Model class to represent expression etag records.
+ *
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ */
+// CHECKSTYLE.OFF: MemberNameCheck
+@Entity
+@Table(name = "expressions_etags", schema = "portal")
+public class ExpressionEtags extends Model {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "organization")
+    private Organization organization;
+
+    @Column(nullable = false)
+    private long etag;
+
+    /**
+     * Increments an etag record or creates one if it does not exist.
+     *
+     * @param organization the organization
+     */
+    public static void incrementEtag(final Organization organization) {
+        ExpressionEtags etag = FINDER.setForUpdate(true)
+                .where()
+                .eq("organization", organization)
+                .findUnique();
+        if (etag == null) {
+            etag = new ExpressionEtags();
+            etag.setOrganization(organization);
+            etag.setEtag(1);
+        } else {
+            etag.setEtag(etag.getEtag() + 1);
+        }
+        etag.save();
+    }
+
+    /**
+     * Looks up an etag value for an organization.
+     *
+     * @param organization the organization
+     * @return the etag value, or 0 if a value does not exist in the table
+     */
+    public static long getEtagByOrganization(final models.internal.Organization organization) {
+        final ExpressionEtags etag = FINDER.where()
+                .eq("organization.uuid", organization.getId())
+                .findUnique();
+        if (etag != null) {
+            return etag.getEtag();
+        }
+        return 0;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(final Long value) {
+        id = value;
+    }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(final Organization value) {
+        organization = value;
+    }
+
+    public long getEtag() {
+        return etag;
+    }
+
+    public void setEtag(final long value) {
+        etag = value;
+    }
+
+    private static final Finder<Long, ExpressionEtags> FINDER = new Finder<>(ExpressionEtags.class);
+}
+// CHECKSTYLE.ON: MemberNameCheck

--- a/app/models/ebean/Host.java
+++ b/app/models/ebean/Host.java
@@ -25,6 +25,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
@@ -63,6 +65,10 @@ public class Host extends Model {
 
     @Column(name = "metrics_software_state")
     private String metricsSoftwareState;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "organization")
+    private Organization organization;
 
     public Long getId() {
         return id;
@@ -118,6 +124,14 @@ public class Host extends Model {
 
     public void setMetricsSoftwareState(final String value) {
         metricsSoftwareState = value;
+    }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(final Organization organizationValue) {
+        this.organization = organizationValue;
     }
 }
 // CHECKSTYLE.ON: MemberNameCheck

--- a/app/models/ebean/Organization.java
+++ b/app/models/ebean/Organization.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Groupon.com
+ * Copyright 2016 Smartsheet.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,30 +21,33 @@ import com.avaje.ebean.annotation.UpdatedTimestamp;
 
 import java.sql.Timestamp;
 import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
 /**
- * Data model for expressions.
+ * Data model for organizations.
  *
- * @author Deepika Misra (deepika at groupon dot com)
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
  */
 // CHECKSTYLE.OFF: MemberNameCheck
 @Entity
-@Table(name = "expressions", schema = "portal")
-public class Expression extends Model {
+@Table(name = "organizations", schema = "portal")
+public class Organization extends Model {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
+
+    @Column(name = "uuid")
+    private UUID uuid;
 
     @Version
     @Column(name = "version")
@@ -58,24 +61,31 @@ public class Expression extends Model {
     @Column(name = "updated_at")
     private Timestamp updatedAt;
 
-    @Column(name = "uuid")
-    private UUID uuid;
+    /**
+     * Finds an {@link Organization} when given an {@link models.internal.Organization}.
+     *
+     * @param organization The organization to lookup.
+     * @return The organization from the database.
+     */
+    @Nullable
+    public static Organization findByOrganization(@Nonnull final models.internal.Organization organization) {
+        final Organization org = FINDER
+                .where()
+                .eq("uuid", organization.getId())
+                .findUnique();
+        return org;
+    }
 
-    @Column(name = "cluster")
-    private String cluster;
-
-    @Column(name = "service")
-    private String service;
-
-    @Column(name = "metric")
-    private String metric;
-
-    @Column(name = "script")
-    private String script;
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "organization")
-    private Organization organization;
+    /**
+     * Returns an {@link Organization} by reference. This defers all database operations until a field besides id is
+     * requested.
+     *
+     * @param id The id (primary key) of the organization.
+     * @return The {@link Organization} with the given primary key.
+     */
+    public static Organization refById(final long id) {
+        return FINDER.ref(id);
+    }
 
     public Long getId() {
         return id;
@@ -114,47 +124,9 @@ public class Expression extends Model {
     }
 
     public void setUuid(final UUID value) {
-        uuid = value;
+        this.uuid = value;
     }
 
-    public String getCluster() {
-        return cluster;
-    }
-
-    public void setCluster(final String value) {
-        cluster = value;
-    }
-
-    public String getService() {
-        return service;
-    }
-
-    public void setService(final String value) {
-        service = value;
-    }
-
-    public String getMetric() {
-        return metric;
-    }
-
-    public void setMetric(final String value) {
-        metric = value;
-    }
-
-    public String getScript() {
-        return script;
-    }
-
-    public void setScript(final String value) {
-        script = value;
-    }
-
-    public Organization getOrganization() {
-        return organization;
-    }
-
-    public void setOrganization(final Organization organizationValue) {
-        this.organization = organizationValue;
-    }
+    private static final Finder<Long, Organization> FINDER = new Finder<>(Organization.class);
 }
 // CHECKSTYLE.ON: MemberNameCheck

--- a/app/models/internal/AlertQuery.java
+++ b/app/models/internal/AlertQuery.java
@@ -80,6 +80,13 @@ public interface AlertQuery {
     QueryResult<Alert> execute();
 
     /**
+     * Accessor for the organization.
+     *
+     * @return The organization.
+     */
+    Organization getOrganization();
+
+    /**
      * Accessor for the contains.
      *
      * @return The contains.

--- a/app/models/internal/ExpressionQuery.java
+++ b/app/models/internal/ExpressionQuery.java
@@ -79,6 +79,13 @@ public interface ExpressionQuery {
     Optional<String> getContains();
 
     /**
+     * Accessor for the organization.
+     *
+     * @return The organization.
+     */
+    Organization getOrganization();
+
+    /**
      * Accessor for the cluster.
      *
      * @return The cluster.

--- a/app/models/internal/HostQuery.java
+++ b/app/models/internal/HostQuery.java
@@ -76,13 +76,6 @@ public interface HostQuery {
     HostQuery sortBy(final Optional<Field> field);
 
     /**
-     * Execute the query and return the results.
-     *
-     * @return The results of the query as an {@code QueryResult<Host>} instance.
-     */
-    QueryResult<Host> execute();
-
-    /**
      * Accessor for the hostname.
      *
      * @return The hostname.
@@ -95,6 +88,13 @@ public interface HostQuery {
      * @return The cluster.
      */
     Optional<String> getCluster();
+
+    /**
+     * Accessor for the organization.
+     *
+     * @return The organization.
+     */
+    Organization getOrganization();
 
     /**
      * Accessor for the metrics software state.

--- a/app/models/internal/Organization.java
+++ b/app/models/internal/Organization.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package models.internal;
+
+import models.internal.impl.DefaultOrganization;
+
+import java.util.UUID;
+
+/**
+ * Represents an organization. Organizations are separate entities for which hosts, alerts, and expressions
+ * can be created.
+ *
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ */
+public interface Organization {
+    /**
+     * Accessor for the uuid.
+     *
+     * @return The uuid.
+     */
+    UUID getId();
+
+    /**
+     * Default organization created by evolutions.
+     */
+    Organization DEFAULT = new DefaultOrganization.Builder()
+            .setId(UUID.fromString("0eb03110-2a36-4cb1-861f-7375afc98b9b"))
+            .build();
+}

--- a/app/models/internal/impl/DefaultAlertQuery.java
+++ b/app/models/internal/impl/DefaultAlertQuery.java
@@ -21,6 +21,7 @@ import com.google.common.base.MoreObjects;
 import models.internal.Alert;
 import models.internal.AlertQuery;
 import models.internal.Context;
+import models.internal.Organization;
 import models.internal.QueryResult;
 
 import java.util.Optional;
@@ -37,9 +38,11 @@ public final class DefaultAlertQuery implements AlertQuery {
      * Public constructor.
      *
      * @param repository The <code>AlertRepository</code>
+     * @param organization The <code>Organization</code> to search in
      */
-    public DefaultAlertQuery(final AlertRepository repository) {
+    public DefaultAlertQuery(final AlertRepository repository, final Organization organization) {
         _repository = repository;
+        _organization = organization;
     }
 
     /**
@@ -102,6 +105,14 @@ public final class DefaultAlertQuery implements AlertQuery {
     @Override
     public QueryResult<Alert> execute() {
         return _repository.query(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Organization getOrganization() {
+        return _organization;
     }
 
     /**
@@ -171,6 +182,7 @@ public final class DefaultAlertQuery implements AlertQuery {
     }
 
     private final AlertRepository _repository;
+    private final Organization _organization;
     private Optional<String> _contains = Optional.empty();
     private Optional<Context> _context = Optional.empty();
     private Optional<String> _cluster = Optional.empty();

--- a/app/models/internal/impl/DefaultExpressionQuery.java
+++ b/app/models/internal/impl/DefaultExpressionQuery.java
@@ -20,6 +20,7 @@ import com.arpnetworking.metrics.portal.expressions.ExpressionRepository;
 import com.google.common.base.MoreObjects;
 import models.internal.Expression;
 import models.internal.ExpressionQuery;
+import models.internal.Organization;
 import models.internal.QueryResult;
 
 import java.util.Optional;
@@ -36,9 +37,11 @@ public final class DefaultExpressionQuery implements ExpressionQuery {
      * Public constructor.
      *
      * @param repository The <code>ExpressionRepository</code>
+     * @param organization The <code>Organization</code> to search in
      */
-    public DefaultExpressionQuery(final ExpressionRepository repository) {
+    public DefaultExpressionQuery(final ExpressionRepository repository, final Organization organization) {
         _repository = repository;
+        _organization = organization;
     }
 
     /**
@@ -122,6 +125,14 @@ public final class DefaultExpressionQuery implements ExpressionQuery {
      * {@inheritDoc}
      */
     @Override
+    public Organization getOrganization() {
+        return _organization;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public int getLimit() {
         return _limit;
     }
@@ -152,6 +163,7 @@ public final class DefaultExpressionQuery implements ExpressionQuery {
     }
 
     private final ExpressionRepository _repository;
+    private final Organization _organization;
     private Optional<String> _contains = Optional.empty();
     private Optional<String> _cluster = Optional.empty();
     private Optional<String> _service = Optional.empty();

--- a/app/models/internal/impl/DefaultHostQuery.java
+++ b/app/models/internal/impl/DefaultHostQuery.java
@@ -18,10 +18,9 @@ package models.internal.impl;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.arpnetworking.metrics.portal.hosts.HostRepository;
 import com.google.common.base.MoreObjects;
-import models.internal.Host;
 import models.internal.HostQuery;
 import models.internal.MetricsSoftwareState;
-import models.internal.QueryResult;
+import models.internal.Organization;
 
 import java.util.Optional;
 
@@ -37,9 +36,11 @@ public final class DefaultHostQuery implements HostQuery {
      * Public constructor.
      *
      * @param repository The <code>HostRepository</code>
+     * @param organization The <code>Organization</code> to search in
      */
-    public DefaultHostQuery(final HostRepository repository) {
+    public DefaultHostQuery(final HostRepository repository, final Organization organization) {
         _repository = repository;
+        _organization = organization;
     }
 
     /**
@@ -100,16 +101,16 @@ public final class DefaultHostQuery implements HostQuery {
      * {@inheritDoc}
      */
     @Override
-    public QueryResult<Host> execute() {
-        return _repository.query(this);
+    public Optional<String> getPartialHostname() {
+        return _partialHostname;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Optional<String> getPartialHostname() {
-        return _partialHostname;
+    public Organization getOrganization() {
+        return _organization;
     }
 
     /**
@@ -171,6 +172,7 @@ public final class DefaultHostQuery implements HostQuery {
 
 
     private final HostRepository _repository;
+    private final Organization _organization;
     private Optional<String> _partialHostname = Optional.empty();
     private Optional<MetricsSoftwareState> _metricsSoftwareState = Optional.empty();
     private Optional<String> _cluster = Optional.empty();

--- a/app/models/internal/impl/DefaultOrganization.java
+++ b/app/models/internal/impl/DefaultOrganization.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package models.internal.impl;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import com.arpnetworking.logback.annotations.Loggable;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import models.internal.Organization;
+import net.sf.oval.constraint.NotEmpty;
+import net.sf.oval.constraint.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Default internal model implementation for an organization.
+ *
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ */
+@Loggable
+public final class DefaultOrganization implements Organization {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UUID getId() {
+        return _id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(final Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof DefaultOrganization)) {
+            return false;
+        }
+
+        final DefaultOrganization otherOrg = (DefaultOrganization) other;
+        return Objects.equal(_id, otherOrg._id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(_id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("id", Integer.toHexString(System.identityHashCode(this)))
+                .add("class", this.getClass())
+                .add("Id", _id)
+                .toString();
+    }
+
+    private DefaultOrganization(final Builder builder) {
+        _id = builder._id;
+    }
+
+    private final UUID _id;
+
+    /**
+     * Implementation of builder pattern for {@link DefaultOrganization}.
+     *
+     * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+     */
+    public static final class Builder extends OvalBuilder<Organization> {
+
+        /**
+         * Public constructor.
+         */
+        public Builder() {
+            super(DefaultOrganization::new);
+        }
+
+        /**
+         * The id. Cannot be null or empty.
+         *
+         * @param value The id.
+         * @return This instance of <code>Builder</code>.
+         */
+        public Builder setId(final UUID value) {
+            _id = value;
+            return this;
+        }
+
+        @NotNull
+        @NotEmpty
+        private UUID _id;
+    }
+}

--- a/conf/db/migration/metrics_portal_ddl/common/V7__add_organization_part_1.sql
+++ b/conf/db/migration/metrics_portal_ddl/common/V7__add_organization_part_1.sql
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Update all version columns to be bigint */
+ALTER TABLE portal.hosts ALTER COLUMN version TYPE BIGINT;
+ALTER TABLE portal.alerts ALTER COLUMN version TYPE BIGINT;
+ALTER TABLE portal.nagios_extensions ALTER COLUMN version TYPE BIGINT;
+ALTER TABLE portal.expressions ALTER COLUMN version TYPE BIGINT;
+ALTER TABLE portal.hosts ALTER COLUMN version TYPE BIGINT;
+
+/* Update all foreign key id columns to be bigint */
+ALTER TABLE portal.nagios_extensions ALTER COLUMN alert_id TYPE BIGINT;
+ALTER TABLE portal.version_set_package_versions ALTER COLUMN version_set_id TYPE BIGINT;
+ALTER TABLE portal.version_set_package_versions ALTER COLUMN package_version_id TYPE BIGINT;
+ALTER TABLE portal.version_specification_attributes ALTER COLUMN version_specification TYPE BIGINT;
+ALTER TABLE portal.version_specifications ALTER COLUMN version_set_id TYPE BIGINT;
+ALTER TABLE portal.version_specifications ALTER COLUMN next TYPE BIGINT;
+
+CREATE TABLE portal.organizations (
+  id BIGSERIAL PRIMARY KEY,
+  uuid UUID NOT NULL,
+  version BIGINT NOT NULL DEFAULT 1,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX organizations_uuid_idx ON portal.organizations (uuid);
+
+INSERT INTO portal.organizations (uuid) VALUES ('0eb03110-2a36-4cb1-861f-7375afc98b9b');
+
+ALTER TABLE portal.hosts ADD COLUMN organization BIGINT DEFAULT NULL;
+UPDATE portal.hosts SET organization = (SELECT MIN(id) FROM portal.organizations);
+ALTER TABLE portal.hosts ADD FOREIGN KEY (organization) REFERENCES organizations(id);
+ALTER TABLE portal.hosts ALTER COLUMN organization SET NOT NULL;
+
+DROP INDEX portal.hosts_name_idx;
+DROP INDEX portal.hosts_cluster_idx;
+DROP INDEX portal.hosts_metrics_software_state_idx;
+
+CREATE UNIQUE INDEX hosts_name_idx ON portal.hosts (organization, name);
+CREATE INDEX hosts_cluster_idx ON portal.hosts (organization, cluster);
+CREATE INDEX hosts_metrics_software_state_idx ON portal.hosts (organization, metrics_software_state);
+
+ALTER TABLE portal.alerts ADD COLUMN organization BIGINT DEFAULT NULL;
+UPDATE portal.alerts SET organization = (SELECT MIN(id) FROM portal.organizations);
+ALTER TABLE portal.alerts ADD FOREIGN KEY (organization) REFERENCES organizations(id);
+ALTER TABLE portal.alerts ALTER COLUMN organization SET NOT NULL;
+
+ALTER TABLE portal.expressions ADD COLUMN organization BIGINT DEFAULT NULL;
+UPDATE portal.expressions SET organization = (SELECT MIN(id) FROM portal.organizations);
+ALTER TABLE portal.expressions ADD FOREIGN KEY (organization) REFERENCES organizations(id);
+ALTER TABLE portal.expressions ALTER COLUMN organization SET NOT NULL;
+
+DROP SEQUENCE portal.alerts_etag_seq;
+DROP SEQUENCE portal.expressions_etag_seq;
+
+CREATE TABLE portal.alerts_etags (
+  id BIGSERIAL PRIMARY KEY,
+  organization BIGINT REFERENCES portal.organizations(id),
+  etag BIGINT NOT NULL
+);
+
+CREATE UNIQUE INDEX alerts_etags_organization on portal.alerts_etags (organization);
+
+CREATE TABLE portal.expressions_etags (
+  id BIGSERIAL PRIMARY KEY,
+  organization BIGINT REFERENCES portal.organizations(id),
+  etag BIGINT NOT NULL
+);
+
+CREATE UNIQUE INDEX expressions_etags_organization on portal.expressions_etags (organization);

--- a/conf/db/migration/metrics_portal_ddl/common/V9__change_hosts_version_schema.sql
+++ b/conf/db/migration/metrics_portal_ddl/common/V9__change_hosts_version_schema.sql
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Groupon.com
+ * Copyright 2016 Smartsheet.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.arpnetworking.database.h2.triggers;
 
-import models.ebean.AlertEtags;
-
-/**
- * Trigger to update Etag after every insert, delete or update statement.
- *
- * @author Deepika Misra (deepika at groupon dot com)
- */
-public class AlertsUpdateEtagTrigger extends BaseUpdateEtagTrigger {
-
-    /**
-     * Public no args constructor.
-     */
-    public AlertsUpdateEtagTrigger() {
-        super(AlertEtags::incrementEtag, 15);
-    }
-}
+ALTER TABLE portal.hosts ADD COLUMN metrics_software_version VARCHAR(255) DEFAULT NULL;
+ALTER TABLE portal.hosts ADD COLUMN metrics_software_sha VARCHAR(255) DEFAULT NULL;
+CREATE INDEX hosts_metrics_software_version_idx ON portal.hosts (organization, metrics_software_version);
+CREATE INDEX hosts_metrics_software_sha_idx ON portal.hosts (organization, metrics_software_sha);

--- a/conf/db/migration/metrics_portal_ddl/h2/V8__add_organization_part_2.sql
+++ b/conf/db/migration/metrics_portal_ddl/h2/V8__add_organization_part_2.sql
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Update all pkey id columns to be bigserial */
+ALTER TABLE portal.alerts ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.expressions ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.hosts ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.nagios_extensions ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.package_versions ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.version_set_package_versions ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.version_sets ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.version_specifications ALTER COLUMN id TYPE BIGSERIAL;
+ALTER TABLE portal.version_specification_attributes ALTER COLUMN id TYPE BIGSERIAL;

--- a/conf/db/migration/metrics_portal_ddl/postgresql/V8__add_organization_part_2.sql
+++ b/conf/db/migration/metrics_portal_ddl/postgresql/V8__add_organization_part_2.sql
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Update all pkey id columns to be bigserial */
+ALTER TABLE portal.alerts ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.expressions ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.hosts ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.nagios_extensions ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.package_versions ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.version_set_package_versions ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.version_sets ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.version_specifications ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE portal.version_specification_attributes ALTER COLUMN id TYPE BIGINT;
+
+
+DROP INDEX portal.hosts_name_full_text_idx;
+CREATE INDEX hosts_name_full_text_idx ON portal.hosts USING gin(organization, name_idx_col);
+
+CREATE OR REPLACE FUNCTION update_alerts_etag() RETURNS TRIGGER AS $update_alerts_etag$
+DECLARE
+  pl_organization integer;
+  pl_modified integer;
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    pl_organization = NEW.organization;
+  ELSE
+    pl_organization = OLD.organization;
+  END IF;
+  UPDATE portal.alerts_etags SET etag = etag + 1 WHERE organization = pl_organization;
+  GET DIAGNOSTICS pl_modified = ROW_COUNT;
+  IF pl_modified = 0 THEN
+    INSERT INTO portal.alerts_etags (organization, etag) VALUES (pl_organization, 1);
+  END IF;
+  RETURN NEW;
+END;
+$update_alerts_etag$ LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION update_expressions_etag() RETURNS TRIGGER AS $update_expressions_etag$
+DECLARE
+  pl_organization integer;
+  pl_modified integer;
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    pl_organization = NEW.organization;
+  ELSE
+    pl_organization = OLD.organization;
+  END IF;
+  UPDATE portal.expressions_etags SET etag = etag + 1 WHERE organization = pl_organization;
+  GET DIAGNOSTICS pl_modified = ROW_COUNT;
+  IF pl_modified = 0 THEN
+    INSERT INTO portal.expressions_etags (organization, etag) VALUES (pl_organization, 1);
+  END IF;
+  RETURN NEW;
+END;
+$update_expressions_etag$ LANGUAGE 'plpgsql';

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -72,9 +72,9 @@ metrics.jvm.interval = "500 millis"
 # Switch between H2 and local Postgres
 
 # Option 1: H2
-db.default.url = "jdbc:h2:./target/h2/metrics:portal;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9091;MODE=PostgreSQL;INIT=create schema if not exists portal;DB_CLOSE_DELAY=-1"
+db.default.url = "jdbc:h2:./target/h2/metrics_portal;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9091;MODE=PostgreSQL;INIT=create schema if not exists portal;DB_CLOSE_DELAY=-1"
 db.default.driver = "org.h2.Driver"
-db.metrics_portal_ddl.url = "jdbc:h2:./target/h2/metrics:portal;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9091;MODE=PostgreSQL;INIT=create schema if not exists portal;DB_CLOSE_DELAY=-1"
+db.metrics_portal_ddl.url = "jdbc:h2:./target/h2/metrics_portal;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9091;MODE=PostgreSQL;INIT=create schema if not exists portal;DB_CLOSE_DELAY=-1"
 db.metrics_portal_ddl.driver = "org.h2.Driver"
 db.metrics_portal_ddl.migration.locations = ["common", "h2"]
 

--- a/test/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -20,8 +20,10 @@ import models.ebean.NagiosExtension;
 import models.internal.Alert;
 import models.internal.Context;
 import models.internal.Operator;
+import models.internal.Organization;
 import models.internal.impl.DefaultAlert;
 import models.internal.impl.DefaultExpression;
+import models.internal.impl.DefaultOrganization;
 import models.internal.impl.DefaultQuantity;
 import org.joda.time.Period;
 
@@ -36,6 +38,18 @@ import java.util.UUID;
  * @author Deepika Misra (deepika at groupon dot com)
  */
 public final class TestBeanFactory {
+
+    public static Organization organizationFrom(final models.ebean.Organization organization) {
+        return new DefaultOrganization.Builder()
+                .setId(organization.getUuid())
+                .build();
+    }
+
+    public static models.ebean.Organization createEbeanOrganization() {
+        final models.ebean.Organization organization = new models.ebean.Organization();
+        organization.setUuid(UUID.randomUUID());
+        return organization;
+    }
 
     public static DefaultAlert.Builder createAlertBuilder() {
         return new DefaultAlert.Builder()
@@ -60,7 +74,10 @@ public final class TestBeanFactory {
     }
 
     public static models.ebean.Alert createEbeanAlert() {
+        final models.ebean.Organization organization = createEbeanOrganization();
+        organization.save();
         final models.ebean.Alert ebeanAlert = new models.ebean.Alert();
+        ebeanAlert.setOrganization(organization);
         ebeanAlert.setUuid(UUID.randomUUID());
         ebeanAlert.setNagiosExtension(createEbeanNagiosExtension());
         ebeanAlert.setName(TEST_NAME + RANDOM.nextInt(100));
@@ -95,7 +112,10 @@ public final class TestBeanFactory {
     }
 
     public static Expression createEbeanExpression() {
+        final models.ebean.Organization organization = createEbeanOrganization();
+        organization.save();
         final models.ebean.Expression ebeanExpression = new models.ebean.Expression();
+        ebeanExpression.setOrganization(organization);
         ebeanExpression.setUuid(UUID.randomUUID());
         ebeanExpression.setCluster(TEST_CLUSTER + RANDOM.nextInt(100));
         ebeanExpression.setMetric(TEST_METRIC + RANDOM.nextInt(100));

--- a/test/com/arpnetworking/metrics/portal/models/ebean/VersionSpecificationTest.java
+++ b/test/com/arpnetworking/metrics/portal/models/ebean/VersionSpecificationTest.java
@@ -17,7 +17,6 @@ package com.arpnetworking.metrics.portal.models.ebean;
 
 import com.arpnetworking.metrics.portal.H2ConnectionStringFactory;
 import com.avaje.ebean.Ebean;
-import com.google.common.collect.ImmutableMap;
 import models.ebean.PackageVersion;
 import models.ebean.VersionSet;
 import models.ebean.VersionSpecification;
@@ -97,9 +96,8 @@ public class VersionSpecificationTest extends WithApplication {
 
     @Override
     protected Application provideApplication() {
-        final String jdbcUrl = H2ConnectionStringFactory.generateJdbcUrl();
         return new GuiceApplicationBuilder()
-                .configure(ImmutableMap.of("db.metrics_portal_ddl.url", jdbcUrl, "db.default.url", jdbcUrl))
+                .configure(H2ConnectionStringFactory.generateConfiguration())
                 .build();
     }
 

--- a/test/controllers/AlertControllerTest.java
+++ b/test/controllers/AlertControllerTest.java
@@ -15,6 +15,7 @@
  */
 package controllers;
 
+import com.arpnetworking.metrics.portal.H2ConnectionStringFactory;
 import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.arpnetworking.metrics.portal.alerts.AlertRepository;
 import com.arpnetworking.metrics.portal.alerts.impl.DatabaseAlertRepository;
@@ -25,6 +26,7 @@ import models.ebean.NagiosExtension;
 import models.internal.Alert;
 import models.internal.Context;
 import models.internal.Operator;
+import models.internal.Organization;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -52,6 +54,7 @@ public class AlertControllerTest {
         Configuration configuration = Configuration.empty();
         app = new GuiceApplicationBuilder()
                 .bindings(Bindings.bind(AlertController.class).toInstance(new AlertController(configuration, alertRepo)))
+                .configure(H2ConnectionStringFactory.generateConfiguration())
                 .build();
         Helpers.start(app);
         alertRepo.open();
@@ -277,7 +280,7 @@ public class AlertControllerTest {
     public void testUpdateValidCase() throws IOException {
         final UUID uuid = UUID.fromString("e62368dc-1421-11e3-91c1-00259069c2f0");
         Alert originalAlert = TestBeanFactory.createAlertBuilder().setId(uuid).build();
-        alertRepo.addOrUpdateAlert(originalAlert);
+        alertRepo.addOrUpdateAlert(originalAlert, Organization.DEFAULT);
         final JsonNode body = readTree("testUpdateValidCase");
         Http.RequestBuilder request = new Http.RequestBuilder()
                 .method("PUT")

--- a/test/controllers/ExpressionControllerTest.java
+++ b/test/controllers/ExpressionControllerTest.java
@@ -15,12 +15,14 @@
  */
 package controllers;
 
+import com.arpnetworking.metrics.portal.H2ConnectionStringFactory;
 import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.arpnetworking.metrics.portal.expressions.ExpressionRepository;
 import com.arpnetworking.metrics.portal.expressions.impl.DatabaseExpressionRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import models.internal.Expression;
+import models.internal.Organization;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -48,6 +50,7 @@ public class ExpressionControllerTest {
         Configuration configuration = Configuration.empty();
         app = new GuiceApplicationBuilder()
                 .bindings(Bindings.bind(ExpressionController.class).toInstance(new ExpressionController(configuration, exprRepo)))
+                .configure(H2ConnectionStringFactory.generateConfiguration())
                 .build();
         Helpers.start(app);
         exprRepo.open();
@@ -144,7 +147,7 @@ public class ExpressionControllerTest {
         Expression originalExpr = TestBeanFactory.createExpressionBuilder()
                 .setId(uuid)
                 .build();
-        exprRepo.addOrUpdateExpression(originalExpr);
+        exprRepo.addOrUpdateExpression(originalExpr, Organization.DEFAULT);
         final JsonNode body = OBJECT_MAPPER.valueToTree(TestBeanFactory.createExpressionBuilder().setId(uuid).build());
         Http.RequestBuilder request = new Http.RequestBuilder()
                 .method("PUT")
@@ -153,7 +156,7 @@ public class ExpressionControllerTest {
                 .uri("/v1/expressions");
         Result result = Helpers.route(request);
         Assert.assertEquals(Http.Status.OK, result.status());
-        Expression expectedExpr = exprRepo.get(originalExpr.getId()).get();
+        Expression expectedExpr = exprRepo.get(originalExpr.getId(), Organization.DEFAULT).get();
         Assert.assertEquals(OBJECT_MAPPER.valueToTree(expectedExpr), body);
     }
 


### PR DESCRIPTION
Here's the big one.  

Organization support.  
Had to change the way etags were computed.
Postgres now works with UUIDs (I don't think it was working before the EBean update)

I tried to keep external APIs the same, so only the default organization can be used at this time.  Only very minor work will need to be done on the APIs to expose the organization id.  We should talk about authentication before we do that, though.