### PR TITLE
Schedule fixups

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/Schedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/Schedule.java
@@ -15,7 +15,8 @@
  */
 package com.arpnetworking.metrics.portal.scheduling;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Optional;
 
 /**
@@ -30,5 +31,12 @@ public interface Schedule {
      * @param lastRun The last time the job was run.
      * @return The next time to run the job.
      */
-    Optional<ZonedDateTime> nextRun(Optional<ZonedDateTime> lastRun);
+    Optional<Instant> nextRun(Optional<Instant> lastRun);
+
+    /**
+     * Gets the time zone that the schedule is most naturally expressed in.
+     *
+     * @return The time zone.
+     */
+    ZoneId getZone();
 }

--- a/app/com/arpnetworking/metrics/portal/scheduling/Schedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/Schedule.java
@@ -16,7 +16,6 @@
 package com.arpnetworking.metrics.portal.scheduling;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.Optional;
 
 /**
@@ -32,11 +31,4 @@ public interface Schedule {
      * @return The next time to run the job.
      */
     Optional<Instant> nextRun(Optional<Instant> lastRun);
-
-    /**
-     * Gets the time zone that the schedule is most naturally expressed in.
-     *
-     * @return The time zone.
-     */
-    ZoneId getZone();
 }

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/BaseSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/BaseSchedule.java
@@ -22,7 +22,6 @@ import net.sf.oval.constraint.NotNull;
 import net.sf.oval.constraint.ValidateWithMethod;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -34,7 +33,6 @@ import javax.annotation.Nullable;
  */
 public abstract class BaseSchedule implements Schedule {
 
-    private final ZoneId _zone;
     private final Instant _runAtAndAfter;
     private final Optional<Instant> _runUntil;
 
@@ -44,7 +42,6 @@ public abstract class BaseSchedule implements Schedule {
      * @param builder Instance of <code>Builder</code>.
      */
     protected BaseSchedule(final Builder<?, ?> builder) {
-        _zone = builder._zone;
         _runAtAndAfter = builder._runAtAndAfter;
         _runUntil = Optional.ofNullable(builder._runUntil);
     }
@@ -55,11 +52,6 @@ public abstract class BaseSchedule implements Schedule {
 
     protected Optional<Instant> getRunUntil() {
         return _runUntil;
-    }
-
-    @Override
-    public ZoneId getZone() {
-        return _zone;
     }
 
     @Override
@@ -93,8 +85,6 @@ public abstract class BaseSchedule implements Schedule {
      */
     protected abstract static class Builder<B extends Builder<B, S>, S extends BaseSchedule> extends OvalBuilder<S> {
         @NotNull
-        protected ZoneId _zone;
-        @NotNull
         @ValidateWithMethod(methodName = "validateRunAtAndAfter", parameterType = Instant.class)
         protected Instant _runAtAndAfter;
         protected Instant _runUntil;
@@ -115,17 +105,6 @@ public abstract class BaseSchedule implements Schedule {
          * @return instance with correct <code>Builder</code> class type.
          */
         protected abstract B self();
-
-        /**
-         * The time zone the schedule is most naturally expressed in. Required. Cannot be null.
-         *
-         * @param zone The time zone.
-         * @return This instance of {@code Builder}.
-         */
-        public B setZone(final ZoneId zone) {
-            _zone = zone;
-            return self();
-        }
 
         /**
          * The earliest time at which the schedule should run. Required. Cannot be null.

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
@@ -15,7 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -39,7 +39,7 @@ public final class NeverSchedule extends BaseSchedule {
     }
 
     @Override
-    protected Optional<ZonedDateTime> unboundedNextRun(final Optional<ZonedDateTime> lastRun) {
+    protected Optional<Instant> unboundedNextRun(final Optional<Instant> lastRun) {
         return Optional.empty();
     }
 

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/OneOffSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/OneOffSchedule.java
@@ -15,7 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -29,12 +29,12 @@ public final class OneOffSchedule extends BaseSchedule {
         super(builder);
     }
 
-    public ZonedDateTime getWhenRun() {
+    public Instant getWhenRun() {
         return getRunAtAndAfter();
     }
 
     @Override
-    protected Optional<ZonedDateTime> unboundedNextRun(final Optional<ZonedDateTime> lastRun) {
+    protected Optional<Instant> unboundedNextRun(final Optional<Instant> lastRun) {
         if (lastRun.isPresent()) {
             return Optional.empty();
         }

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
@@ -88,7 +88,7 @@ public final class PeriodicSchedule extends BaseSchedule {
         @NotNull
         private ChronoUnit _period;
         @NotNull
-        protected ZoneId _zone;
+        private ZoneId _zone;
         @NotNull
         @ValidateWithMethod(methodName = "validateOffset", parameterType = Duration.class)
         private Duration _offset = Duration.ZERO;

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
@@ -20,6 +20,7 @@ import net.sf.oval.constraint.NotNull;
 import net.sf.oval.constraint.ValidateWithMethod;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -41,15 +42,16 @@ public final class PeriodicSchedule extends BaseSchedule {
     }
 
     @Override
-    protected Optional<ZonedDateTime> unboundedNextRun(final Optional<ZonedDateTime> lastRun) {
+    protected Optional<Instant> unboundedNextRun(final Optional<Instant> lastRun) {
         if (!lastRun.isPresent()) {
-            ZonedDateTime alignedStart = getRunAtAndAfter().truncatedTo(_period);
-            if (alignedStart.isBefore(getRunAtAndAfter())) {
+            ZonedDateTime alignedStart = ZonedDateTime.ofInstant(getRunAtAndAfter(), getZone()).truncatedTo(_period);
+            if (alignedStart.toInstant().isBefore(getRunAtAndAfter())) {
                 alignedStart = alignedStart.plus(Duration.of(1, _period));
             }
-            return Optional.of(alignedStart.plus(_offset));
+            return Optional.of(alignedStart.plus(_offset).toInstant());
         }
-        return Optional.of(lastRun.get().truncatedTo(_period).plus(Duration.of(1, _period)).plus(_offset));
+        final ZonedDateTime alignedLastRun = ZonedDateTime.ofInstant(lastRun.get(), getZone()).truncatedTo(_period);
+        return Optional.of(alignedLastRun.plus(Duration.of(1, _period)).plus(_offset).toInstant());
     }
 
 

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
 import org.junit.Test;
@@ -8,6 +23,11 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests for {@link BaseSchedule}.
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
 public final class BaseScheduleTest {
 
     private static final ZonedDateTime t0 = ZonedDateTime.parse("2018-01-01T00:00:00Z");

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
@@ -67,7 +67,6 @@ public final class BaseScheduleTest {
     @Test(expected = net.sf.oval.exception.ConstraintsViolatedException.class)
     public void testBuilderRejectsRunAfterAfterRunUntil() {
         new MinimalSchedule.Builder()
-                .setZone(ZoneId.of("+00:00"))
                 .setRunAtAndAfter(t0)
                 .setRunUntil(t0.minus(Duration.ofSeconds(1)))
                 .build();

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
@@ -18,6 +18,8 @@ package com.arpnetworking.metrics.portal.scheduling.impl;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -30,7 +32,7 @@ import static org.junit.Assert.assertEquals;
  */
 public final class BaseScheduleTest {
 
-    private static final ZonedDateTime t0 = ZonedDateTime.parse("2018-01-01T00:00:00Z");
+    private static final Instant t0 = Instant.parse("2018-01-01T00:00:00Z");
 
     private static final class MinimalSchedule extends BaseSchedule {
 
@@ -41,7 +43,7 @@ public final class BaseScheduleTest {
         }
 
         @Override
-        protected Optional<ZonedDateTime> unboundedNextRun(Optional<ZonedDateTime> lastRun) {
+        protected Optional<Instant> unboundedNextRun(Optional<Instant> lastRun) {
             return Optional.empty();
         }
 
@@ -65,6 +67,7 @@ public final class BaseScheduleTest {
     @Test(expected = net.sf.oval.exception.ConstraintsViolatedException.class)
     public void testBuilderRejectsRunAfterAfterRunUntil() {
         new MinimalSchedule.Builder()
+                .setZone(ZoneId.of("+00:00"))
                 .setRunAtAndAfter(t0)
                 .setRunUntil(t0.minus(Duration.ofSeconds(1)))
                 .build();

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/NeverScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/NeverScheduleTest.java
@@ -17,6 +17,7 @@ package com.arpnetworking.metrics.portal.scheduling.impl;
 
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -33,7 +34,7 @@ public final class NeverScheduleTest {
     public void testNextRun() {
         // Two interesting cases: lastRun=null, lastRun!=null
         assertEquals(Optional.empty(), NeverSchedule.getInstance().nextRun(Optional.empty()));
-        assertEquals(Optional.empty(), NeverSchedule.getInstance().nextRun(Optional.of(ZonedDateTime.parse("2019-01-01T00:00:00Z"))));
+        assertEquals(Optional.empty(), NeverSchedule.getInstance().nextRun(Optional.of(Instant.parse("2019-01-01T00:00:00Z"))));
     }
 
 }

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/OneOffScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/OneOffScheduleTest.java
@@ -18,8 +18,8 @@ package com.arpnetworking.metrics.portal.scheduling.impl;
 import com.arpnetworking.metrics.portal.scheduling.Schedule;
 import org.junit.Test;
 
-import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -34,31 +34,32 @@ public final class OneOffScheduleTest {
     @Test
     public void testNextRun() {
         final Schedule schedule = new OneOffSchedule.Builder()
-                .setRunAtAndAfter(ZonedDateTime.parse("2019-01-01T00:00:00Z"))
+                .setZone(ZoneId.of("+00:00"))
+                .setRunAtAndAfter(Instant.parse("2019-01-01T00:00:00Z"))
                 .build();
 
         // typical progression, from lastRun=null to lastRun>runUntil
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-01T00:00:00Z")),
+                Optional.of(Instant.parse("2019-01-01T00:00:00Z")),
                 schedule.nextRun(Optional.empty()));
         assertEquals(
                 Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-01T00:00:00Z"))));
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-01T00:00:00Z"))));
 
         // lastRun < runAfter: next run should be null
         assertEquals(
                 Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2018-12-20T12:34:56Z"))));
+                schedule.nextRun(Optional.of(Instant.parse("2018-12-20T12:34:56Z"))));
 
         // runAfter < lastRun < runUntil: next run should be null
         assertEquals(
                 Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-02T12:34:56Z"))));
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-02T12:34:56Z"))));
 
         // lastRun > runUntil: next run should be null
         assertEquals(
                 Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("9999-01-01T00:00:00Z"))));
+                schedule.nextRun(Optional.of(Instant.parse("9999-01-01T00:00:00Z"))));
     }
 
 }

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/OneOffScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/OneOffScheduleTest.java
@@ -34,7 +34,6 @@ public final class OneOffScheduleTest {
     @Test
     public void testNextRun() {
         final Schedule schedule = new OneOffSchedule.Builder()
-                .setZone(ZoneId.of("+00:00"))
                 .setRunAtAndAfter(Instant.parse("2019-01-01T00:00:00Z"))
                 .build();
 

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicScheduleTest.java
@@ -61,6 +61,10 @@ public final class PeriodicScheduleTest {
                 Optional.empty(),
                 schedule.nextRun(Optional.of(Instant.parse("2019-01-03T00:00:00Z"))));
 
+        // lastRun < runAfter: should round correctly
+        assertEquals(
+                Optional.of(Instant.parse("2019-01-01T00:00:00Z")), schedule.nextRun(Optional.of(Instant.parse("2018-12-20T12:34:56Z"))));
+
         // runAfter < lastRun < runUntil: should round correctly
         assertEquals(
                 Optional.of(Instant.parse("2019-01-03T00:00:00Z")), schedule.nextRun(Optional.of(Instant.parse("2019-01-02T12:34:56Z"))));
@@ -86,8 +90,15 @@ public final class PeriodicScheduleTest {
                 Optional.of(Instant.parse("2019-01-02T12:00:00Z")),
                 schedule.nextRun(Optional.empty()));
         assertEquals(
-                Optional.of(Instant.parse("2019-01-01T12:00:00Z")),
-                schedule.nextRun(Optional.of(Instant.parse("2018-12-20T12:34:56Z"))));
+                Optional.of(Instant.parse("2019-01-03T12:00:00Z")),
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-02T12:00:00Z"))));
+        assertEquals(
+                Optional.empty(),
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-03T12:00:00Z"))));
+
+        // lastRun < runAfter: should round correctly
+        assertEquals(
+                Optional.of(Instant.parse("2019-01-01T12:00:00Z")), schedule.nextRun(Optional.of(Instant.parse("2018-12-20T12:34:56Z"))));
 
         // runAfter < lastRun < runUntil: should round correctly
         assertEquals(

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicScheduleTest.java
@@ -55,8 +55,11 @@ public final class PeriodicScheduleTest {
                 Optional.of(Instant.parse("2019-01-02T00:00:00Z")),
                 schedule.nextRun(Optional.of(Instant.parse("2019-01-01T00:00:00Z"))));
         assertEquals(
-                Optional.of(Instant.parse("2019-01-01T00:00:00Z")),
-                schedule.nextRun(Optional.of(Instant.parse("2018-12-20T12:34:56Z"))));
+                Optional.of(Instant.parse("2019-01-03T00:00:00Z")),
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-02T00:00:00Z"))));
+        assertEquals(
+                Optional.empty(),
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-03T00:00:00Z"))));
 
         // runAfter < lastRun < runUntil: should round correctly
         assertEquals(

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicScheduleTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicScheduleTest.java
@@ -19,6 +19,8 @@ import com.arpnetworking.metrics.portal.scheduling.Schedule;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -32,98 +34,86 @@ import static org.junit.Assert.assertEquals;
  */
 public final class PeriodicScheduleTest {
 
-    private static final ZonedDateTime t0 = ZonedDateTime.parse("2019-01-01T00:00:00Z");
+    private static final Instant t0 = Instant.parse("2019-01-01T00:00:00Z");
 
     @Test
     public void testNextRunWithAlignedBounds() {
         final Schedule schedule = new PeriodicSchedule.Builder()
+                .setZone(ZoneId.of("+00:00"))
                 .setPeriod(ChronoUnit.DAYS)
                 .setOffset(Duration.ZERO)
-                .setRunAtAndAfter(ZonedDateTime.parse("2019-01-01T00:00:00Z"))
-                .setRunUntil(ZonedDateTime.parse("2019-01-03T00:00:00Z"))
+                .setRunAtAndAfter(Instant.parse("2019-01-01T00:00:00Z"))
+                .setRunUntil(Instant.parse("2019-01-03T00:00:00Z"))
                 .build();
 
         // typical progression, from lastRun=null to lastRun>runUntil
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-01T00:00:00Z")),
+                Optional.of(Instant.parse("2019-01-01T00:00:00Z")),
                 schedule.nextRun(Optional.empty()));
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-02T00:00:00Z")),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-01T00:00:00Z"))));
+                Optional.of(Instant.parse("2019-01-02T00:00:00Z")),
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-01T00:00:00Z"))));
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-03T00:00:00Z")),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-02T00:00:00Z"))));
-        assertEquals(
-                Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-03T00:00:00Z"))));
-
-        // lastRun<runAfter: next run should be right at/after runAfter
-        assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-01T00:00:00Z")),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2018-12-20T12:34:56Z"))));
+                Optional.of(Instant.parse("2019-01-01T00:00:00Z")),
+                schedule.nextRun(Optional.of(Instant.parse("2018-12-20T12:34:56Z"))));
 
         // runAfter < lastRun < runUntil: should round correctly
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-03T00:00:00Z")), schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-02T12:34:56Z"))));
+                Optional.of(Instant.parse("2019-01-03T00:00:00Z")), schedule.nextRun(Optional.of(Instant.parse("2019-01-02T12:34:56Z"))));
 
         // lastRun>runUntil: should not run again
         assertEquals(
                 Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("9999-01-01T00:00:00Z"))));
+                schedule.nextRun(Optional.of(Instant.parse("9999-01-01T00:00:00Z"))));
     }
 
     @Test
     public void testNextRunWithUnalignedBounds() {
         final Schedule schedule = new PeriodicSchedule.Builder()
+                .setZone(ZoneId.of("+00:00"))
                 .setPeriod(ChronoUnit.DAYS)
                 .setOffset(Duration.ofHours(12))
-                .setRunAtAndAfter(ZonedDateTime.parse("2019-01-01T06:00:00Z"))
-                .setRunUntil(ZonedDateTime.parse("2019-01-04T00:00:00Z"))
+                .setRunAtAndAfter(Instant.parse("2019-01-01T06:00:00Z"))
+                .setRunUntil(Instant.parse("2019-01-04T00:00:00Z"))
                 .build();
 
         // typical progression, from lastRun=null to lastRun>runUntil
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-02T12:00:00Z")),
+                Optional.of(Instant.parse("2019-01-02T12:00:00Z")),
                 schedule.nextRun(Optional.empty()));
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-03T12:00:00Z")),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-02T12:00:00Z"))));
-        assertEquals(
-                Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-03T12:00:00Z"))));
-
-        // lastRun<runAfter: next run should be right at/after runAfter
-        assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-01T12:00:00Z")),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2018-12-20T12:34:56Z"))));
+                Optional.of(Instant.parse("2019-01-01T12:00:00Z")),
+                schedule.nextRun(Optional.of(Instant.parse("2018-12-20T12:34:56Z"))));
 
         // runAfter < lastRun < runUntil: should round correctly
         assertEquals(
-                Optional.of(ZonedDateTime.parse("2019-01-03T12:00:00Z")),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("2019-01-02T12:34:56Z"))));
+                Optional.of(Instant.parse("2019-01-03T12:00:00Z")),
+                schedule.nextRun(Optional.of(Instant.parse("2019-01-02T12:34:56Z"))));
 
         // lastRun>runUntil: should not run again
         assertEquals(
                 Optional.empty(),
-                schedule.nextRun(Optional.of(ZonedDateTime.parse("9999-01-01T00:00:00Z"))));
+                schedule.nextRun(Optional.of(Instant.parse("9999-01-01T00:00:00Z"))));
     }
 
     @Test
     public void testNextRunWithPathologicallySmallBounds() {
         final Schedule schedule = new PeriodicSchedule.Builder()
+                .setZone(ZoneId.of("+00:00"))
                 .setPeriod(ChronoUnit.DAYS)
                 .setOffset(Duration.ZERO)
-                .setRunAtAndAfter(ZonedDateTime.parse("2019-01-01T12:34:56Z"))
-                .setRunUntil(ZonedDateTime.parse("2019-01-01T12:34:57Z"))
+                .setRunAtAndAfter(Instant.parse("2019-01-01T12:34:56Z"))
+                .setRunUntil(Instant.parse("2019-01-01T12:34:57Z"))
                 .build();
 
         assertEquals(Optional.empty(), schedule.nextRun(Optional.empty()));
-        assertEquals(Optional.empty(), schedule.nextRun(Optional.of(ZonedDateTime.parse("2018-01-01T00:00:00Z"))));
+        assertEquals(Optional.empty(), schedule.nextRun(Optional.of(Instant.parse("2018-01-01T00:00:00Z"))));
     }
 
     @Test(expected = net.sf.oval.exception.ConstraintsViolatedException.class)
     public void testBuilderOffsetMustBeSmallerThanPeriod() {
         new PeriodicSchedule.Builder()
+                .setZone(ZoneId.of("+00:00"))
                 .setPeriod(ChronoUnit.HOURS)
                 .setOffset(Duration.ofHours(1))
                 .setRunAtAndAfter(t0)
@@ -133,6 +123,7 @@ public final class PeriodicScheduleTest {
     @Test(expected = net.sf.oval.exception.ConstraintsViolatedException.class)
     public void testBuilderOffsetCannotBeNegative() {
         new PeriodicSchedule.Builder()
+                .setZone(ZoneId.of("+00:00"))
                 .setPeriod(ChronoUnit.HOURS)
                 .setOffset(Duration.ofSeconds(-1))
                 .setRunAtAndAfter(t0)
@@ -142,6 +133,7 @@ public final class PeriodicScheduleTest {
     @Test
     public void testBuilderOffsetDefaultsToZero() {
         PeriodicSchedule schedule = new PeriodicSchedule.Builder()
+                .setZone(ZoneId.of("+00:00"))
                 .setPeriod(ChronoUnit.HOURS)
                 .setRunAtAndAfter(t0)
                 .build();
@@ -151,12 +143,13 @@ public final class PeriodicScheduleTest {
     @Test
     public void testAlignsToCorrectTimeZone() {
         final Schedule schedule = new PeriodicSchedule.Builder()
+                .setZone(ZoneId.of("+12:34"))
                 .setPeriod(ChronoUnit.DAYS)
                 .setOffset(Duration.ofHours(12))
-                .setRunAtAndAfter(ZonedDateTime.parse("2019-01-01T00:00:00+12:34"))
-                .setRunUntil(ZonedDateTime.parse("2019-01-04T00:00:00+12:34"))
+                .setRunAtAndAfter(ZonedDateTime.parse("2019-01-01T00:00:00+12:34").toInstant())
+                .setRunUntil(ZonedDateTime.parse("2019-01-04T00:00:00+12:34").toInstant())
                 .build();
-        assertEquals(Optional.of(ZonedDateTime.parse("2019-01-01T12:00:00+12:34")), schedule.nextRun(Optional.empty()));
+        assertEquals(Optional.of(ZonedDateTime.parse("2019-01-01T12:00:00+12:34").toInstant()), schedule.nextRun(Optional.empty()));
     }
 
 }


### PR DESCRIPTION
- bugfix in how PeriodicSchedule interacts with DST switchovers (and add tests for such cases)
- prefer `Instant` to `ZonedDateTime` ~everywhere; PeriodicSchedule still uses zones, but the `Schedule` interface now uses plain `Instant`s, because Schedules should have the option to not care about time zones.
