### PR TITLE
remove direct dependency on async-http-client, add dep plugin

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -71,7 +71,6 @@ object ApplicationBuild extends Build {
       "com.arpnetworking.metrics.extras" % "apache-http-sink-extra" % "0.8.2",
       "com.arpnetworking.metrics.extras" % "incubator-extra" % "0.6.3",
       "com.arpnetworking.metrics.extras" % "jvm-extra" % "0.7.0",
-      "org.asynchttpclient" % "async-http-client" % "2.0.32",
       "com.chrisomeara" %% "pillar" % "2.3.0",
       "com.datastax.cassandra" % "cassandra-driver-core" % cassandraDriverVersion,
       "com.datastax.cassandra" % "cassandra-driver-mapping" % cassandraDriverVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,6 +45,8 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+
 libraryDependencies ++= Seq(
     "com.puppycrawl.tools" % "checkstyle" % "8.4"
 )


### PR DESCRIPTION
There's a classpath conflict that causes the shaded async client to try and load its config from the non-shaded jar's resource path. The shaded keys don't exist in this configuration, and so loading from that resource fails.

Luckily, it looks like MP doesn't actually need this direct dependency. Verified that the conflict no longer exists using the dependency graph plugin.

See: https://github.com/playframework/play-ws/issues/87