### PR TITLE
Added rollup metric name filtering, add default configuration and made rollups a feature.

### DIFF
--- a/app/com/arpnetworking/rollups/MetricsDiscovery.java
+++ b/app/com/arpnetworking/rollups/MetricsDiscovery.java
@@ -121,7 +121,6 @@ public final class MetricsDiscovery extends AbstractActorWithTimers {
     private Predicate<String> toPredicate(final List<String> regexList, final boolean defaultResult) {
         return regexList
                 .stream()
-                .map(r -> "^" + r + "$")
                 .map(Pattern::compile)
                 .map(Pattern::asPredicate)
                 .reduce(Predicate::or).orElse(t -> defaultResult);

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -350,15 +350,19 @@ public class MainModule extends AbstractModule {
 
     private static final class RollupMetricsDiscoveryProvider implements Provider<ActorRef> {
         @Inject
-        RollupMetricsDiscoveryProvider(final Injector injector, final ActorSystem system) {
+        RollupMetricsDiscoveryProvider(
+                final Injector injector,
+                final ActorSystem system,
+                final Features features) {
             _injector = injector;
             _system = system;
+            _enabled = features.isRollupsEnabled();
         }
 
         @Override
         public ActorRef get() {
             final Cluster cluster = Cluster.get(_system);
-            if (cluster.selfRoles().contains(ROLLUP_METRICS_DISCOVERY_ROLE)) {
+            if (_enabled && cluster.selfRoles().contains(ROLLUP_METRICS_DISCOVERY_ROLE)) {
                 return _system.actorOf(ClusterSingletonManager.props(
                         GuiceActorCreator.props(_injector, MetricsDiscovery.class),
                         PoisonPill.getInstance(),
@@ -371,6 +375,7 @@ public class MainModule extends AbstractModule {
 
         private final Injector _injector;
         private final ActorSystem _system;
+        private final boolean _enabled;
 
         private static final String ROLLUP_METRICS_DISCOVERY_ROLE = "rollup_metrics_discovery";
     }

--- a/app/models/internal/Features.java
+++ b/app/models/internal/Features.java
@@ -67,6 +67,13 @@ public interface Features {
     boolean isAlertsEnabled();
 
     /**
+     * Rollups feature.
+     *
+     * @return true if and only if rollups is enabled.
+     */
+    boolean isRollupsEnabled();
+
+    /**
      * Metrics aggregator daemon ports.
      *
      * @return list of ports for metrics aggregator daemon (or its proxies).

--- a/app/models/internal/impl/DefaultFeatures.java
+++ b/app/models/internal/impl/DefaultFeatures.java
@@ -59,6 +59,11 @@ public final class DefaultFeatures implements Features {
     }
 
     @Override
+    public boolean isRollupsEnabled() {
+        return _rollupsEnabled;
+    }
+
+    @Override
     public ImmutableList<Integer> getMetricsAggregatorDaemonPorts() {
         return _metricsAggregatorDaemonPorts;
     }
@@ -72,6 +77,7 @@ public final class DefaultFeatures implements Features {
                 .append(", hostRegistryEnabled=").append(_hostRegistryEnabled)
                 .append(", expressionsEnabled=").append(_expressionsEnabled)
                 .append(", alertsEnabled=").append(_alertsEnabled)
+                .append(", rollupsEnabled=").append(_rollupsEnabled)
                 .append(", metricsAggregatorDaemonPorts=").append(_metricsAggregatorDaemonPorts)
                 .append("}")
                 .toString();
@@ -89,6 +95,7 @@ public final class DefaultFeatures implements Features {
         _hostRegistryEnabled = configuration.getBoolean("portal.features.hostRegistry.enabled");
         _expressionsEnabled = configuration.getBoolean("portal.features.expressions.enabled");
         _alertsEnabled = configuration.getBoolean("portal.features.alerts.enabled");
+        _rollupsEnabled = configuration.getBoolean("portal.features.rollups.enabled");
         _metricsAggregatorDaemonPorts = ImmutableList.copyOf(
                 configuration.getIntList("portal.features.metricsAggregatorDaemonPorts"));
     }
@@ -99,5 +106,6 @@ public final class DefaultFeatures implements Features {
     private final boolean _hostRegistryEnabled;
     private final boolean _expressionsEnabled;
     private final boolean _alertsEnabled;
+    private final boolean _rollupsEnabled;
     private final ImmutableList<Integer> _metricsAggregatorDaemonPorts;
 }

--- a/conf/cluster.conf
+++ b/conf/cluster.conf
@@ -19,7 +19,7 @@ akka {
   cluster {
     seed-nodes = ["akka.tcp://mportal@127.0.0.1:2558"]
     auto-down-unreachable-after = 300s
-    roles = ["host_indexer"]
+    roles = ["host_indexer", "rollup_metrics_discovery"]
     sharding {
       guardian-name="sharding"
       role=""

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -70,6 +70,9 @@ portal.features {
   # Alerts
   alerts.enabled = true
 
+  # Rollups
+  rollups.enabled = false
+
   # Metrics aggregator ports
   metricsAggregatorDaemonPorts = [7090]
 }
@@ -229,6 +232,14 @@ reportRepository {
 expressionRepository {
   type = com.arpnetworking.metrics.portal.expressions.impl.NoExpressionRepository
   expressionQueryGenerator.type = "com.arpnetworking.metrics.portal.expressions.impl.DatabaseExpressionRepository$GenericQueryGenerator"
+}
+
+# Rollups
+# ~~~~~
+rollups {
+  fetch.interval = "1h"
+  metric.whitelist = [""]
+  metric.blacklist = [""]
 }
 
 # KairosDB proxying

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -238,8 +238,8 @@ expressionRepository {
 # ~~~~~
 rollups {
   fetch.interval = "1h"
-  metric.whitelist = [""]
-  metric.blacklist = [""]
+  metric.whitelist = []
+  metric.blacklist = []
 }
 
 # KairosDB proxying

--- a/test/com/arpnetworking/rollups/MetricsDiscoveryTest.java
+++ b/test/com/arpnetworking/rollups/MetricsDiscoveryTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import scala.concurrent.duration.Duration;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -62,6 +63,8 @@ public class MetricsDiscoveryTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         when(_config.getString(eq("rollup.fetch.interval"))).thenReturn("1h");
+        when(_config.getStringList(eq("rollup.metric.whitelist"))).thenReturn(Collections.emptyList());
+        when(_config.getStringList(eq("rollup.metric.blacklist"))).thenReturn(Collections.emptyList());
 
         _injector = Guice.createInjector(new AbstractModule() {
             @Override
@@ -103,6 +106,46 @@ public class MetricsDiscoveryTest {
 
     @Test
     public void testNoMoreMetrics() {
+        when(_config.getStringList(eq("rollup.metric.whitelist")))
+                .thenReturn(ImmutableList.of(
+                        "cmf/web_perf/.*",
+                        "cmf/test/.*"));
+        when(_config.getStringList(eq("rollup.metric.blacklist"))).thenReturn(ImmutableList.of("cmf/.*"));
+        when(_kairosDbClient.queryMetricNames())
+                .thenReturn(CompletableFuture
+                        .completedFuture(new KairosMetricNamesQueryResponse.Builder()
+                                .setResults(ImmutableList.of(
+                                        "metric1",
+                                        "cmf/web_perf/time_to_interactive",
+                                        "cmf/foo/bar",
+                                        "cmf/test/foobar"
+                                ))
+                                .build()));
+        new TestKit(_system) {{
+            final ActorRef actor = createActor();
+            final ActorRef testActor = getTestActor();
+            awaitAssert(() -> {
+                actor.tell(MetricFetch.getInstance(), testActor);
+                return expectMsg("metric1");
+            });
+
+            awaitAssert(() -> {
+                actor.tell(MetricFetch.getInstance(), testActor);
+                return expectMsg("cmf/web_perf/time_to_interactive");
+            });
+
+            awaitAssert(() -> {
+                actor.tell(MetricFetch.getInstance(), testActor);
+                return expectMsg("cmf/test/foobar");
+            });
+
+            actor.tell(MetricFetch.getInstance(), testActor);
+            expectMsgClass(NoMoreMetrics.class);
+        }};
+    }
+
+    @Test
+    public void testMetricsFiltering() {
         when(_kairosDbClient.queryMetricNames())
                 .thenReturn(CompletableFuture
                         .completedFuture(new KairosMetricNamesQueryResponse.Builder()

--- a/test/com/arpnetworking/rollups/MetricsDiscoveryTest.java
+++ b/test/com/arpnetworking/rollups/MetricsDiscoveryTest.java
@@ -108,9 +108,9 @@ public class MetricsDiscoveryTest {
     public void testNoMoreMetrics() {
         when(_config.getStringList(eq("rollup.metric.whitelist")))
                 .thenReturn(ImmutableList.of(
-                        "cmf/web_perf/.*",
-                        "cmf/test/.*"));
-        when(_config.getStringList(eq("rollup.metric.blacklist"))).thenReturn(ImmutableList.of("cmf/.*"));
+                        "^cmf/web_perf/.*$",
+                        "^cmf/test/.*$"));
+        when(_config.getStringList(eq("rollup.metric.blacklist"))).thenReturn(ImmutableList.of("^cmf/.*$"));
         when(_kairosDbClient.queryMetricNames())
                 .thenReturn(CompletableFuture
                         .completedFuture(new KairosMetricNamesQueryResponse.Builder()


### PR DESCRIPTION
I added regex based whitelist/blacklist support.  The behavior is that if a metric isn't in either list then it is accepted, if it's in the blacklist then it is filtered out unless it is also found in the whitelist.

I also add 'rollups' as a feature in the configuration and provided a default configuration.