### PR TITLE
Improve Postgresql Autocomplete

### DIFF
--- a/app/com/arpnetworking/metrics/portal/hosts/impl/DatabaseHostRepository.java
+++ b/app/com/arpnetworking/metrics/portal/hosts/impl/DatabaseHostRepository.java
@@ -41,6 +41,7 @@ import play.Environment;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -360,21 +361,21 @@ public class DatabaseHostRepository implements HostRepository {
 
             // Add the partial host name clause using the postgresql full text index
             if (query.getPartialHostname().isPresent() && !query.getPartialHostname().get().isEmpty()) {
-                final List<String> tokens = tokenize(query.getPartialHostname().get());
-                final String prefixExpression = tokens
+                final List<String> queryTokens = Arrays.asList(query.getPartialHostname().get().split(" "));
+                final String prefixExpression = queryTokens
                         .stream()
                         .map(s -> s + ":*")
-                        .reduce((s1, s2) -> s1 + " | " + s2)
+                        .reduce((s1, s2) -> s1 + " & " + s2)
                         .orElse(null);
-                final String termExpression = tokenize(query.getPartialHostname().get())
+                final String termExpression = queryTokens
                         .stream()
-                        .reduce((s1, s2) -> s1 + " | " + s2)
+                        .reduce((s1, s2) -> s1 + " & " + s2)
                         .orElse(null);
                 if (prefixExpression != null && termExpression != null) {
                     parameters.put("prefixQuery", prefixExpression);
                     parameters.put("termQuery", termExpression);
                     selectBuilder.append(", to_tsquery('simple',:prefixQuery) prefixQuery, to_tsquery('simple',:termQuery) termQuery");
-                    whereBuilder.append("where t0.name_idx_col @@ prefixQuery or t0.name_idx_col @@ termQuery");
+                    whereBuilder.append("where (t0.name_idx_col @@ prefixQuery or t0.name_idx_col @@ termQuery)");
                     orderBuilder.append("order by ts_rank(t0.name_idx_col, prefixQuery) * ts_rank(t0.name_idx_col, termQuery) "
                             + "/ char_length(t0.name) DESC, name ASC");
                 } else {
@@ -383,7 +384,6 @@ public class DatabaseHostRepository implements HostRepository {
                             .setMessage("Skipping partial host name query clause")
                             .addData("organization", organization)
                             .addData("partialHostName", query.getPartialHostname().get())
-                            .addData("tokens", tokens)
                             .addData("prefixExpression", prefixExpression)
                             .addData("termExpression", termExpression)
                             .log();
@@ -406,8 +406,10 @@ public class DatabaseHostRepository implements HostRepository {
 
             // Add the sort order
             if (query.getSortBy().isPresent()) {
-                beginOrExtend(orderBuilder, "order by ", ", ");
-                orderBuilder.append(mapField(query.getSortBy().get()))
+                // NOTE: Replace the ordering (if any) with the user specified one
+                orderBuilder.setLength(0);
+                orderBuilder.append("order by ")
+                        .append(mapField(query.getSortBy().get()))
                         .append(" ASC");
             }
 
@@ -429,15 +431,27 @@ public class DatabaseHostRepository implements HostRepository {
          */
         @Override
         public void saveHost(final models.ebean.Host host) {
+            final String hostname = host.getName();
+            final String labels = hostname.replace('.', ' ');
+            final String words = labels.replace('-', ' ');
+            final String alnum = tokenize(labels)
+                    .stream()
+                    .reduce((s1, s2) -> s1 + " " + s2)
+                    .orElse("");
+
             Ebean.save(host);
-            Ebean.createSqlUpdate("UPDATE portal.hosts SET name_idx_col = to_tsvector('simple', coalesce(:tokens,'')) WHERE id = :id")
+            Ebean.createSqlUpdate(
+                    "UPDATE portal.hosts SET name_idx_col = "
+                            + "setweight(to_tsvector('simple', coalesce(:hostname,'')), 'A')"
+                            + "|| setweight(to_tsvector('simple', coalesce(:labels,'')), 'B')"
+                            + "|| setweight(to_tsvector('simple', coalesce(:words,'')), 'C')"
+                            + "|| setweight(to_tsvector('simple', coalesce(:alnum,'')), 'D')"
+                            + "WHERE id = :id")
                     .setParameter("id", host.getId())
-                    .setParameter(
-                            "tokens",
-                            tokenize(host.getName())
-                                    .stream()
-                                    .reduce((s1, s2) -> s1 + " " + s2)
-                                    .orElse(host.getName()))
+                    .setParameter("hostname", hostname)
+                    .setParameter("labels", labels)
+                    .setParameter("words", words)
+                    .setParameter("alnum", alnum)
                     .execute();
         }
 


### PR DESCRIPTION
Improved postgresql full-text autocomplete. This treats spaces as search token separators and looks for to match all tokens or all token prefixes. The tokenization was also updated to include priority: first, the full hostname; second, the 'lablels' (separated by '.'); third, the 'words' (separated by '-'); finally, any alpha-numeric tokens. The results on my sample data are better prefix matching, and improved targetting during multi-token searches.

PS. @BrandonArp can you take a look at: https://github.com/ArpNetworking/metrics-portal/issues/74