### PR TITLE
Refine the ReportRepository API to allow for querying Reports

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/ReportQuery.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportQuery.java
@@ -14,47 +14,46 @@
  * limitations under the License.
  */
 
-package com.arpnetworking.metrics.portal.scheduling;
+package com.arpnetworking.metrics.portal.reports;
 
+import com.arpnetworking.metrics.portal.scheduling.JobQuery;
 import models.internal.Organization;
 import models.internal.QueryResult;
-import models.internal.scheduling.Job;
+import models.internal.reports.Report;
 
 import java.util.Optional;
 
 // CHECKSTYLE.OFF: JavadocTypeCheck - Checkstyle does not recognize implSpec.
 /**
- * A query against a {@link JobRepository}.
+ * A query against a {@link ReportRepository}.
  *
- * @implSpec This should be kept in sync with {@link JobQuery}.
- *
- * @param <T> The result type of the Jobs returned by this query.
  * @author Christian Briones (cbriones at dropbox dot com)
+ * @implSpec This should be kept in sync with {@link JobQuery}.
  */
-// CHECKSTYLE.ON: JavadocTypeCheck
-public interface JobQuery<T> {
+// CHECKSTYLE.ON: JavadocTypeCheck - Checkstyle does not recognize implSpec.
+public interface ReportQuery {
     /**
      * Execute the query and return the results.
      *
-     * @return The results of the query as a {@code QueryResult<Job<T>>} instance.
+     * @return The results of the query as a {@code QueryResult<Report>} instance.
      */
-    QueryResult<Job<T>> execute();
+    QueryResult<Report> execute();
 
     /**
-     * The maximum number of jobs to return.  Optional. Default is 1000.
+     * The maximum number of reports to return.  Optional. Default is 1000.
      *
-     * @param limit The maximum number of jobs to return.
-     * @return This instance of {@code JobQuery}
+     * @param limit The maximum number of reports to return.
+     * @return This instance of {@code ReportQuery}
      */
-    JobQuery<T> limit(int limit);
+    ReportQuery limit(int limit);
 
     /**
      * The offset into the result set. Optional. Default is not set.
      *
      * @param offset The offset into the result set.
-     * @return This instance of {@code JobQuery}
+     * @return This instance of {@code ReportQuery}
      */
-    JobQuery<T> offset(int offset);
+    ReportQuery offset(int offset);
 
     /**
      * Accessor for the organization.

--- a/app/com/arpnetworking/metrics/portal/reports/ReportQuery.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportQuery.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * @author Christian Briones (cbriones at dropbox dot com)
  * @implSpec This should be kept in sync with {@link JobQuery}.
  */
-// CHECKSTYLE.ON: JavadocTypeCheck - Checkstyle does not recognize implSpec.
+// CHECKSTYLE.ON: JavadocTypeCheck
 public interface ReportQuery {
     /**
      * Execute the query and return the results.

--- a/app/com/arpnetworking/metrics/portal/reports/ReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportRepository.java
@@ -16,9 +16,13 @@
 
 package com.arpnetworking.metrics.portal.reports;
 
+import com.arpnetworking.metrics.portal.scheduling.JobQuery;
 import com.arpnetworking.metrics.portal.scheduling.JobRepository;
 import models.internal.Organization;
+import models.internal.QueryResult;
+import models.internal.impl.DefaultQueryResult;
 import models.internal.reports.Report;
+import models.internal.scheduling.Job;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -45,5 +49,23 @@ public interface ReportRepository extends JobRepository<Report.Result> {
      * @param organization The {@code Organization} which owns the report.
      */
     void addOrUpdateReport(Report report, Organization organization);
+
+    /**
+     * Query reports.
+     *
+     * This is a specialization of {@link JobRepository#query} for cases where you want to
+     * handle the reports themselves, outside of a Job context.
+     *
+     * @param query The {@code JobQuery} instance to execute.
+     * @return The reports resulting from executing the query.
+     */
+    QueryResult<Report> queryReports(JobQuery<Report.Result> query);
+
+    @Override
+    default QueryResult<Job<Report.Result>> query(JobQuery<Report.Result> query) {
+        final QueryResult<Report> reports = queryReports(query);
+        // This re-wrap step is necessary to satisfy the compiler typecheck.
+        return new DefaultQueryResult<>(reports.values(), reports.values().size());
+    }
 }
 

--- a/app/com/arpnetworking/metrics/portal/reports/ReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportRepository.java
@@ -21,6 +21,7 @@ import com.arpnetworking.metrics.portal.scheduling.JobRepository;
 import models.internal.Organization;
 import models.internal.QueryResult;
 import models.internal.impl.DefaultQueryResult;
+import models.internal.impl.DefaultReportQuery;
 import models.internal.reports.Report;
 import models.internal.scheduling.Job;
 
@@ -59,13 +60,25 @@ public interface ReportRepository extends JobRepository<Report.Result> {
      * @param query The {@code JobQuery} instance to execute.
      * @return The reports resulting from executing the query.
      */
-    QueryResult<Report> queryReports(JobQuery<Report.Result> query);
+    QueryResult<Report> query(ReportQuery query);
 
-    @Override
-    default QueryResult<Job<Report.Result>> query(JobQuery<Report.Result> query) {
-        final QueryResult<Report> reports = queryReports(query);
-        // This re-wrap step is necessary to satisfy the compiler typecheck.
-        return new DefaultQueryResult<>(reports.values(), reports.values().size());
+    // CHECKSTYLE.OFF: JavadocMethodCheck - doc should be inherited from JobRepository
+    default QueryResult<Job<Report.Result>> query(final JobQuery<Report.Result> query) {
+        final ReportQuery reportQuery = new DefaultReportQuery(this, query);
+        final QueryResult<Report> reports = query(reportQuery);
+        return new DefaultQueryResult<>(reports.values(), reports.total());
+    }
+    // CHECKSTYLE.ON: JavadocMethodCheck
+
+    /**
+     * Create a report query against this repository.
+     *
+     * @param organization Organization to search in.
+     * @return An instance of {@code ReportQuery}.
+     */
+    default ReportQuery createReportQuery(final Organization organization) {
+        final JobQuery<Report.Result> jobQuery = createQuery(organization);
+        return new DefaultReportQuery(this, jobQuery);
     }
 }
 

--- a/app/com/arpnetworking/metrics/portal/reports/ReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportRepository.java
@@ -54,10 +54,10 @@ public interface ReportRepository extends JobRepository<Report.Result> {
     /**
      * Query reports.
      *
-     * This is a specialization of {@link JobRepository#query} for cases where you want to
+     * This can be considered a specialization of {@link JobRepository#query} for cases where you want to
      * handle the reports themselves, outside of a Job context.
      *
-     * @param query The {@code JobQuery} instance to execute.
+     * @param query The {@code ReportQuery} instance to execute.
      * @return The reports resulting from executing the query.
      */
     QueryResult<Report> query(ReportQuery query);

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -272,6 +272,7 @@ public final class DatabaseReportRepository implements ReportRepository {
                         .stream()
                         .map(models.ebean.Report::toInternal)
                         .collect(ImmutableList.toImmutableList());
+
         return new DefaultQueryResult<>(reports, reports.size());
     }
 

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.reports.impl;
 
+import com.arpnetworking.metrics.portal.reports.ReportQuery;
 import com.arpnetworking.metrics.portal.reports.ReportRepository;
 import com.arpnetworking.metrics.portal.scheduling.JobQuery;
 import com.arpnetworking.metrics.portal.scheduling.Schedule;
@@ -256,7 +257,7 @@ public final class DatabaseReportRepository implements ReportRepository {
     }
 
     @Override
-    public QueryResult<Report> queryReports(final JobQuery<Report.Result> query) {
+    public QueryResult<Report> query(final ReportQuery query) {
         assertIsOpen();
 
         LOGGER.debug()
@@ -463,10 +464,10 @@ public final class DatabaseReportRepository implements ReportRepository {
         /**
          * Translate the {@code JobQuery} to an ebean {@link Query}.
          *
-         * @param query The repository agnostic {@code JobQuery}.
+         * @param query The repository agnostic {@code ReportQuery}.
          * @return The database specific {@code PagedList} query result.
          */
-        PagedList<models.ebean.Report> createReportQuery(JobQuery<Report.Result> query);
+        PagedList<models.ebean.Report> createReportQuery(ReportQuery query);
     }
 
     /**
@@ -477,11 +478,10 @@ public final class DatabaseReportRepository implements ReportRepository {
         /**
          * Default constructor.
          */
-        public GenericQueryGenerator() {
-        }
+        public GenericQueryGenerator() {}
 
         @Override
-        public PagedList<models.ebean.Report> createReportQuery(final JobQuery<Report.Result> query) {
+        public PagedList<models.ebean.Report> createReportQuery(final ReportQuery query) {
             final int offset = query.getOffset().orElse(0);
             final int limit = query.getLimit();
 

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -256,7 +256,7 @@ public final class DatabaseReportRepository implements ReportRepository {
     }
 
     @Override
-    public QueryResult<Job<Report.Result>> query(final JobQuery<Report.Result> query) {
+    public QueryResult<Report> queryReports(final JobQuery<Report.Result> query) {
         assertIsOpen();
 
         LOGGER.debug()
@@ -271,7 +271,6 @@ public final class DatabaseReportRepository implements ReportRepository {
                         .stream()
                         .map(models.ebean.Report::toInternal)
                         .collect(ImmutableList.toImmutableList());
-
         return new DefaultQueryResult<>(reports, reports.size());
     }
 

--- a/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
@@ -141,7 +141,7 @@ public final class NoReportRepository implements ReportRepository {
     }
 
     @Override
-    public QueryResult<Job<Report.Result>> query(final JobQuery<Report.Result> query) {
+    public QueryResult<Report> queryReports(final JobQuery<Report.Result> query) {
         assertIsOpen();
         LOGGER.debug()
                 .setMessage("Executing query")

--- a/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
@@ -16,6 +16,7 @@
 
 package com.arpnetworking.metrics.portal.reports.impl;
 
+import com.arpnetworking.metrics.portal.reports.ReportQuery;
 import com.arpnetworking.metrics.portal.reports.ReportRepository;
 import com.arpnetworking.metrics.portal.scheduling.JobQuery;
 import com.arpnetworking.steno.Logger;
@@ -134,14 +135,14 @@ public final class NoReportRepository implements ReportRepository {
     public JobQuery<Report.Result> createQuery(final Organization organization) {
         assertIsOpen();
         LOGGER.debug()
-                .setMessage("Preparing query")
+                .setMessage("Preparing job query")
                 .addData("organization", organization)
                 .log();
         return new DefaultJobQuery<>(this, organization);
     }
 
     @Override
-    public QueryResult<Report> queryReports(final JobQuery<Report.Result> query) {
+    public QueryResult<Report> query(final ReportQuery query) {
         assertIsOpen();
         LOGGER.debug()
                 .setMessage("Executing query")

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
@@ -92,7 +92,7 @@ public interface JobRepository<T> {
     void jobFailed(UUID id, Organization organization, Instant scheduled, Throwable error);
 
     /**
-     * Create a query against this job repository.
+     * Create a job query against this repository.
      *
      * @param organization Organization to search in.
      * @return An instance of {@code JobQuery}.

--- a/app/models/internal/impl/DefaultJobQuery.java
+++ b/app/models/internal/impl/DefaultJobQuery.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 @Loggable
 public final class DefaultJobQuery<T> implements JobQuery<T> {
     private static final int DEFAULT_LIMIT = 1000;
+
     private final JobRepository<T> _repository;
     private final Organization _organization;
     private int _limit = DEFAULT_LIMIT;

--- a/app/models/internal/impl/DefaultJobQuery.java
+++ b/app/models/internal/impl/DefaultJobQuery.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  */
 @Loggable
 public final class DefaultJobQuery<T> implements JobQuery<T> {
-    private static final int DEFAULT_LIMIT = 100;
+    private static final int DEFAULT_LIMIT = 1000;
     private final JobRepository<T> _repository;
     private final Organization _organization;
     private int _limit = DEFAULT_LIMIT;

--- a/app/models/internal/impl/DefaultQueryResult.java
+++ b/app/models/internal/impl/DefaultQueryResult.java
@@ -34,8 +34,8 @@ public final class DefaultQueryResult<T> implements QueryResult<T> {
     /**
      * Public constructor.
      *
-     * @param values The <code>List</code> of <code>Host</code> instances.
-     * @param total The total number of matching <code>Host</code> instances.
+     * @param values The {@code List} of {@code T} instances.
+     * @param total The total number of matching results.
      */
     public DefaultQueryResult(final List<? extends T> values, final long total) {
         _values = values;
@@ -46,8 +46,8 @@ public final class DefaultQueryResult<T> implements QueryResult<T> {
     /**
      * Public constructor.
      *
-     * @param values The <code>List</code> of <code>Host</code> instances.
-     * @param total The total number of matching <code>Host</code> instances.
+     * @param values The {@code List} of {@code T} instances.
+     * @param total The total number of matching results.
      * @param etag The etag.
      */
     public DefaultQueryResult(final List<? extends T> values, final long total, final String etag) {

--- a/app/models/internal/impl/DefaultReportQuery.java
+++ b/app/models/internal/impl/DefaultReportQuery.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package models.internal.impl;
+
+import com.arpnetworking.logback.annotations.Loggable;
+import com.arpnetworking.metrics.portal.reports.ReportQuery;
+import com.arpnetworking.metrics.portal.reports.ReportRepository;
+import com.arpnetworking.metrics.portal.scheduling.JobQuery;
+import com.google.common.base.MoreObjects;
+import models.internal.Organization;
+import models.internal.QueryResult;
+import models.internal.reports.Report;
+
+import java.util.Optional;
+
+// CHECKSTYLE.OFF: JavadocTypeCheck - Checkstyle does not recognize implNote.
+/**
+ * Default internal model implementation for a report query.
+ *
+ * @implNote This should delegate all methods to an instance of {@link JobQuery} when
+ * possible. Ideally these types would be within the same class hierarchy but we would
+ * be unable to reconcile their return types otherwise.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+// CHECKSTYLE.ON: JavadocTypeCheck
+@Loggable
+public final class DefaultReportQuery implements ReportQuery {
+    private final ReportRepository _repository;
+    private final JobQuery<Report.Result> _jobQuery;
+
+    /**
+     * Public constructor.
+     *
+     * @param repository The {@code ReportRepository} to query against.
+     * @param jobQuery   The corresponding {@code JobQuery}.
+     */
+    public DefaultReportQuery(final ReportRepository repository, final JobQuery<Report.Result> jobQuery) {
+        _repository = repository;
+        _jobQuery = jobQuery;
+    }
+
+    @Override
+    public QueryResult<Report> execute() {
+        return _repository.query(this);
+    }
+
+    // Delegate all other methods to JobQuery
+
+    @Override
+    public ReportQuery limit(final int limit) {
+        _jobQuery.limit(limit);
+        return this;
+    }
+
+    @Override
+    public ReportQuery offset(final int offset) {
+        _jobQuery.offset(offset);
+        return this;
+    }
+
+    @Override
+    public Organization getOrganization() {
+        return _jobQuery.getOrganization();
+    }
+
+    @Override
+    public int getLimit() {
+        return _jobQuery.getLimit();
+    }
+
+    @Override
+    public Optional<Integer> getOffset() {
+        return _jobQuery.getOffset();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("id", Integer.toHexString(System.identityHashCode(this)))
+                .add("class", this.getClass())
+                .add("repository", _repository)
+                .add("jobQuery", _jobQuery)
+                .toString();
+    }
+}

--- a/app/models/internal/impl/DefaultReportQuery.java
+++ b/app/models/internal/impl/DefaultReportQuery.java
@@ -40,6 +40,17 @@ import java.util.Optional;
 @Loggable
 public final class DefaultReportQuery implements ReportQuery {
     private final ReportRepository _repository;
+
+    // This reference, while mutable, is safe to store since either:
+    //
+    //  A. The client code using the JobQuery, so this ReportQuery is only ever used as a wrapper
+    //     by the ReportRepository implementation and never mutated.
+    //
+    //  B. The client code is using this ReportQuery, in which case it never sees the embedded
+    //     JobQuery.
+    //
+    // In either case a client never has independent references to both. See ReportRepository for
+    // this query wrapping/unwrapping.
     private final JobQuery<Report.Result> _jobQuery;
 
     /**


### PR DESCRIPTION
The current API only allows for querying for the Reports as Jobs.

`ReportRepository#queryReports` can be used to retrieve the Report instances directly (e.g. for controller pagination). This doesn't require much of an implementation change since we can add a default for `ReportRepository#query` that just wraps `queryReport`.

Alternatively, I could have used wildcard types in JobRepository, but this ends up polluting client-side code and the query result types with wildcards themselves.