### PR TITLE
Improve Slick DB Config

### DIFF
--- a/conf/postgresql.application.conf
+++ b/conf/postgresql.application.conf
@@ -132,8 +132,8 @@ jdbc-read-journal {
 slick {
   profile = "slick.jdbc.PostgresProfile$"
   db {
-    host = "localhost"
-    url = "jdbc:postgresql://localhost:5432/metrics?reWriteBatchedInserts=true"
+    host = ${postgres.db}
+    url = "jdbc:postgresql://"${postgres.host}":"${postgres.port}"/"${postgres.db}"?reWriteBatchedInserts=true"
     user = "akka_app"
     password = "akka_app_password"
     driver = "org.postgresql.Driver"


### PR DESCRIPTION
Configure the Akka JDBC Slick configuration using the common `postgres.*` variables the same as the Play/Ebean DB server default configuration.