### PR TITLE
refactor/enhance JobExecutorActor

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.scheduling;
+
+import akka.actor.ActorRef;
+import com.arpnetworking.steno.Logger;
+import com.arpnetworking.steno.LoggerFactory;
+import com.google.common.base.MoreObjects;
+import com.google.inject.Injector;
+import models.internal.scheduling.Job;
+
+import java.time.Instant;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Wrapper around a {@link JobRef} / {@link Job} that tries to minimize interaction with the underlying repository.
+ *
+ * @param <T> Type of the result computed by the referenced {@link Job}.
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
+public final class CachedJob<T> implements Job<T> {
+    private final Injector _injector;
+    private final JobRef<T> _ref;
+    private Job<T> _cached;
+    private Optional<Instant> _lastRun;
+
+    CachedJob(final Injector injector, final JobRef<T> ref) {
+        _injector = injector;
+        _ref = ref;
+        reload();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("ref", _ref)
+                .add("cached", _cached)
+                .toString();
+    }
+
+    public JobRef<T> getRef() {
+        return _ref;
+    }
+
+    public Optional<Instant> getLastRun() {
+        return _lastRun;
+    }
+
+    public Optional<Instant> getNextRun() {
+        return _cached.getSchedule().nextRun(_lastRun);
+    }
+
+    /**
+     * Unconditionally reloads the cached information from the repository.
+     */
+    public void reload() {
+        final Optional<Job<T>> loaded = _ref.get(_injector);
+        if (!loaded.isPresent()) {
+            throw new NoSuchElementException("TODO(spencerpearson)");
+        }
+        _cached = loaded.get();
+        _lastRun = _ref.getRepository(_injector).getLastRun(_ref.getJobId(), _ref.getOrganization());
+    }
+
+    /**
+     * Reloads the cached information from the repository, iff it's out of date.
+     *
+     * @param upToDateETag Checked for equality to the cached job's ETag;
+     *   if equal, the cached version is assumed to be up to date and no reload is performed.
+     */
+    public void reloadIfOutdated(final String upToDateETag) {
+        if (_cached.getETag().equals(upToDateETag)) {
+            return;
+        }
+        LOGGER.debug()
+                .setMessage("job is stale; reloading")
+                .addData("jobRef", _ref)
+                .addData("oldETag", _cached.getETag())
+                .addData("newETag", upToDateETag)
+                .log();
+        reload();
+    }
+
+    @Override
+    public UUID getId() {
+        return _cached.getId();
+    }
+
+    @Override
+    public String getETag() {
+        return _cached.getETag();
+    }
+
+    @Override
+    public Schedule getSchedule() {
+        return _cached.getSchedule();
+    }
+
+    @Override
+    public CompletionStage<T> execute(final ActorRef scheduler, final Instant scheduled) {
+        final JobRepository<T> repo = _ref.getRepository(_injector);
+        repo.jobStarted(_cached.getId(), _ref.getOrganization(), scheduled);
+        return _cached.execute(scheduler, scheduled)
+                .handle((result, error) -> {
+                    _lastRun = Optional.of(scheduled);
+                    if (error == null) {
+                        repo.jobSucceeded(_cached.getId(), _ref.getOrganization(), scheduled, result);
+                    } else {
+                        repo.jobFailed(_cached.getId(), _ref.getOrganization(), scheduled, error);
+                    }
+                    return null;
+                });
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CachedJob.class);
+}

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * A storage medium for {@link Job}s.
@@ -68,6 +69,15 @@ public interface JobRepository<T> {
      * @throws NoSuchElementException if no job has the given UUID.
      */
     Optional<Instant> getLastRun(UUID id, Organization organization) throws NoSuchElementException;
+
+    /**
+     * Returns every job the repository contains (for a given {@link Organization}).
+     *
+     * @param organization The organization whose jobs to iterate over.
+     * @return A stream of every job in the repository. No order guaranteed.
+     *         No guarantees about presence of jobs added by other threads/processes while the stream is running.
+     */
+    Stream<Job<T>> getAllJobs(Organization organization);
 
     /**
      * Notify the repository that a job has started executing.

--- a/app/models/internal/scheduling/Job.java
+++ b/app/models/internal/scheduling/Job.java
@@ -39,6 +39,13 @@ public interface Job<T> {
     UUID getId();
 
     /**
+     * Gets an <a href="https://en.wikipedia.org/wiki/HTTP_ETag">ETag</a> that changes each time the job changes.
+     *
+     * @return The ETag.
+     */
+    String getETag();
+
+    /**
      * Returns the schedule on which the Job should be repeated.
      *
      * @return The schedule.

--- a/test/com/arpnetworking/metrics/portal/AkkaClusteringConfigFactory.java
+++ b/test/com/arpnetworking/metrics/portal/AkkaClusteringConfigFactory.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -35,12 +36,23 @@ public final class AkkaClusteringConfigFactory {
     public static Map<String, Object> generateConfiguration() {
         final int nextCounter = UNIQUE_COUNTER.getAndIncrement();
         final int port = BASE_PORT + nextCounter;
-        return ImmutableMap.of(
-                "akka.cluster.seed-nodes", Collections.singletonList(String.format("akka.tcp://mportal@127.0.0.1:%d", port)),
-                "akka.remote.netty.tcp.hostname", "127.0.0.1",
-                "akka.remote.netty.tcp.port", port);
+        return ImmutableMap.<String, Object>builder()
+                .put("akka.cluster.seed-nodes", Collections.singletonList(String.format("akka.tcp://mportal@127.0.0.1:%d", port)))
+                .put("akka.actor.provider", "akka.cluster.ClusterActorRefProvider")
+                .put("akka.remote.netty.tcp.hostname", "127.0.0.1")
+                .put("akka.remote.netty.tcp.port", port)
+                .put("akka.persistence.snapshot-store.plugin", "akka.persistence.snapshot-store.local")
+                .put("akka.persistence.journal.plugin", "akka.persistence.journal.inmem")
+                .put(
+                        "akka.persistence.snapshot-store.local.dir",
+                        "test-snapshots/"
+                                + RUN_ID + "/"
+                                + nextCounter + "/"
+                )
+                .build();
     }
 
+    private static final UUID RUN_ID = UUID.randomUUID();
     private static final AtomicInteger UNIQUE_COUNTER = new AtomicInteger(1);
     private static final int BASE_PORT = 20000;
 }

--- a/test/com/arpnetworking/metrics/portal/scheduling/JobExecutorActorTest.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/JobExecutorActorTest.java
@@ -15,15 +15,24 @@
  */
 package com.arpnetworking.metrics.portal.scheduling;
 
+import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
+import akka.actor.PoisonPill;
 import akka.actor.Props;
+import akka.actor.Terminated;
+import akka.cluster.pubsub.DistributedPubSub;
+import akka.cluster.pubsub.DistributedPubSubMediator;
 import akka.testkit.TestActorRef;
+import akka.testkit.javadsl.TestKit;
 import com.arpnetworking.commons.java.time.ManualClock;
-import com.arpnetworking.metrics.MetricsFactory;
 import com.arpnetworking.metrics.impl.TsdMetricsFactory;
+import com.arpnetworking.metrics.incubator.PeriodicMetrics;
+import com.arpnetworking.metrics.incubator.impl.TsdPeriodicMetrics;
 import com.arpnetworking.metrics.portal.AkkaClusteringConfigFactory;
-import com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule;
+import com.arpnetworking.metrics.portal.scheduling.impl.MapJobRepository;
+import com.arpnetworking.metrics.portal.scheduling.impl.PeriodicSchedule;
+import com.arpnetworking.metrics.portal.scheduling.mocks.DummyJob;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -33,18 +42,19 @@ import models.internal.scheduling.Job;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.NoSuchElementException;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
@@ -56,27 +66,18 @@ import static org.junit.Assert.assertEquals;
  */
 public final class JobExecutorActorTest {
 
-    private static class MockableJobRepository implements JobRepository<UUID> {
-         @Override public void open() {}
-         @Override public void close() {}
-         @Override public void addOrUpdateJob(final Job<UUID> job, final Organization organization) {}
-         @Override public Optional<Job<UUID>> getJob(final UUID id, final Organization organization) { return Optional.empty(); }
-         @Override public Optional<Instant> getLastRun(final UUID id, final Organization organization) throws NoSuchElementException { return Optional.empty(); }
-         @Override public void jobStarted(final UUID id, final Organization organization, final Instant scheduled) {}
-         @Override public void jobSucceeded(final UUID id, final Organization organization, final Instant scheduled, final UUID result) {}
-         @Override public void jobFailed(final UUID id, final Organization organization, final Instant scheduled, final Throwable error) {}
-    }
-
-
     private static final Instant t0 = Instant.ofEpochMilli(0);
     private static final java.time.Duration tickSize = java.time.Duration.ofSeconds(1);
     private static final Organization organization = Organization.DEFAULT;
 
+    private static class MockableIntJobRepository extends MapJobRepository<Integer> {}
+
     private Injector injector;
-    @Mock
-    private MockableJobRepository repo;
+    private MockableIntJobRepository repo;
     private ManualClock clock;
+    private PeriodicMetrics periodicMetrics;
     private ActorSystem system;
+    private DistributedPubSub reloadPubSub;
 
     private static final AtomicLong systemNameNonce = new AtomicLong(0);
 
@@ -84,19 +85,28 @@ public final class JobExecutorActorTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
+        repo = Mockito.spy(new MockableIntJobRepository());
+        repo.open();
+
+        clock = new ManualClock(t0, tickSize, ZoneId.systemDefault());
+
         injector = Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
-                bind(MockableJobRepository.class).toInstance(repo);
-                bind(MetricsFactory.class).toInstance(TsdMetricsFactory.newInstance("test", "test"));
+                bind(MockableIntJobRepository.class).toInstance(repo);
+                bind(Clock.class).toInstance(clock);
             }
         });
 
-        clock = new ManualClock(t0, tickSize, ZoneId.systemDefault());
+        periodicMetrics = new TsdPeriodicMetrics.Builder()
+                .setMetricsFactory(TsdMetricsFactory.newInstance("test", "test"))
+                .build();
 
         system = ActorSystem.create(
                 "test-"+systemNameNonce.getAndIncrement(),
                 ConfigFactory.parseMap(AkkaClusteringConfigFactory.generateConfiguration()));
+
+        reloadPubSub = DistributedPubSub.get(system);
     }
 
     @After
@@ -104,141 +114,149 @@ public final class JobExecutorActorTest {
         system.terminate();
     }
 
-    private <T> void addJobToRepo(final Job<T> job) {
+    private DummyJob<Integer> addJobToRepo(final DummyJob<Integer> job) {
         Mockito.doReturn(Optional.of(job)).when(repo).getJob(job.getId(), organization);
         Mockito.doReturn(Optional.empty()).when(repo).getLastRun(job.getId(), organization);
+        return job;
     }
 
-    private SuccessfulJob makeSuccessfulJob() {
-        return makeSuccessfulJob(t0);
-    }
-    private SuccessfulJob makeSuccessfulJob(final Instant runAt) {
-        SuccessfulJob result = new SuccessfulJob(runAt);
-        addJobToRepo(result);
-        return result;
+    private Props makeExecutorActorProps() {
+        return JobExecutorActor.props(injector, clock, reloadPubSub, periodicMetrics);
     }
 
-    private FailingJob makeFailingJob() {
-        FailingJob result = new FailingJob(new Throwable("huh, something went wrong"));
-        addJobToRepo(result);
-        return result;
+    private ActorRef makeExecutorActor() {
+        return system.actorOf(makeExecutorActorProps());
     }
 
-    private Props makeExecutorActorProps(final Job<UUID> job) {
-        final JobRef<UUID> ref = new JobRef.Builder<UUID>()
-                .setRepositoryType(MockableJobRepository.class)
+    private ActorRef makeAndInitializeExecutorActor(final Job<Integer> job) {
+        final JobRef<Integer> ref = new JobRef.Builder<Integer>()
+                .setRepositoryType(MockableIntJobRepository.class)
                 .setId(job.getId())
                 .setOrganization(organization)
                 .build();
-        return JobExecutorActor.props(injector, ref, clock);
-    }
-
-    private ActorRef makeExecutorActor(final Job<UUID> job) {
-        return system.actorOf(makeExecutorActorProps(job));
+        final ActorRef result = makeExecutorActor();
+        result.tell(new JobExecutorActor.Reload.Builder<Integer>().setJobRef(ref).build(), null);
+        result.tell(JobExecutorActor.Tick.INSTANCE, null);
+        return result;
     }
 
     @Test
     public void testJobSuccess() {
-        final Job<UUID> j = makeSuccessfulJob();
-        final ActorRef scheduler = makeExecutorActor(j);
-
-        scheduler.tell(JobExecutorActor.Tick.INSTANCE, null);
+        final DummyJob<Integer> j = addJobToRepo(new DummyJob.Builder<Integer>().setOneOffSchedule(t0).setResult(123).build());
+        makeAndInitializeExecutorActor(j);
 
         Mockito.verify(repo, Mockito.timeout(1000)).jobSucceeded(
                 j.getId(),
                 organization,
                 j.getSchedule().nextRun(Optional.empty()).get(),
-                j.getId());
+                123);
     }
 
     @Test
     public void testJobFailure() {
-        final FailingJob j = makeFailingJob();
+        final Throwable error = new Throwable("huh");
+        final DummyJob<Integer> j = addJobToRepo(new DummyJob.Builder<Integer>().setOneOffSchedule(t0).setError(error).build());
+        makeAndInitializeExecutorActor(j);
 
-        final ActorRef scheduler = makeExecutorActor(j);
-
-        scheduler.tell(JobExecutorActor.Tick.INSTANCE, null);
         Mockito.verify(repo, Mockito.timeout(1000)).jobFailed(
-                j.getId(),
-                organization,
-                j.getSchedule().nextRun(Optional.empty()).get(),
-                j._error);
+                Mockito.eq(j.getId()),
+                Mockito.eq(organization),
+                Mockito.eq(j.getSchedule().nextRun(Optional.empty()).get()),
+                Mockito.any(CompletionException.class));
     }
 
     @Test
     public void testJobInFutureNotRun() {
-        final Job<UUID> j = makeSuccessfulJob(t0.plus(Duration.ofMinutes(1)));
+        final Job<Integer> j = addJobToRepo(new DummyJob.Builder<Integer>().setOneOffSchedule(t0.plus(Duration.ofMinutes(1))).setResult(123).build());
+        makeAndInitializeExecutorActor(j);
 
-        final ActorRef scheduler = makeExecutorActor(j);
-
-        scheduler.tell(JobExecutorActor.Tick.INSTANCE, null);
         Mockito.verify(repo, Mockito.after(1000).never()).jobStarted(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(repo, Mockito.never()).jobSucceeded(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(repo, Mockito.never()).jobFailed(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 
     @Test
+    public void testOnlyExecutesOneAtATime() {
+        final Instant startAt = t0.minus(ChronoUnit.HOURS.getDuration());
+        final CompletableFuture<Void> blocker = new CompletableFuture<>();
+        final DummyJob<Integer> job = addJobToRepo(new DummyJob.Builder<Integer>()
+                .setSchedule(new PeriodicSchedule.Builder()
+                        .setRunAtAndAfter(startAt)
+                        .setZone(ZoneId.of("UTC"))
+                        .setPeriod(ChronoUnit.MINUTES)
+                        .build())
+                .setResult(123)
+                .setBlocker(blocker)
+                .build());
+
+        final ActorRef executor = makeAndInitializeExecutorActor(job);
+
+        Mockito.verify(repo, Mockito.timeout(1000).times(1)).jobStarted(job.getId(), organization, startAt);
+
+        // Now that execution has started once, execution shouldn't start until the job completes, even if the executor ticks several times
+        executor.tell(JobExecutorActor.Tick.INSTANCE, null);
+        executor.tell(JobExecutorActor.Tick.INSTANCE, null);
+        executor.tell(JobExecutorActor.Tick.INSTANCE, null);
+        executor.tell(JobExecutorActor.Tick.INSTANCE, null);
+        // (ensure that the job didn't weirdly complete for some reason)
+        Mockito.verify(repo, Mockito.after(1000).never()).jobSucceeded(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        // Ensure that, despite the ticks, still only a single execution for the job has ever started
+        Mockito.verify(repo, Mockito.timeout(1000).times(1)).jobStarted(Mockito.eq(job.getId()), Mockito.eq(organization), Mockito.any());
+
+        blocker.complete(null);
+
+        // NOW we should be able to run again
+        executor.tell(JobExecutorActor.Tick.INSTANCE, null);
+        Mockito.verify(repo, Mockito.timeout(1000)).jobStarted(job.getId(), organization, job.getSchedule().nextRun(Optional.of(startAt)).get());
+        // ...but still, only two executions should ever have started (one for t0, one for the moment after t0)
+        Mockito.verify(repo, Mockito.timeout(1000).times(2)).jobStarted(Mockito.eq(job.getId()), Mockito.eq(organization), Mockito.any());
+    }
+
+    @Test
     public void testExtraTicks() {
-        final TestActorRef<JobExecutorActor<UUID>> testActor = TestActorRef.create(system, makeExecutorActorProps(makeSuccessfulJob()));
-        final JobExecutorActor<UUID> scheduler = testActor.underlyingActor();
+        final TestActorRef<JobExecutorActor<Integer>> testActor = TestActorRef.create(system, makeExecutorActorProps());
+        final JobExecutorActor<Integer> scheduler = testActor.underlyingActor();
         Duration jTickInterval = Duration.ofNanos(JobExecutorActor.TICK_INTERVAL.toNanos());
         assertEquals(
-                scala.concurrent.duration.Duration.Zero(),
-                scheduler.timeUntilNextTick(t0.minus(Duration.ofDays(1))));
+                Optional.of(scala.concurrent.duration.Duration.Zero()),
+                scheduler.timeUntilExtraTick(t0.minus(Duration.ofDays(1))));
         assertEquals(
-                JobExecutorActor.TICK_INTERVAL.div(2),
-                scheduler.timeUntilNextTick(t0.plus(jTickInterval.dividedBy(2))));
+                Optional.of(JobExecutorActor.TICK_INTERVAL.div(2)),
+                scheduler.timeUntilExtraTick(t0.plus(jTickInterval.dividedBy(2))));
         assertEquals(
-                JobExecutorActor.TICK_INTERVAL,
-                scheduler.timeUntilNextTick(t0.plus(Duration.ofDays(1))));
+                Optional.empty(),
+                scheduler.timeUntilExtraTick(t0.plus(Duration.ofDays(1))));
     }
 
-    private static abstract class DummyJob implements Job<UUID> {
-        private final UUID _uuid = UUID.randomUUID();
-        private final Instant _runAt;
+    @Test
+    public void testEnsureJobStillExists() throws Exception {
+        final Job<Integer> fineJob = addJobToRepo(new DummyJob.Builder<Integer>()
+                .setId(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+                .setOneOffSchedule(t0)
+                .setResult(123)
+                .build());
+        final ActorRef fineScheduler = makeAndInitializeExecutorActor(fineJob);
 
-        DummyJob() {
-            this(t0);
-        }
-        DummyJob(final Instant runAt) {
-            _runAt = runAt;
-        }
+        final Job<Integer> danglingJob = new DummyJob.Builder<Integer>()
+                .setId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
+                .setOneOffSchedule(t0)
+                .setResult(123)
+                .build();
+        final ActorRef danglingScheduler = makeAndInitializeExecutorActor(danglingJob);
 
-        @Override
-        public UUID getId() {
-            return _uuid;
-        }
+        final TestKit tk = new TestKit(system);
+        tk.watch(fineScheduler);
+        tk.watch(danglingScheduler);
 
-        @Override
-        public Schedule getSchedule() {
-            return new OneOffSchedule.Builder()
-                    .setRunAtAndAfter(_runAt)
-                    .build();
-        }
-    }
+        reloadPubSub.mediator().tell(
+                new DistributedPubSubMediator.Publish(
+                        JobExecutorActor.RELOAD_TOPIC,
+                        JobExecutorActor.EnsureJobStillExists.INSTANCE),
+                null);
 
-    private static final class SuccessfulJob extends DummyJob {
-        SuccessfulJob(final Instant runAt) {super(runAt);}
-        @Override
-        public CompletionStage<UUID> execute(ActorRef scheduler, Instant scheduled) {
-            return CompletableFuture.completedFuture(getId());
-        }
-    }
-
-    private static final class FailingJob extends DummyJob {
-        private final Throwable _error;
-
-        FailingJob(final Throwable error) {
-            super();
-            _error = error;
-        }
-
-        @Override
-        public CompletionStage<UUID> execute(ActorRef scheduler, Instant scheduled) {
-            CompletableFuture<UUID> result = new CompletableFuture<>();
-            result.completeExceptionally(_error);
-            return result;
-        }
+        Thread.sleep(1000);
+        tk.expectMsg(new Terminated(danglingScheduler, true, true));
+        tk.expectNoMsg();
     }
 
 }

--- a/test/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
@@ -29,6 +29,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 /**
  * A simple in-memory {@link JobRepository}. Not in any way persistent, probably not good for production usage.
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
-public final class MapJobRepository<T> implements JobRepository<T> {
+public class MapJobRepository<T> implements JobRepository<T> {
 
     /**
      * Guice constructor.
@@ -78,6 +79,11 @@ public final class MapJobRepository<T> implements JobRepository<T> {
     public Optional<Instant> getLastRun(final UUID id, final Organization organization) throws NoSuchElementException {
         assertIsOpen();
         return Optional.ofNullable(_lastRuns.getOrDefault(organization, Maps.newHashMap()).get(id));
+    }
+
+    @Override
+    public Stream<Job<T>> getAllJobs(final Organization organization) {
+        return _jobs.get(organization).values().stream();
     }
 
     @Override

--- a/test/com/arpnetworking/metrics/portal/scheduling/mocks/DummyJob.java
+++ b/test/com/arpnetworking/metrics/portal/scheduling/mocks/DummyJob.java
@@ -1,0 +1,131 @@
+package com.arpnetworking.metrics.portal.scheduling.mocks;
+
+import akka.actor.ActorRef;
+import com.arpnetworking.commons.builder.OvalBuilder;
+import com.arpnetworking.metrics.portal.scheduling.Schedule;
+import com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import models.internal.scheduling.Job;
+import net.sf.oval.constraint.NotNull;
+import net.sf.oval.constraint.ValidateWithMethod;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class DummyJob<T> implements Job<T> {
+    private final UUID _uuid;
+    private final Schedule _schedule;
+    private final Optional<T> _result;
+    private final Optional<Throwable> _error;
+    private final CompletionStage<?> _blocker;
+
+    private DummyJob(final Builder<T> builder) {
+        _uuid = builder._uuid;
+        _schedule = builder._schedule;
+        _result = builder._result;
+        _error = builder._error;
+        _blocker = builder._blocker;
+    }
+
+    @Override
+    public UUID getId() {
+        return _uuid;
+    }
+
+    @Override
+    public String getETag() {
+        return _uuid.toString();
+    }
+
+    @Override
+    public Schedule getSchedule() {
+        return _schedule;
+    }
+
+    public Optional<T> getResult() {
+        return _result;
+    }
+
+    public Optional<Throwable> getError() {
+        return _error;
+    }
+
+    @Override
+    public CompletionStage<T> execute(ActorRef scheduler, Instant scheduled) {
+        return _blocker.thenCompose(whatever -> {
+            CompletableFuture<T> future = new CompletableFuture<>();
+            if (_result.isPresent()) {
+                future.complete(_result.get());
+            } else {
+                future.completeExceptionally(_error.get());
+            }
+            return future;
+        });
+    }
+
+
+    /**
+     * Implementation of builder pattern for {@link DummyJob}.
+     *
+     * @param <T> The type of result of the job run by the recipient actor.
+     *
+     * @author Spencer Pearson (spencerpearson at dropbox dot com)
+     */
+    public static final class Builder<T> extends OvalBuilder<DummyJob<T>> {
+        @NotNull
+        private UUID _uuid = UUID.randomUUID();
+        @NotNull
+        private Schedule _schedule;
+        @ValidateWithMethod(methodName = "validateResultXorError", parameterType = Object.class)
+        private Optional<T> _result = Optional.empty();
+        private Optional<Throwable> _error = Optional.empty();
+        private CompletionStage<?> _blocker = CompletableFuture.completedFuture(null);
+
+        /**
+         * Public constructor.
+         */
+        public Builder() {
+            super(DummyJob<T>::new);
+        }
+
+        public Builder<T> setId(final UUID uuid) {
+            _uuid = uuid;
+            return this;
+        }
+
+        public Builder<T> setSchedule(final Schedule schedule) {
+            _schedule = schedule;
+            return this;
+        }
+
+        public Builder<T> setOneOffSchedule(final Instant runAt) {
+            _schedule = new OneOffSchedule.Builder().setRunAtAndAfter(runAt).build();
+            return this;
+        }
+
+        public Builder<T> setResult(final T result) {
+            _result = Optional.of(result);
+            _error = Optional.empty();
+            return this;
+        }
+
+        public Builder<T> setError(final Throwable error) {
+            _result = Optional.empty();
+            _error = Optional.of(error);
+            return this;
+        }
+
+        public Builder<T> setBlocker(final CompletionStage<?> blocker) {
+            _blocker = blocker;
+            return this;
+        }
+
+        @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "invoked reflectively by @ValidateWithMethod")
+        private boolean validateResultXorError(final Object result) {
+            return _result.isPresent() ^ _error.isPresent();
+        }
+    }
+}


### PR DESCRIPTION
New functionality:
- Make executor subscribe to a distributed pub/sub mechanism that will allow anti-entropy to wipe out any dangling actors that reference nonexistent jobs
- Make executor hit the repository less (encapsulating that logic in the new `CachedJob` class)
- Make executor persistent, so it will be resurrected if it dies
- Add `Reload` message to executor, for anti-entropy
  - (related)Add `getETag()` method to `Job` interface
- [testing] Add `DummyJob` class for tests

Refactors:
- Major: undo a previous change: executor now has periodic ticks, rather than scheduling its next tick after completing each execution. This introduces some threading concerns, which is sad; but it's much simpler than ensuring that only one series of ticks is running at a time, while accounting for restarts.
- Minor: pass `PeriodicMetrics` into executor via props rather than digging it out of Guice