### PR TITLE
Edit alert ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 project/project
 project/target
 conf/evolutions/
+conf/dev.conf
 
 # Output
 target/

--- a/app/assets/javascripts/classes/PaginatedSearchableList.ts
+++ b/app/assets/javascripts/classes/PaginatedSearchableList.ts
@@ -83,7 +83,7 @@ abstract class PaginatedSearchableList<T> {
 
     abstract fetchData(query: any, callback: (data: T[], pagination: Pagination) => void): void;
 
-    query() {
+    public query() {
         var query = this.createQuery();
         this.amendQuery(query);
 

--- a/app/assets/javascripts/classes/Uuid.ts
+++ b/app/assets/javascripts/classes/Uuid.ts
@@ -1,0 +1,25 @@
+class Uuid {
+    private static lut = [];
+    static initialize = () => {
+        for (var i=0; i<256; i++) {
+            Uuid.lut[i] = (i < 16 ? '0' : '') + (i).toString(16);
+        }
+        delete Uuid.initialize;
+    };
+
+    static v4(): string {
+        var d0 = Math.random()*0xffffffff|0;
+        var d1 = Math.random()*0xffffffff|0;
+        var d2 = Math.random()*0xffffffff|0;
+        var d3 = Math.random()*0xffffffff|0;
+        return Uuid.lut[d0&0xff]+Uuid.lut[d0>>8&0xff]+Uuid.lut[d0>>16&0xff]+Uuid.lut[d0>>24&0xff]+'-'+
+            Uuid.lut[d1&0xff]+Uuid.lut[d1>>8&0xff]+'-'+Uuid.lut[d1>>16&0x0f|0x40]+Uuid.lut[d1>>24&0xff]+'-'+
+            Uuid.lut[d2&0x3f|0x80]+Uuid.lut[d2>>8&0xff]+'-'+Uuid.lut[d2>>16&0xff]+Uuid.lut[d2>>24&0xff]+
+            Uuid.lut[d3&0xff]+Uuid.lut[d3>>8&0xff]+Uuid.lut[d3>>16&0xff]+Uuid.lut[d3>>24&0xff];
+    }
+}
+module Uuid {
+    Uuid.initialize();
+}
+
+export = Uuid;

--- a/app/assets/javascripts/classes/alerts/AlertData.ts
+++ b/app/assets/javascripts/classes/alerts/AlertData.ts
@@ -32,6 +32,7 @@ class AlertData {
     extensions: { [id: string]: string };
     contextStyle: KnockoutComputed<string>;
     contextTip: KnockoutComputed<string>;
+    editUri: KnockoutComputed<string>;
 
     constructor(id: string, context: string, name: string, metric: string, service: string, cluster: string, statistic: string, period: string, operator: Operator, value: Quantity, extensions: { [id: string]: string }) {
         this.id = id;
@@ -66,6 +67,10 @@ class AlertData {
                 return "";
             }
         }, self);
+
+        this.editUri = ko.computed<string>(() => {
+            return "#alert/edit/" + this.id;
+        });
     }
 }
 

--- a/app/assets/javascripts/classes/alerts/AlertsViewModel.ts
+++ b/app/assets/javascripts/classes/alerts/AlertsViewModel.ts
@@ -18,12 +18,7 @@ import AlertData = require('./AlertData');
 import PaginatedSearchableList = require('../PaginatedSearchableList');
 import $ = require('jquery');
 
-class AlertsViewModel extends PaginatedSearchableList<AlertData> {
-    constructor() {
-        super();
-        this.query();
-    }
-
+class AlertsList extends PaginatedSearchableList<AlertData> {
     fetchData(query, callback) {
         $.getJSON("v1/alerts/query", query, (data) => {
             var alertsList: AlertData[] = data.data.map((v: AlertData)=> { return new AlertData(
@@ -42,6 +37,15 @@ class AlertsViewModel extends PaginatedSearchableList<AlertData> {
             callback(alertsList, data.pagination);
         });
     }
+}
+
+class AlertsViewModel {
+    alerts: AlertsList = new AlertsList();
+
+    constructor() {
+        this.alerts.query();
+    }
+
 }
 
 export = AlertsViewModel;

--- a/app/assets/javascripts/classes/alerts/AlertsViewModel.ts
+++ b/app/assets/javascripts/classes/alerts/AlertsViewModel.ts
@@ -41,11 +41,30 @@ class AlertsList extends PaginatedSearchableList<AlertData> {
 
 class AlertsViewModel {
     alerts: AlertsList = new AlertsList();
+    deletingId: string = null;
+    remove: (alert: AlertData) => void;
 
     constructor() {
         this.alerts.query();
+        this.remove = (alert: AlertData) => {
+            this.deletingId = alert.id;
+            console.log("set deletingId: ", this, this.deletingId);
+
+            $("#confirm-delete-modal").modal('show');
+        };
     }
 
+    confirmDelete() {
+        $.ajax({
+            type: "DELETE",
+            url: "/v1/alerts/" + this.deletingId,
+            contentType: "application/json"
+        }).done(() => {
+            $("#confirm-delete-modal").modal('hide');
+            this.alerts.query();
+            this.deletingId = null;
+        });
+    }
 }
 
 export = AlertsViewModel;

--- a/app/assets/javascripts/classes/alerts/EditAlertViewModel.ts
+++ b/app/assets/javascripts/classes/alerts/EditAlertViewModel.ts
@@ -19,6 +19,7 @@ import ko = require('knockout');
 import $ = require('jquery');
 import Operator = require("./Operator");
 import Quantity = require("../Quantity");
+import uuid = require('../Uuid');
 
 class OperatorOption {
     text: string;
@@ -68,6 +69,8 @@ class EditAlertViewModel {
     activate(id: String) {
         if (id != null) {
             this.loadAlert(id);
+        } else {
+            this.id(uuid.v4());
         }
     }
 
@@ -107,7 +110,6 @@ class EditAlertViewModel {
                 "value": {"value": this.value(), "unit": this.valueUnit()}
             }),
         }).done(() => {
-            console.log("success callback");
             window.location.href = "/#alerts";
         });
     }

--- a/app/assets/javascripts/classes/alerts/EditAlertViewModel.ts
+++ b/app/assets/javascripts/classes/alerts/EditAlertViewModel.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import AlertData = require('./AlertData');
+import ko = require('knockout');
+import $ = require('jquery');
+import Operator = require("./Operator");
+import Quantity = require("../Quantity");
+
+class OperatorOption {
+    text: string;
+    value: string;
+
+    constructor(text, value) {
+        this.text = text;
+        this.value = value;
+    }
+}
+
+class ContextOption {
+    text: string;
+    value: string;
+
+    constructor(text, value) {
+        this.text = text;
+        this.value = value;
+    }
+}
+
+class EditAlertViewModel {
+    id = ko.observable<string>("");
+    context = ko.observable<string>("CLUSTER");
+    name = ko.observable<string>("");
+    metric = ko.observable<string>("");
+    service = ko.observable<string>("");
+    cluster = ko.observable<string>("");
+    statistic = ko.observable<string>("");
+    period = ko.observable<string>("PT1M");
+    operator = ko.observable<string>("GREATER_THAN");
+    value = ko.observable<number>(0);
+    valueUnit = ko.observable<string>(null);
+    operators = [
+        new OperatorOption("<", "LESS_THAN"),
+        new OperatorOption("<=", "LESS_THAN_OR_EQUAL_TO"),
+        new OperatorOption(">", "GREATER_THAN"),
+        new OperatorOption(">=", "GREATER_THAN_OR_EQUAL_TO"),
+        new OperatorOption("=", "EQUAL_TO"),
+        new OperatorOption("!=", "NOT_EQUAL_TO"),
+    ];
+    contexts = [
+        new ContextOption("Host", "HOST"),
+        new ContextOption("Cluster", "CLUSTER")
+    ];
+
+    activate(id: String) {
+        if (id != null) {
+            this.loadAlert(id);
+        }
+    }
+
+    loadAlert(id: String): void {
+        $.getJSON("/v1/alerts/" + id, {}, (data) => {
+            console.log(data);
+            this.id(data.id);
+            this.context(data.context);
+            this.name(data.name);
+            this.metric(data.metric);
+            this.service(data.service);
+            this.cluster(data.cluster);
+            this.statistic(data.statistic);
+            this.period(data.period);
+            this.operator(data.operator);
+            this.value(data.value.value);
+            this.valueUnit(data.value.unit);
+        });
+    }
+
+    save(): void {
+        $.ajax({
+            type: "PUT",
+            url: "/v1/alerts",
+            contentType: "application/json",
+            dataType: "json",
+            data: JSON.stringify({
+                "id": this.id(),
+                "context": this.context(),
+                "metric": this.metric(),
+                "name": this.name(),
+                "cluster": this.cluster(),
+                "service": this.service(),
+                "statistic": this.statistic(),
+                "period": this.period(),
+                "operator": this.operator(),
+                "value": {"value": this.value(), "unit": this.valueUnit()}
+            }),
+        }).done(() => {
+            console.log("success callback");
+            window.location.href = "/#alerts";
+        });
+    }
+
+    cancel(): void {
+        window.location.href = "/#alerts";
+    }
+}
+
+export = EditAlertViewModel;

--- a/app/assets/javascripts/classes/expressions/ExpressionsViewModel.ts
+++ b/app/assets/javascripts/classes/expressions/ExpressionsViewModel.ts
@@ -18,18 +18,21 @@ import ExpressionData = require('./ExpressionData');
 import PaginatedSearchableList = require('../PaginatedSearchableList');
 import $ = require('jquery');
 
-class ExpressionsViewModel extends PaginatedSearchableList<ExpressionData> {
-    constructor() {
-        super();
-        this.query();
-    }
-
+class ExpressionsList extends PaginatedSearchableList<ExpressionData> {
     fetchData(query, callback) {
         $.getJSON("v1/expressions/query", query, (data) => {
             var expressionsList: ExpressionData[] = data.data.map((v: ExpressionData)=> {
                 return new ExpressionData(v.id, v.metric, v.service, v.cluster, v.script);});
             callback(expressionsList, data.pagination);
         });
+    }
+}
+
+class ExpressionsViewModel {
+    expressions: ExpressionsList = new ExpressionsList();
+
+    constructor() {
+        this.expressions.query();
     }
 }
 

--- a/app/assets/javascripts/classes/hostregistry/HostRegistryViewModel.ts
+++ b/app/assets/javascripts/classes/hostregistry/HostRegistryViewModel.ts
@@ -22,13 +22,12 @@ import GraphViewModel = require('../GraphViewModel');
 import $ = require('jquery');
 import ko = require('knockout');
 
-class HostRegistryViewModel extends PaginatedSearchableList<HostData> {
+class HostList extends PaginatedSearchableList<HostData> {
     versionFilter: KnockoutObservable <string> = ko.observable('');
 
     constructor() {
         super();
         this.versionFilter.subscribe(() => {this.page(1); this.query()});
-        this.query();
     };
 
     click(connectTo: HostData) {
@@ -55,4 +54,11 @@ class HostRegistryViewModel extends PaginatedSearchableList<HostData> {
     }
 }
 
+class HostRegistryViewModel {
+    hosts: HostList = new HostList();
+
+    constructor() {
+        this.hosts.query();
+    };
+}
 export = HostRegistryViewModel;

--- a/app/assets/javascripts/classes/shell.ts
+++ b/app/assets/javascripts/classes/shell.ts
@@ -25,7 +25,8 @@ class shell {
             { route: 'live-logging', title: 'Live Logging', moduleId: 'classes/logging/LiveLoggingViewModel', nav: false },
             { route: 'host-registry', title: 'Host Registry', moduleId: 'classes/hostregistry/HostRegistryViewModel', nav: false },
             { route: 'expressions', title: 'Expressions', moduleId: 'classes/expressions/ExpressionsViewModel', nav: false },
-            { route: 'alerts', title: 'Alerts', moduleId: 'classes/alerts/AlertsViewModel', nav: false }
+            { route: 'alerts', title: 'Alerts', moduleId: 'classes/alerts/AlertsViewModel', nav: false },
+            { route: 'alert/edit(/:id)', title: 'Alerts', moduleId: 'classes/alerts/EditAlertViewModel', nav: false }
         ]).buildNavigationModel();
 
         return router.activate();

--- a/app/com/arpnetworking/metrics/portal/alerts/AlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/AlertRepository.java
@@ -50,6 +50,15 @@ public interface AlertRepository {
     Optional<Alert> get(UUID identifier, Organization organization);
 
     /**
+     * Delete an <code>Alert</code> by identifier.
+     *
+     * @param identifier The <code>Alert</code> identifier.
+     * @param organization The organization owning the alert.
+     * @return The matching <code>Alert</code> if found or <code>Optional.empty()</code>.
+     */
+    int delete(UUID identifier, Organization organization);
+
+    /**
      * Create a query against the alerts repository.
      *
      * @param organization Organization to search in.

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/CassandraAlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/CassandraAlertRepository.java
@@ -97,6 +97,24 @@ public final class CassandraAlertRepository implements AlertRepository {
     }
 
     @Override
+    public int delete(final UUID identifier, final Organization organization) {
+        assertIsOpen();
+        LOGGER.debug()
+                .setMessage("Deleting alert")
+                .addData("alertId", identifier)
+                .addData("organization", organization)
+                .log();
+        final Optional<Alert> alert = get(identifier, organization);
+        if (alert.isPresent()) {
+            final Mapper<models.cassandra.Alert> mapper = _mappingManager.mapper(models.cassandra.Alert.class);
+            mapper.delete(alert);
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
     public AlertQuery createQuery(final Organization organization) {
         assertIsOpen();
         LOGGER.debug()

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertRepository.java
@@ -157,6 +157,23 @@ public class DatabaseAlertRepository implements AlertRepository {
     }
 
     @Override
+    public int delete(final UUID identifier, final Organization organization) {
+        LOGGER.debug()
+                .setMessage("Deleting alert")
+                .addData("id", identifier)
+                .addData("organization", organization)
+                .log();
+        return Ebean.find(models.ebean.Alert.class)
+                .where()
+                .eq("uuid", identifier)
+                .eq("organization.uuid", organization.getId())
+                .delete();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void addOrUpdateAlert(final Alert alert, final Organization organization) {
         assertIsOpen();
         LOGGER.debug()

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/ReadOnlyAbstractAlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/ReadOnlyAbstractAlertRepository.java
@@ -21,6 +21,8 @@ import com.arpnetworking.steno.LoggerFactory;
 import models.internal.Alert;
 import models.internal.Organization;
 
+import java.util.UUID;
+
 /**
  * Abstract repository that overrides the write functions for the <code>AlertRepository</code>.
  *
@@ -30,6 +32,14 @@ public abstract class ReadOnlyAbstractAlertRepository implements AlertRepository
 
     @Override
     public void addOrUpdateAlert(final Alert alert, final Organization organization) {
+        throw new UnsupportedOperationException("This is a read only repository.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int delete(final UUID identifier, final Organization organization) {
         throw new UnsupportedOperationException("This is a read only repository.");
     }
 

--- a/app/controllers/AlertController.java
+++ b/app/controllers/AlertController.java
@@ -221,6 +221,22 @@ public class AlertController extends Controller {
         return ok(Json.toJson(result.get()));
     }
 
+    /**
+     * Delete a specific alert.
+     *
+     * @param id The identifier of the alert.
+     * @return No content
+     */
+    public Result delete(final String id) {
+        final UUID identifier = UUID.fromString(id);
+        final int deleted = _alertRepository.delete(identifier, Organization.DEFAULT);
+        if (deleted > 0) {
+            return noContent();
+        } else {
+            return notFound();
+        }
+    }
+
     private models.view.Alert internalModelToViewModel(final Alert alert) {
         final models.view.Alert viewAlert = new models.view.Alert();
         viewAlert.setCluster(alert.getCluster());

--- a/app/controllers/AlertController.java
+++ b/app/controllers/AlertController.java
@@ -100,7 +100,7 @@ public class AlertController extends Controller {
                     .log();
             return internalServerError();
         }
-        return ok();
+        return noContent();
     }
 
     /**

--- a/app/controllers/ExpressionController.java
+++ b/app/controllers/ExpressionController.java
@@ -93,7 +93,7 @@ public class ExpressionController extends Controller {
                     .log();
             return internalServerError();
         }
-        return ok();
+        return noContent();
     }
 
     /**

--- a/conf/db/migration/metrics_portal_ddl/h2/V10__fix_pg_etag_triggers.sql
+++ b/conf/db/migration/metrics_portal_ddl/h2/V10__fix_pg_etag_triggers.sql
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Nothing to do here */

--- a/conf/db/migration/metrics_portal_ddl/postgresql/V10__fix_pg_etag_triggers.sql
+++ b/conf/db/migration/metrics_portal_ddl/postgresql/V10__fix_pg_etag_triggers.sql
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2016 Smartsheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE OR REPLACE FUNCTION update_alerts_etag() RETURNS TRIGGER AS $update_alerts_etag$
+DECLARE
+  pl_organization integer;
+  pl_modified integer;
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    pl_organization = NEW.organization;
+  ELSE
+    pl_organization = OLD.organization;
+  END IF;
+  UPDATE portal.alerts_etags SET etag = etag + 1 WHERE organization = pl_organization;
+  GET DIAGNOSTICS pl_modified = ROW_COUNT;
+  IF pl_modified = 0 THEN
+    INSERT INTO portal.alerts_etags (organization, etag) VALUES (pl_organization, 1);
+  END IF;
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    RETURN NEW;
+  ELSE
+    RETURN OLD;
+  END IF;
+END;
+$update_alerts_etag$ LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION update_expressions_etag() RETURNS TRIGGER AS $update_expressions_etag$
+DECLARE
+  pl_organization integer;
+  pl_modified integer;
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    pl_organization = NEW.organization;
+  ELSE
+    pl_organization = OLD.organization;
+  END IF;
+  UPDATE portal.expressions_etags SET etag = etag + 1 WHERE organization = pl_organization;
+  GET DIAGNOSTICS pl_modified = ROW_COUNT;
+  IF pl_modified = 0 THEN
+    INSERT INTO portal.expressions_etags (organization, etag) VALUES (pl_organization, 1);
+  END IF;
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    RETURN NEW;
+  ELSE
+    RETURN OLD;
+  END IF;
+END;
+$update_expressions_etag$ LANGUAGE 'plpgsql';
+

--- a/conf/dev.conf
+++ b/conf/dev.conf
@@ -1,0 +1,6 @@
+# This file is intentionally empty
+# To prevent git from tracking changes in this file, run the following command:
+#   git update-index --assume-unchanged conf/dev.conf
+include "portal.application.conf"
+
+# Put all of your local development configuration changes below here

--- a/conf/portal.routes
+++ b/conf/portal.routes
@@ -35,6 +35,7 @@ GET        /v1/hosts/query                      controllers.HostController.query
 # Alerts
 GET        /v1/alerts/query                     controllers.AlertController.query(contains: String ?= null, context: String ?= null, cluster: String ?= null, service: String ?= null, limit: java.lang.Integer ?= null, offset: java.lang.Integer ?= null)
 GET        /v1/alerts/:id                       controllers.AlertController.get(id: String)
+DELETE     /v1/alerts/:id                       controllers.AlertController.delete(id: String)
 PUT        /v1/alerts                           controllers.AlertController.addOrUpdate
 
 # Expressions

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -86,7 +86,7 @@ object ApplicationBuild extends Build {
       "org.webjars" % "bean" % "1.0.14",
       "org.webjars" % "bootstrap" % "3.2.0",
       "org.webjars" % "d3js" % "3.4.8",
-      "org.webjars" % "durandal" % "2.1.0",
+      "org.webjars" % "durandal" % "2.1.0-2",
       "org.webjars" % "flotr2" % "d43f8566e8",
       "org.webjars" % "font-awesome" % "4.3.0-2",
       "org.webjars" % "jQRangeSlider" % "5.7.0",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -248,7 +248,7 @@ object ApplicationBuild extends Build {
         "-Xlint:-try"
       ),
 
-      devSettings := Seq(("config.resource", "portal.application.conf")),
+      devSettings := Seq(("config.resource", "dev.conf")),
       javaOptions += "-Dconfig.file=conf/portal.application.conf",
 
       JsEngineKeys.engineType := JsEngineKeys.EngineType.Node,

--- a/public/html/GraphViewModel.html
+++ b/public/html/GraphViewModel.html
@@ -35,7 +35,7 @@
                     </div>
                 </div>
                 <div data-bind="attr:{'id': 'modal_'+id}" class="modal fade" role="dialog">
-                    <div class=modal-dialog">
+                    <div class="modal-dialog">
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h4><span class="fa fa-cog"></span> Configure Graph</h4>

--- a/public/html/alerts/AlertsViewModel.html
+++ b/public/html/alerts/AlertsViewModel.html
@@ -18,46 +18,33 @@
     <div class="row-fluid">
         <div class="col-md-12">
             <h2>Alerts</h2>
-
-            <div class="col-md-12 col-sm-12 col-lg-12 search-header">
-                <form role="form" class="container-fluid form-inline col-md-8 col-sm-12 col-lg-6">
-                    <div class="form-group has-feedback">
-                        <input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
-                        <span class="glyphicon glyphicon-search form-control-feedback"></span>
-                    </div>
-                </form>
-            </div>
-            <div style="font-size: large; overflow-style: scrollbar; overflow-y: auto" class="container-fluid col-md-12 col-sm-12 col-lg-12">
-                <div data-bind="foreach: filteredEntities" class="row">
-                    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
-                        <i class="fa fa-sitemap"></i>
-                        <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
-                        <br/>
-                        <i class="fa fa-cog"></i>
-                        <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
-                        <br/>
-                        <i class="fa fa-bar-chart"></i>
-                        <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
-                        <br/>
-                        <i class="fa fa-bell"></i>
-                        <span data-bind="text: name, tooltip:{ name, tooltipClass: 'host-tip'}, attr: {title: name}"></span>
-                        <br/>
-                        <i class="fa fa-calculator"></i>
-                        <span data-bind="text: statistic, tooltip:{ statistic, tooltipClass: 'host-tip'}, attr: {title: statistic}"></span>
-                        <br/>
-                        <i class="fa fa-clock-o"></i>
-                        <span data-bind="text: period, tooltip:{ period, tooltipClass: 'host-tip'}, attr: {title: period}"></span>
-                        <i class="fa" style="float : right;" data-bind="css: contextStyle, tooltip:{ contextTip, tooltipClass: 'host-tip'}, attr: {title: contextTip}"></i>
-                    </div>
-                </div>
-            </div>
-            <nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
-                <div class="text-center">
-                    <ul class="pagination" data-bind="foreach: pagerElements">
-                        <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
-                    </ul>
-                </div>
-            </nav>
+            <div data-bind="compose: { model: alerts, view: '/assets/html/components/Pager.html' }"></div>
         </div>
     </div>
 </div>
+
+<script type="text/html" id="list-element-template">
+    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
+        <i class="fa fa-sitemap"></i>
+        <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
+        <br/>
+        <i class="fa fa-cog"></i>
+        <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
+        <br/>
+        <i class="fa fa-bar-chart"></i>
+        <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
+        <br/>
+        <i class="fa fa-bell"></i>
+        <span data-bind="text: name, tooltip:{ name, tooltipClass: 'host-tip'}, attr: {title: name}"></span>
+        <br/>
+        <i class="fa fa-calculator"></i>
+        <span data-bind="text: statistic, tooltip:{ statistic, tooltipClass: 'host-tip'}, attr: {title: statistic}"></span>
+        <br/>
+        <i class="fa fa-clock-o left"></i>
+        <span data-bind="text: period, tooltip:{ period, tooltipClass: 'host-tip'}, attr: {title: period}"></span>
+        <a data-bind="attr: { href: editUri }">
+            <i class="fa fa-pencil-square-o right"></i>
+        </a>
+        <i class="fa right" data-bind="css: contextStyle, tooltip:{ contextTip, tooltipClass: 'host-tip'}, attr: {title: contextTip}"></i>
+    </div>
+</script>

--- a/public/html/alerts/AlertsViewModel.html
+++ b/public/html/alerts/AlertsViewModel.html
@@ -24,31 +24,19 @@
         <div class="col-md-12">
             <div><a href="#alert/edit" class="btn btn-default" style="margin-bottom: .5em">Create New Alert</a></div>
             <div data-bind="compose: { model: alerts, view: '/assets/html/components/Pager.html', mode: 'templated' }">
-                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
-                    <i class="fa fa-sitemap"></i>
-                    <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
-                    <br/>
-                    <i class="fa fa-cog"></i>
-                    <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
-                    <br/>
-                    <i class="fa fa-bar-chart"></i>
-                    <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
-                    <br/>
-                    <i class="fa fa-bell"></i>
-                    <span data-bind="text: name, tooltip:{ name, tooltipClass: 'host-tip'}, attr: {title: name}"></span>
-                    <br/>
-                    <i class="fa fa-calculator"></i>
-                    <span data-bind="text: statistic, tooltip:{ statistic, tooltipClass: 'host-tip'}, attr: {title: statistic}"></span>
-                    <br/>
-                    <i class="fa fa-clock-o left"></i>
-                    <span data-bind="text: period, tooltip:{ period, tooltipClass: 'host-tip'}, attr: {title: period}"></span>
-                    <a data-bind="attr: { href: editUri }">
-                        <i class="fa fa-pencil-square-o right"></i>
-                    </a>
-                    <a data-bind="click: $root.remove">
-                        <i class="fa fa-times right"></i>
-                    </a>
-                    <i class="fa right" data-bind="css: contextStyle, tooltip:{ contextTip, tooltipClass: 'host-tip'}, attr: {title: contextTip}"></i>
+                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6">
+                    <div class="left">
+                        <i class="fa" data-bind="css: contextStyle"></i>
+                        <i><span data-bind="text: service"></span></i>/<b><span data-bind="text: metric"></span></b>/<span data-bind="text: statistic"></span>
+                    </div>
+                    <div class="right">
+                        <a data-bind="attr: { href: editUri }">
+                            <i class="fa fa-pencil-square-o"></i>
+                        </a>
+                        <a data-bind="click: $root.remove" href="#">
+                            <i class="fa fa-times"></i>
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/public/html/alerts/AlertsViewModel.html
+++ b/public/html/alerts/AlertsViewModel.html
@@ -18,33 +18,57 @@
     <div class="row-fluid">
         <div class="col-md-12">
             <h2>Alerts</h2>
-            <div data-bind="compose: { model: alerts, view: '/assets/html/components/Pager.html' }"></div>
+        </div>
+    </div>
+    <div class="row-fluid">
+        <div class="col-md-12">
+            <div><a href="#alert/edit" class="btn btn-default" style="margin-bottom: .5em">Create New Alert</a></div>
+            <div data-bind="compose: { model: alerts, view: '/assets/html/components/Pager.html', mode: 'templated' }">
+                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
+                    <i class="fa fa-sitemap"></i>
+                    <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
+                    <br/>
+                    <i class="fa fa-cog"></i>
+                    <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
+                    <br/>
+                    <i class="fa fa-bar-chart"></i>
+                    <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
+                    <br/>
+                    <i class="fa fa-bell"></i>
+                    <span data-bind="text: name, tooltip:{ name, tooltipClass: 'host-tip'}, attr: {title: name}"></span>
+                    <br/>
+                    <i class="fa fa-calculator"></i>
+                    <span data-bind="text: statistic, tooltip:{ statistic, tooltipClass: 'host-tip'}, attr: {title: statistic}"></span>
+                    <br/>
+                    <i class="fa fa-clock-o left"></i>
+                    <span data-bind="text: period, tooltip:{ period, tooltipClass: 'host-tip'}, attr: {title: period}"></span>
+                    <a data-bind="attr: { href: editUri }">
+                        <i class="fa fa-pencil-square-o right"></i>
+                    </a>
+                    <a data-bind="click: $root.remove">
+                        <i class="fa fa-times right"></i>
+                    </a>
+                    <i class="fa right" data-bind="css: contextStyle, tooltip:{ contextTip, tooltipClass: 'host-tip'}, attr: {title: contextTip}"></i>
+                </div>
+            </div>
         </div>
     </div>
 </div>
 
-<script type="text/html" id="list-element-template">
-    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
-        <i class="fa fa-sitemap"></i>
-        <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
-        <br/>
-        <i class="fa fa-cog"></i>
-        <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
-        <br/>
-        <i class="fa fa-bar-chart"></i>
-        <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
-        <br/>
-        <i class="fa fa-bell"></i>
-        <span data-bind="text: name, tooltip:{ name, tooltipClass: 'host-tip'}, attr: {title: name}"></span>
-        <br/>
-        <i class="fa fa-calculator"></i>
-        <span data-bind="text: statistic, tooltip:{ statistic, tooltipClass: 'host-tip'}, attr: {title: statistic}"></span>
-        <br/>
-        <i class="fa fa-clock-o left"></i>
-        <span data-bind="text: period, tooltip:{ period, tooltipClass: 'host-tip'}, attr: {title: period}"></span>
-        <a data-bind="attr: { href: editUri }">
-            <i class="fa fa-pencil-square-o right"></i>
-        </a>
-        <i class="fa right" data-bind="css: contextStyle, tooltip:{ contextTip, tooltipClass: 'host-tip'}, attr: {title: contextTip}"></i>
+<div id="confirm-delete-modal" class="modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Are you sure?</h4>
+            </div>
+            <div class="modal-body">
+                <div>Are you sure you want to delete the alert?</div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" data-bind="click: confirmDelete">Confirm</button>
+            </div>
+        </div>
     </div>
-</script>
+</div>

--- a/public/html/alerts/EditAlertViewModel.html
+++ b/public/html/alerts/EditAlertViewModel.html
@@ -1,0 +1,71 @@
+<!--
+  ~ Copyright 2016 Smartsheet.com
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="container-fluid">
+    <div class="row-fluid">
+        <div class="col-md-12">
+            <h2>Edit Alert</h2>
+            <div class="col-md-12 col-sm-12 col-lg-12">
+                <form role="form" class="container-fluid form-horizontal col-md-8 col-sm-12 col-lg-6">
+                    <div class="form-group">
+                        <label for="nameInput">Name</label>
+                        <input class="form-control" data-bind="value: name" type="text" id="nameInput" placeholder="Name">
+                    </div>
+                    <div class="form-group">
+                        <label for="contextInput">Context</label>
+                        <select class="form-control" data-bind="options: contexts, optionsText: 'text', optionsValue: 'value', value: context" id="contextInput"></select>
+                        <!--<input class="form-control" data-bind="value: operator" type="text" id="operatorInput" placeholder="Operator">-->
+                    </div>
+                    <div class="form-group">
+                        <label for="metricInput">Metric</label>
+                        <input class="form-control" data-bind="value: metric" type="text" id="metricInput" placeholder="Metric">
+                    </div>
+                    <div class="form-group">
+                        <label for="serviceInput">Service</label>
+                        <input class="form-control" data-bind="value: service" type="text" id="serviceInput" placeholder="Service">
+                    </div>
+                    <div class="form-group">
+                        <label for="clusterInput">Cluster</label>
+                        <input class="form-control" data-bind="value: cluster" type="text" id="clusterInput" placeholder="Cluster">
+                    </div>
+                    <div class="form-group">
+                        <label for="statisticInput">Statistic</label>
+                        <input class="form-control" data-bind="value: statistic" type="text" id="statisticInput" placeholder="Statistic">
+                    </div>
+                    <div class="form-group">
+                        <label for="periodInput">Period</label>
+                        <input class="form-control" data-bind="value: period" type="text" id="periodInput" placeholder="Period">
+                    </div>
+                    <div class="form-group">
+                        <label for="operatorInput">Operator</label>
+                        <select class="form-control" data-bind="options: operators, optionsText: 'text', optionsValue: 'value', value: operator" id="operatorInput"></select>
+                        <!--<input class="form-control" data-bind="value: operator" type="text" id="operatorInput" placeholder="Operator">-->
+                    </div>
+                    <div class="form-group">
+                        <label for="valueInput">Value</label>
+                        <input class="form-control" data-bind="value: value" type="text" id="valueInput" placeholder="Value">
+                    </div>
+                    <div class="form-group">
+                        <label for="unitInput">Unit</label>
+                        <input class="form-control" data-bind="value: valueUnit" type="text" id="unitInput" placeholder="Unit">
+                    </div>
+                    <button type="submit" class="btn btn-default" data-bind="click: save">Save</button>
+                    <button type="submit" class="btn btn-warning" data-bind="click: cancel">Cancel</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/public/html/components/Pager.html
+++ b/public/html/components/Pager.html
@@ -14,15 +14,17 @@
   ~ limitations under the License.
   -->
 <div class="col-md-12 col-sm-12 col-lg-12 search-header">
-    <form role="form" class="container-fluid form-inline col-md-8 col-sm-12 col-lg-6">
+    <form role="form" class="form-inline">
         <div class="form-group has-feedback">
             <input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
             <span class="glyphicon glyphicon-search form-control-feedback"></span>
         </div>
     </form>
 </div>
-<div style="font-size: large; overflow-style: scrollbar; overflow-y: auto; margin-bottom: 6em" class="container-fluid col-md-12 col-sm-12 col-lg-12">
-    <div data-bind="template: {foreach: filteredEntities, name: 'list-element-template'}" class="row"></div>
+<div style="font-size: large; overflow-style: scrollbar; overflow-y: auto; margin-bottom: 6em" class="col-md-12 col-sm-12 col-lg-12">
+    <div data-bind="foreach: filteredEntities" class="row">
+        <div data-part="content"></div>
+    </div>
 </div>
 <nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
     <div class="text-center">

--- a/public/html/components/Pager.html
+++ b/public/html/components/Pager.html
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright 2016 Smartsheet.com
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<div class="col-md-12 col-sm-12 col-lg-12 search-header">
+    <form role="form" class="container-fluid form-inline col-md-8 col-sm-12 col-lg-6">
+        <div class="form-group has-feedback">
+            <input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
+            <span class="glyphicon glyphicon-search form-control-feedback"></span>
+        </div>
+    </form>
+</div>
+<div style="font-size: large; overflow-style: scrollbar; overflow-y: auto; margin-bottom: 6em" class="container-fluid col-md-12 col-sm-12 col-lg-12">
+    <div data-bind="template: {foreach: filteredEntities, name: 'list-element-template'}" class="row"></div>
+</div>
+<nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
+    <div class="text-center">
+        <ul class="pagination" data-bind="foreach: pagerElements">
+            <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
+        </ul>
+    </div>
+</nav>

--- a/public/html/expressions/ExpressionsViewModel.html
+++ b/public/html/expressions/ExpressionsViewModel.html
@@ -18,21 +18,19 @@
     <div class="row-fluid">
         <div class="col-md-12">
             <h2>Expressions</h2>
-            <div data-bind="compose: { model: expressions, view: '/assets/html/components/Pager.html' }"></div>
+            <div data-bind="compose: { model: expressions, view: '/assets/html/components/Pager.html', mode: 'templated' }">
+                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
+                    <i class="fa fa-sitemap"></i>
+                    <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
+                    <br/>
+                    <i class="fa fa-cloud"></i>
+                    <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
+                    <br/>
+                    <i class="fa fa-bar-chart"></i>
+                    <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
+                    <br/>
+                </div>
+            </div>
         </div>
     </div>
 </div>
-
-<script type="text/html" id="list-element-template">
-    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
-        <i class="fa fa-sitemap"></i>
-        <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
-        <br/>
-        <i class="fa fa-cloud"></i>
-        <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
-        <br/>
-        <i class="fa fa-bar-chart"></i>
-        <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
-        <br/>
-    </div>
-</script>

--- a/public/html/expressions/ExpressionsViewModel.html
+++ b/public/html/expressions/ExpressionsViewModel.html
@@ -18,37 +18,21 @@
     <div class="row-fluid">
         <div class="col-md-12">
             <h2>Expressions</h2>
-
-            <div class="col-md-12 col-sm-12 col-lg-12 search-header">
-                <form role="form" class="container-fluid form-inline col-md-8 col-sm-12 col-lg-6">
-                    <div class="form-group has-feedback">
-                        <input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
-                        <span class="glyphicon glyphicon-search form-control-feedback"></span>
-                    </div>
-                </form>
-            </div>
-            <div style="font-size: large; overflow-style: scrollbar; overflow-y: auto" class="container-fluid col-md-12 col-sm-12 col-lg-12">
-                <div data-bind="foreach: filteredEntities" class="row">
-                    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
-                        <i class="fa fa-sitemap"></i>
-                        <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
-                        <br/>
-                        <i class="fa fa-cloud"></i>
-                        <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
-                        <br/>
-                        <i class="fa fa-bar-chart"></i>
-                        <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
-                        <br/>
-                    </div>
-                </div>
-            </div>
-            <nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
-                <div class="text-center">
-                    <ul class="pagination" data-bind="foreach: pagerElements">
-                        <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
-                    </ul>
-                </div>
-            </nav>
+            <div data-bind="compose: { model: expressions, view: '/assets/html/components/Pager.html' }"></div>
         </div>
     </div>
 </div>
+
+<script type="text/html" id="list-element-template">
+    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6 box">
+        <i class="fa fa-sitemap"></i>
+        <span data-bind="text: cluster, tooltip:{ cluster, tooltipClass: 'host-tip'}, attr: {title: cluster}"></span>
+        <br/>
+        <i class="fa fa-cloud"></i>
+        <span data-bind="text: service, tooltip:{ service, tooltipClass: 'host-tip'}, attr: {title: service}"></span>
+        <br/>
+        <i class="fa fa-bar-chart"></i>
+        <span data-bind="text: metric, tooltip:{ metric, tooltipClass: 'host-tip'}, attr: {title: metric}"></span>
+        <br/>
+    </div>
+</script>

--- a/public/html/hostregistry/HostRegistryViewModel.html
+++ b/public/html/hostregistry/HostRegistryViewModel.html
@@ -2,41 +2,15 @@
     <div class="row-fluid">
         <div class="col-md-12">
             <h2>Host Registry</h2>
-
-            <div class="col-md-12 col-sm-12 col-lg-12 search-header">
-                <form role="form" class="container-fluid form-inline col-md-8 col-sm-12 col-lg-6">
-                    <div class="form-group has-feedback">
-                        <input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
-                        <span class="glyphicon glyphicon-search form-control-feedback"></span>
-                    </div>
-                    <div class="form-group">
-                        <select class="form-control" data-bind="value: versionFilter">
-                            <option value="" selected disabled>Software State</option>
-                            <option value="">Any</option>
-                            <option value="LATEST_VERSION_INSTALLED">Latest Version</option>
-                            <option value="OLD_VERSION_INSTALLED">Old Version</option>
-                            <option value="NOT_INSTALLED">Not Installed</option>
-                        </select>
-                    </div>
-                </form>
-            </div>
-            <div style="font-size: large; overflow-style: scrollbar; overflow-y: auto" class="container-fluid col-md-12 col-sm-12 col-lg-12">
-                <div data-bind="foreach: filteredEntities" class="row">
-                    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap" class="col-md-4 col-lg-3 col-sm-6">
-                        <button class="btn btn-default btn-xs" data-bind="enable: connectable, click: $parent.click">
-                            <i class="glyphicon" data-bind="css: connectionStyle"></i>
-                        </button>
-                        <span data-bind="text: hostname, tooltip:{ title: hostname, tooltipClass: 'host-tip'}, attr: {title: hostname}"></span>
-                    </div>
-                </div>
-            </div>
-            <nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
-                <div class="text-center">
-                    <ul class="pagination" data-bind="foreach: pagerElements">
-                        <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
-                    </ul>
-                </div>
-            </nav>
+            <div data-bind="compose: { model: hosts, view: '/assets/html/components/Pager.html' }"></div>
         </div>
     </div>
 </div>
+<script type="text/html" id="list-element-template">
+    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap" class="col-md-4 col-lg-3 col-sm-6">
+        <button class="btn btn-default btn-xs" data-bind="enable: connectable, click: $parent.click">
+            <i class="glyphicon" data-bind="css: connectionStyle"></i>
+        </button>
+        <span data-bind="text: hostname, tooltip:{ title: hostname, tooltipClass: 'host-tip'}, attr: {title: hostname}"></span>
+    </div>
+</script>

--- a/public/html/hostregistry/HostRegistryViewModel.html
+++ b/public/html/hostregistry/HostRegistryViewModel.html
@@ -2,15 +2,14 @@
     <div class="row-fluid">
         <div class="col-md-12">
             <h2>Host Registry</h2>
-            <div data-bind="compose: { model: hosts, view: '/assets/html/components/Pager.html' }"></div>
+            <div data-bind="compose: { model: hosts, view: '/assets/html/components/Pager.html', mode: 'templated' }">
+                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap" class="col-md-4 col-lg-3 col-sm-6">
+                    <button class="btn btn-default btn-xs" data-bind="enable: connectable, click: $parent.click">
+                        <i class="glyphicon" data-bind="css: connectionStyle"></i>
+                    </button>
+                    <span data-bind="text: hostname, tooltip:{ title: hostname, tooltipClass: 'host-tip'}, attr: {title: hostname}"></span>
+                </div>
+            </div>
         </div>
     </div>
 </div>
-<script type="text/html" id="list-element-template">
-    <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap" class="col-md-4 col-lg-3 col-sm-6">
-        <button class="btn btn-default btn-xs" data-bind="enable: connectable, click: $parent.click">
-            <i class="glyphicon" data-bind="css: connectionStyle"></i>
-        </button>
-        <span data-bind="text: hostname, tooltip:{ title: hostname, tooltipClass: 'host-tip'}, attr: {title: hostname}"></span>
-    </div>
-</script>

--- a/public/stylesheets/graph-config.css
+++ b/public/stylesheets/graph-config.css
@@ -3,19 +3,10 @@ input[type="checkbox"] {
     display: none;
 }
 
-.modal {
-    left: 50%;
-    width: 500px;
-    margin-left: -250px;
-    margin-top: 20px;
-}
-
 .modal-header, h4, .close {
     background-color: #666666;
     color:white !important;
     text-align: center;
-    font-size: 20px;
-    padding: 1px 40px;
 }
 
 .modal-footer {

--- a/test/controllers/AlertControllerTest.java
+++ b/test/controllers/AlertControllerTest.java
@@ -76,7 +76,7 @@ public class AlertControllerTest {
                 .header("Content-Type", "application/json")
                 .uri("/v1/alerts");
         Result result = Helpers.route(request);
-        Assert.assertEquals(Http.Status.OK, result.status());
+        Assert.assertEquals(Http.Status.NO_CONTENT, result.status());
         final models.ebean.Alert alert = Ebean.find(models.ebean.Alert.class)
                 .where()
                 .eq("uuid", UUID.fromString("88410734-aed7-11e1-8e54-00259060b612"))
@@ -262,7 +262,7 @@ public class AlertControllerTest {
                 .header("Content-Type", "application/json")
                 .uri("/v1/alerts");
         Result result = Helpers.route(request);
-        Assert.assertEquals(Http.Status.OK, result.status());
+        Assert.assertEquals(Http.Status.NO_CONTENT, result.status());
     }
 
     @Test
@@ -273,7 +273,7 @@ public class AlertControllerTest {
                 .header("Content-Type", "application/json")
                 .uri("/v1/alerts");
         Result result = Helpers.route(request);
-        Assert.assertEquals(Http.Status.OK, result.status());
+        Assert.assertEquals(Http.Status.NO_CONTENT, result.status());
     }
 
     @Test
@@ -288,7 +288,7 @@ public class AlertControllerTest {
                 .header("Content-Type", "application/json")
                 .uri("/v1/alerts");
         Result result = Helpers.route(request);
-        Assert.assertEquals(Http.Status.OK, result.status());
+        Assert.assertEquals(Http.Status.NO_CONTENT, result.status());
     }
 
     private JsonNode readTree(final String resourceSuffix) {

--- a/test/controllers/ExpressionControllerTest.java
+++ b/test/controllers/ExpressionControllerTest.java
@@ -73,7 +73,7 @@ public class ExpressionControllerTest {
                 .header("Content-Type", "application/json")
                 .uri("/v1/expressions");
         Result result = Helpers.route(request);
-        Assert.assertEquals(Http.Status.OK, result.status());
+        Assert.assertEquals(Http.Status.NO_CONTENT, result.status());
     }
 
     @Test
@@ -155,7 +155,7 @@ public class ExpressionControllerTest {
                 .header("Content-Type", "application/json")
                 .uri("/v1/expressions");
         Result result = Helpers.route(request);
-        Assert.assertEquals(Http.Status.OK, result.status());
+        Assert.assertEquals(Http.Status.NO_CONTENT, result.status());
         Expression expectedExpr = exprRepo.get(originalExpr.getId(), Organization.DEFAULT).get();
         Assert.assertEquals(OBJECT_MAPPER.valueToTree(expectedExpr), body);
     }


### PR DESCRIPTION
UI for editing, creating, and deleting alerts.  It's not pretty, but it's functional.

changes include:
- refactoring the pagination component to use the compose "template" mode
- new edit/create alert page
- modifying alert list to include create, edit and delete links
- API for deleting alerts
- shiny new UUID class
- fixing graph config modal
