### PR TITLE
Fixed incorrect aggregator name and paramter for SaveAs aggregator.

### DIFF
--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -318,8 +318,8 @@ public class RollupGenerator extends AbstractActorWithTimers {
                         .setAlignEndTime(true)
                         .build(),
                 new Aggregator.Builder()
-                        .setName("saveAs")
-                        .setOtherArgs(ImmutableMap.of("save_as", rollupMetricName))
+                        .setName("save_as")
+                        .setOtherArgs(ImmutableMap.of("metric_name", rollupMetricName))
                         .build()
         ));
 

--- a/test/com/arpnetworking/rollups/RollupGeneratorTest.java
+++ b/test/com/arpnetworking/rollups/RollupGeneratorTest.java
@@ -376,8 +376,8 @@ public class RollupGeneratorTest {
         assertTrue(metric.getAggregators().get(0).getSampling().isPresent());
         assertEquals(1L, metric.getAggregators().get(0).getSampling().get().getValue());
         assertEquals(SamplingUnit.HOURS, metric.getAggregators().get(0).getSampling().get().getUnit());
-        assertEquals("saveAs", metric.getAggregators().get(1).getName());
-        assertEquals("metric_1h", metric.getAggregators().get(1).getOtherArgs().get("save_as"));
+        assertEquals("save_as", metric.getAggregators().get(1).getName());
+        assertEquals("metric_1h", metric.getAggregators().get(1).getOtherArgs().get("metric_name"));
         assertFalse(metric.getAggregators().get(1).getSampling().isPresent());
 
         _probe.expectNoMessage();


### PR DESCRIPTION
When working on the Kairos tools (https://github.com/ddimensia/kairos_tools) for copying metrics data I noticed that the SaveAs aggregator name and parameters were incorrect in the Metrics Portal RollupGenerator.  They should be name = 'save_as' and the parameter for the destination metric name should be 'metric_name'.