### PR TITLE
Report list view frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ eclipse-bin/
 
 # Akka test persistence data
 test-snapshots/
+
+# VSCode
+.vscode/
+.project

--- a/app/assets/javascripts/classes/KnockoutBindings.ts
+++ b/app/assets/javascripts/classes/KnockoutBindings.ts
@@ -9,6 +9,7 @@ import $ = require('jquery');
 import _ = require('underscore');
 import bootstrap = require('bootstrap');
 
+// @ts-ignore: import is valid
 import * as moment from 'moment-timezone/moment-timezone';
 
 // This const is necessary for typescript to see bootstrap as a 'used' import and not remove it as dead code

--- a/app/assets/javascripts/classes/KnockoutBindings.ts
+++ b/app/assets/javascripts/classes/KnockoutBindings.ts
@@ -57,8 +57,25 @@ module kobindings {
     ko.bindingHandlers['popover'] = {
         init: function(element, valueAccessor) {
             const value = valueAccessor();
-            const valueUnwrapped = ko.utils.unwrapObservable(value);
-            $(element).popover({content: valueUnwrapped});
+            const valueUnwrapped = ko.unwrap(value);
+
+            let options;
+            if (valueUnwrapped === Object(valueUnwrapped)) {
+                // It's an options map
+                if (valueUnwrapped.hasOwnProperty('content')) {
+                    options = {content: valueUnwrapped.content};
+                } else if (valueUnwrapped.hasOwnProperty('id')) {
+                    const id = ko.unwrap(valueUnwrapped.id);
+                    const selector = `.popover-content[data-id="${id}"]`;
+                    options = {
+                        content: $(selector).html(),
+                    }
+                }
+            } else {
+                // Bind the top level value as the content
+                options = {content: valueUnwrapped};
+            }
+            $(element).popover(options);
         }
     };
 

--- a/app/assets/javascripts/classes/KnockoutBindings.ts
+++ b/app/assets/javascripts/classes/KnockoutBindings.ts
@@ -166,7 +166,6 @@ module kobindings {
                     });
                 } else {
                     ta.on('blur', (event) => {
-                        console.log("blur time", event, ta.val(), valueUnwrapped.value());
                         if (ta.typeahead('val') != displayFn(valueUnwrapped.value())) {
                             valueUnwrapped.value(null);
                         }

--- a/app/assets/javascripts/classes/PaginatedSearchableList.ts
+++ b/app/assets/javascripts/classes/PaginatedSearchableList.ts
@@ -19,6 +19,17 @@ import ko = require('knockout');
 interface PagerElement { name: string; page: number; disabled: boolean; active: boolean}
 interface Pagination { total: number; offset: number}
 
+interface PagerOptions {
+    // The title to display above the pager.
+    title?: string;
+    // Whether or not to display the create entity button in the pager.
+    create?: boolean,
+    // The text to display on the create entity button.
+    createLabel?: string;
+    // The URI to link to from the create entity button.
+    createUri?: string;
+}
+
 abstract class PaginatedSearchableList<T> {
     filteredEntities: KnockoutObservableArray<T> = ko.observableArray<T>();
     searchExpression: KnockoutObservable<string> = ko.observable('');
@@ -30,9 +41,20 @@ abstract class PaginatedSearchableList<T> {
     private pagerElements: KnockoutComputed<PagerElement[]>;
     private perPage = 24;
 
-    constructor() {
+    entityName: string;
+    options: PagerOptions = {};
+
+    constructor(entityName, options: PagerOptions = {}) {
         var self = this;
         this.searchExpressionThrottled.subscribe(() => {this.page(1); this.query();});
+
+        this.entityName = entityName;
+        this.options = {
+            title: options.title || (entityName.charAt(0).toUpperCase() + entityName.slice(1) + 's'),
+            create: options.create === undefined ? true : options.create,
+            createLabel: options.createLabel || `Create new ${entityName}`,
+            createUri: options.createUri || `#${entityName}/edit`,
+        };
 
         this.pagerElements = ko.computed(() => {
             var p = this.page();

--- a/app/assets/javascripts/classes/alerts/AlertsViewModel.ts
+++ b/app/assets/javascripts/classes/alerts/AlertsViewModel.ts
@@ -20,6 +20,10 @@ import $ = require('jquery');
 import csrf from '../Csrf'
 
 class AlertsList extends PaginatedSearchableList<AlertData> {
+    constructor() {
+        super("alert");
+    }
+
     fetchData(query, callback) {
         $.getJSON("v1/alerts/query", query, (data) => {
             var alertsList: AlertData[] = data.data.map((v: AlertData)=> { return new AlertData(
@@ -55,7 +59,7 @@ class AlertsViewModel {
         };
     }
 
-    confirmDelete() {
+    confirmDelete = () => {
         $.ajax({
             type: "DELETE",
             url: "/v1/alerts/" + this.deletingId,

--- a/app/assets/javascripts/classes/hostregistry/HostRegistryViewModel.ts
+++ b/app/assets/javascripts/classes/hostregistry/HostRegistryViewModel.ts
@@ -26,7 +26,7 @@ class HostList extends PaginatedSearchableList<HostData> {
     versionFilter: KnockoutObservable <string> = ko.observable('');
 
     constructor() {
-        super();
+        super("host", {create: false});
         this.versionFilter.subscribe(() => {this.page(1); this.query()});
     };
 

--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -61,7 +61,6 @@ class EditReportViewModel {
 
     loadReport(id: String): void {
         $.getJSON("/v1/reports/" + id, null, (rawReport) => {
-            // FIXME(cbriones): Bind these to the view model.
             this.id(rawReport.id);
             this.name(rawReport.name);
             this.existingReport(true);
@@ -97,7 +96,6 @@ class EditReportViewModel {
     save(): void {
         const request = this.toRequest();
 
-        console.log(request);
         $.ajax({
             type: "PUT",
             url: "/v1/reports",
@@ -178,12 +176,8 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
 
 class EditSourceViewModel extends BaseSourceViewModel {
     toRequest() {
-        let requestType;
-        if (this.type() == SourceType.ChromeScreenshot) {
-            requestType = "ChromeScreenshot"
-        }
         return {
-            type: requestType,
+            type: SourceType[this.type()],
             id: this.id(),
             uri: this.url(),
             title: this.title(),

--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -26,6 +26,8 @@ import * as _ from 'underscore';
 import moment = require('moment-timezone/moment-timezone');
 
 class EditReportViewModel {
+    enabled = true;
+
     id = ko.observable<string>("");
     name = ko.observable<string>("");
     source = new EditSourceViewModel();
@@ -60,7 +62,16 @@ class EditReportViewModel {
             this.schedule.load(reportData.schedule);
             const recipients = reportData.recipients.map(Recipient.fromObject);
             this.recipients(recipients);
+        }).fail(() => {
+            this.alertMessage("Report not found");
+            this.enabled = false;
         });
+    }
+
+    compositionComplete() {
+        if (!this.enabled) {
+            $("#editReportForm :input").attr("disabled", "true");
+        }
     }
 
     addRecipient(recipientType: RecipientType): void {

--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -127,7 +127,7 @@ class EditReportViewModel {
     }
 
     readonly availableRecipientTypes = [
-        {value: RecipientType.Email,  text: "Email"},
+        {value: RecipientType.EMAIL,  text: "Email"},
     ];
 }
 
@@ -142,7 +142,7 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
 
     placeholder(): string {
         switch (this.type) {
-            case RecipientType.Email:
+            case RecipientType.EMAIL:
                 return 'example@domain.com'
         }
     }
@@ -151,7 +151,7 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
         const format: any = {
             type: ReportFormat[this.format()],
         };
-        if (this.format() == ReportFormat.Pdf) {
+        if (this.format() == ReportFormat.PDF) {
             format.widthInches = EditRecipientViewModel.DEFAULT_PDF_WIDTH_INCHES;
             format.heightInches = EditRecipientViewModel.DEFAULT_PDF_HEIGHT_INCHES;
         }
@@ -164,8 +164,8 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
     }
 
     readonly availableFormats = [
-        {value: ReportFormat.Pdf,  text: "PDF"},
-        {value: ReportFormat.Html,  text: "HTML"},
+        {value: ReportFormat.PDF,  text: "PDF"},
+        {value: ReportFormat.HTML,  text: "HTML"},
     ];
 
     readonly helpMessages = {
@@ -188,7 +188,7 @@ class EditSourceViewModel extends BaseSourceViewModel {
 
     // Used by KO data-bind.
     readonly availableSourceTypes = [
-        {value: SourceType.ChromeScreenshot,  text: "Browser rendered"},
+        {value: SourceType.CHROME_SCREENSHOT,  text: "Browser rendered"},
     ];
 
     readonly helpMessages = {
@@ -215,7 +215,7 @@ class EditScheduleViewModel extends BaseScheduleViewModel {
             queryTokenizer: tokenizer,
         });
         this.engine.initialize();
-        this.isPeriodic = ko.pureComputed(() => this.repeat() != ScheduleRepetition.OneOff);
+        this.isPeriodic = ko.pureComputed(() => this.repeat() != ScheduleRepetition.ONE_OFF);
     }
 
     getAutocompleteOpts(): any {
@@ -247,15 +247,15 @@ class EditScheduleViewModel extends BaseScheduleViewModel {
             zone,
         };
         const repeat = this.repeat();
-        if (repeat == ScheduleRepetition.OneOff) {
+        if (repeat == ScheduleRepetition.ONE_OFF) {
             return Object.assign(baseRequest, {
-                type: "OneOff",
+                type: "ONE_OFF",
             });
         } else {
             let offset = this.offset().toISOString();
             let period = ScheduleRepetition[repeat];
             return Object.assign(baseRequest, {
-                type: "Periodic",
+                type: "PERIODIC",
                 period,
                 offset,
             });
@@ -263,11 +263,11 @@ class EditScheduleViewModel extends BaseScheduleViewModel {
     }
 
     readonly availableRepeatTypes = [
-        {value: ScheduleRepetition.OneOff,  text: "Does not repeat"},
-        {value: ScheduleRepetition.Hourly,  text: "Hourly"},
-        {value: ScheduleRepetition.Daily,   text: "Daily"},
-        {value: ScheduleRepetition.Weekly,  text: "Weekly"},
-        {value: ScheduleRepetition.Monthly, text: "Monthly"},
+        {value: ScheduleRepetition.ONE_OFF, text: "Does not repeat"},
+        {value: ScheduleRepetition.HOURLY,  text: "Hourly"},
+        {value: ScheduleRepetition.DAILY,   text: "Daily"},
+        {value: ScheduleRepetition.WEEKLY,  text: "Weekly"},
+        {value: ScheduleRepetition.MONTHLY, text: "Monthly"},
     ];
 
     readonly helpMessages = {

--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -95,6 +95,9 @@ class EditReportViewModel {
     }
 
     save(): void {
+        const request = this.toRequest();
+
+        console.log(request);
         $.ajax({
             type: "PUT",
             url: "/v1/reports",
@@ -103,7 +106,7 @@ class EditReportViewModel {
             },
             contentType: "application/json",
             dataType: "json",
-            data: JSON.stringify(this.toRequest())
+            data: JSON.stringify(request),
         })
         .fail(() => {
             this.alertMessage(EditReportViewModel.ERROR_MESSAGE);
@@ -147,11 +150,9 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
             type: RecipientType[this.type],
             id: this.id(),
             address: this.address(),
-            formats: [
-                {
-                    type: ReportFormat[this.format()],
-                },
-            ],
+            format: {
+                type: ReportFormat[this.format()],
+            },
         }
     }
 
@@ -170,7 +171,7 @@ class EditSourceViewModel extends BaseSourceViewModel {
     toRequest() {
         let requestType;
         if (this.type() == SourceType.ChromeScreenshot) {
-            requestType = "CHROME_SCREENSHOT"
+            requestType = "ChromeScreenshot"
         }
         return {
             type: requestType,

--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -134,6 +134,10 @@ class EditReportViewModel {
 }
 
 class EditRecipientViewModel extends BaseRecipientViewModel {
+
+    static DEFAULT_PDF_WIDTH_INCHES = 8.5;
+    static DEFAULT_PDF_HEIGHT_INCHES = 11;
+
     label(): string {
         return RecipientType[this.type]
     }
@@ -146,13 +150,18 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
     }
 
     toRequest(): any {
+        const format: any = {
+            type: ReportFormat[this.format()],
+        };
+        if (this.format() == ReportFormat.Pdf) {
+            format.widthInches = EditRecipientViewModel.DEFAULT_PDF_WIDTH_INCHES;
+            format.heightInches = EditRecipientViewModel.DEFAULT_PDF_HEIGHT_INCHES;
+        }
         return {
             type: RecipientType[this.type],
             id: this.id(),
             address: this.address(),
-            format: {
-                type: ReportFormat[this.format()],
-            },
+            format: format,
         }
     }
 

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -1,0 +1,128 @@
+import ko = require('knockout');
+// @ts-ignore: import is valid
+import moment = require('moment-timezone/moment-timezone');
+
+export enum RecipientType {
+    Email,
+}
+
+export enum ReportFormat {
+    Pdf,
+    Html,
+}
+
+export enum SourceType {
+    ChromeScreenshot,
+}
+
+export enum ScheduleRepetition {
+    OneOff,
+    Hourly,
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+export class ZoneInfo {
+    value: string;
+    display: string;
+
+    constructor(value: string) {
+        this.value = value;
+        this.display = `${this.value} (${moment.tz(this.value).zoneAbbr()})`;
+    }
+
+    public abbr(): string {
+        return moment.tz(this.value).zoneAbbr();
+    }
+}
+
+export class Source {
+    id = ko.observable("");
+    type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
+    title = ko.observable<string>("");
+    url = ko.observable<string>("");
+    eventName = ko.observable<string>("");
+    ignoreCertificateErrors = ko.observable<boolean>(false);
+
+    public static fromObject(raw): Source {
+        const source = new Source();
+
+        source.id(raw.id);
+        source.url(raw.uri);
+        source.title(raw.title);
+        source.eventName(raw.triggeringEventName);
+        source.ignoreCertificateErrors(raw.ignoreCertificateErrors);
+        // FIXME(cbriones)
+        // type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
+        return source
+    }
+}
+
+export class Schedule {
+    repeat = ko.observable<ScheduleRepetition>(ScheduleRepetition.OneOff);
+    start = ko.observable<moment.Moment>();
+    end = ko.observable<moment.Moment | undefined>(undefined);
+    offset = ko.pureComputed<moment.Duration>(() => moment.duration(this.offsetString()));
+    zone = ko.observable<ZoneInfo>(new ZoneInfo(moment.tz.guess()));
+
+    offsetString = ko.observable<string>("");
+
+    public static fromObject(raw: any): Schedule {
+        const schedule = new Schedule();
+
+        let repeat = ScheduleRepetition.OneOff;
+        if (raw.type == "Periodic") {
+            switch (raw.period) {
+                case "Hourly":
+                    repeat = ScheduleRepetition.Hourly;
+                    break;
+                case "Daily":
+                    repeat = ScheduleRepetition.Daily;
+                    break;
+                case "Monthly":
+                    repeat = ScheduleRepetition.Monthly;
+                    break;
+            }
+        }
+        schedule.repeat(repeat);
+        schedule.offsetString(raw.offset);
+        schedule.zone(new ZoneInfo(raw.zone));
+        schedule.start(moment(raw.runAtAndAfter));
+        schedule.end(moment(raw.runUntil));
+        return schedule;
+    }
+}
+
+export class Recipient {
+    id: KnockoutObservable<string>;
+    type: RecipientType;
+    address: KnockoutObservable<string>;
+    format: KnockoutObservable<ReportFormat>;
+
+    constructor(id: string, type: RecipientType) {
+        this.id = ko.observable(id);
+        this.type = type;
+        this.address = ko.observable("");
+        this.format = ko.observable(ReportFormat.Pdf);
+    }
+
+    public static fromObject(raw): Recipient {
+        const type = RecipientType.Email;
+
+        const recipient = new Recipient(raw.id, type);
+        recipient.address(raw.address)
+
+        let format;
+        if (raw.format.type == "Html") {
+            format = ReportFormat.Html;
+        } else if (raw.format.type == "Pdf") {
+            format = ReportFormat.Pdf;
+        } else {
+            throw new Error(`Unknown format "${raw.format.type}"`);
+        }
+
+        recipient.format(format);
+        return recipient;
+    }
+}

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -84,7 +84,9 @@ export class BaseScheduleViewModel {
         this.offsetString(raw.offset);
         this.zone(new ZoneInfo(raw.zone));
         this.start(moment(raw.runAtAndAfter));
-        this.end(moment(raw.runUntil));
+        if (raw.runUntil) {
+            this.end(moment(raw.runUntil));
+        }
         return this;
     }
 }

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -39,7 +39,7 @@ export class ZoneInfo {
 }
 
 export class BaseSourceViewModel {
-    id = ko.observable("");
+    id = ko.observable(uuid.v4());
     type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
     title = ko.observable<string>("");
     url = ko.observable<string>("");

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -4,24 +4,24 @@ import ko = require('knockout');
 import moment = require('moment-timezone/moment-timezone');
 
 export enum RecipientType {
-    Email,
+    EMAIL,
 }
 
 export enum ReportFormat {
-    Pdf,
-    Html,
+    PDF,
+    HTML,
 }
 
 export enum SourceType {
-    ChromeScreenshot,
+    CHROME_SCREENSHOT,
 }
 
 export enum ScheduleRepetition {
-    OneOff,
-    Hourly,
-    Daily,
-    Weekly,
-    Monthly,
+    ONE_OFF,
+    HOURLY,
+    DAILY,
+    WEEKLY,
+    MONTHLY,
 }
 
 export class ZoneInfo {
@@ -40,7 +40,7 @@ export class ZoneInfo {
 
 export class BaseSourceViewModel {
     id = ko.observable(uuid.v4());
-    type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
+    type = ko.observable<SourceType>(SourceType.CHROME_SCREENSHOT);
     title = ko.observable<string>("");
     url = ko.observable<string>("");
     eventName = ko.observable<string>("");
@@ -63,7 +63,7 @@ export class BaseSourceViewModel {
 }
 
 export class BaseScheduleViewModel {
-    repeat = ko.observable<ScheduleRepetition>(ScheduleRepetition.OneOff);
+    repeat = ko.observable<ScheduleRepetition>(ScheduleRepetition.ONE_OFF);
     start = ko.observable<moment.Moment>();
     end = ko.observable<moment.Moment | undefined>(undefined);
     offset = ko.pureComputed<moment.Duration>(() => moment.duration(this.offsetString()));
@@ -72,20 +72,22 @@ export class BaseScheduleViewModel {
     offsetString = ko.observable<string>("");
 
     public load(raw: any): this {
-        if (raw.type == "OneOff") {
-            this.repeat(ScheduleRepetition.OneOff)
-        } else if (raw.type == "Periodic") {
+        this.start(moment(raw.runAtAndAfter));
+        if (raw.type == "ONE_OFF") {
+            this.repeat(ScheduleRepetition.ONE_OFF)
+        } else if (raw.type == "PERIODIC") {
             const repeat = raw.period && ScheduleRepetition[raw.period as string];
-            if (repeat === undefined || repeat == ScheduleRepetition.OneOff) {
+            if (repeat === undefined || repeat == ScheduleRepetition.ONE_OFF) {
                 throw new Error(`Invalid schedule period: ${raw.period}`);
             }
             this.repeat(repeat);
-        }
-        this.offsetString(raw.offset);
-        this.zone(new ZoneInfo(raw.zone));
-        this.start(moment(raw.runAtAndAfter));
-        if (raw.runUntil) {
-            this.end(moment(raw.runUntil));
+            this.zone(new ZoneInfo(raw.zone));
+            this.offsetString(raw.offset);
+            if (raw.runUntil) {
+                this.end(moment(raw.runUntil));
+            }
+        } else {
+            throw new Error(`Invalid schedule type: ${raw.type}`)
         }
         return this;
     }
@@ -99,9 +101,9 @@ export class BaseRecipientViewModel {
 
     constructor(type?: RecipientType) {
         this.id = ko.observable(uuid.v4());
-        this.type = type || RecipientType.Email;
+        this.type = type || RecipientType.EMAIL;
         this.address = ko.observable("");
-        this.format = ko.observable(ReportFormat.Pdf);
+        this.format = ko.observable(ReportFormat.PDF);
     }
 
     public load(raw): this {

--- a/app/assets/javascripts/classes/reports/Report.ts
+++ b/app/assets/javascripts/classes/reports/Report.ts
@@ -52,5 +52,3 @@ export default class Report {
         // this.source = source;
     }
 }
-
-export = Report;

--- a/app/assets/javascripts/classes/reports/Report.ts
+++ b/app/assets/javascripts/classes/reports/Report.ts
@@ -16,16 +16,17 @@
 import ko = require('knockout');
 
 import {
-    Recipient,
+    BaseRecipientViewModel,
+    BaseScheduleViewModel,
+    BaseSourceViewModel,
     ReportFormat,
-    Source,
-    Schedule,
     ScheduleRepetition,
 } from "./Models";
 
 export default class Report {
     id: string;
     name: string;
+
     schedule: ScheduleViewModel;
     source: SourceViewModel;
     recipients: RecipientViewModel[];
@@ -35,48 +36,48 @@ export default class Report {
     constructor(id: string, name: string, source: any, schedule: any, recipients: object[]) {
         this.id = id;
         this.name = name;
-        this.recipients = recipients.map((raw) => new RecipientViewModel(Recipient.fromObject(raw)));
-        this.schedule = new ScheduleViewModel(Schedule.fromObject(schedule));
-        this.source = new SourceViewModel(Source.fromObject(source));
+
+        this.recipients = recipients.map((raw) =>
+            new RecipientViewModel().load(raw)
+        );
+        this.schedule = new ScheduleViewModel().load(schedule);
+        this.source = new SourceViewModel().load(source);
 
         this.editUri = `#report/edit/${this.id}`;
     }
 }
 
-class RecipientViewModel {
-    model: Recipient;
+class RecipientViewModel extends BaseRecipientViewModel {
     badgeText: KnockoutComputed<string>;
 
-    constructor(model: Recipient) {
-        this.model = model;
+    constructor() {
+        super();
         this.badgeText = ko.computed(() =>
-            `${this.model.address()} (${ReportFormat[this.model.format()].toUpperCase()})`
+            `${this.address()} (${ReportFormat[this.format()].toUpperCase()})`
         );
     }
 }
 
-class SourceViewModel {
-    model: Source;
+class SourceViewModel extends BaseSourceViewModel {
     displayText: KnockoutComputed<string>;
 
-    constructor(model: Source) {
-        this.model = model;
+    constructor() {
+        super();
         this.displayText = ko.computed<string>(() => {
             const type = "Browser rendered";
-            return `${this.model.title()} (${type})`
+            return `${this.title()} (${type})`
         });
     }
 
 }
 
-class ScheduleViewModel {
-    model: Schedule;
+class ScheduleViewModel extends BaseScheduleViewModel {
     displayType: KnockoutComputed<string>;
 
-    constructor(model: Schedule) {
-        this.model = model;
+    constructor() {
+        super();
         this.displayType = ko.computed(() => {
-            switch (this.model.repeat()) {
+            switch (this.repeat()) {
                 case ScheduleRepetition.OneOff:
                     return "One-off";
                 case ScheduleRepetition.Daily:

--- a/app/assets/javascripts/classes/reports/Report.ts
+++ b/app/assets/javascripts/classes/reports/Report.ts
@@ -14,41 +14,197 @@
  * limitations under the License.
  */
 import ko = require('knockout');
-
-interface OneOffSchedule {
-    type: 'OneOff';
-    runAtAndAfter: string;
-    runUntil: string;
-    zone: string;
-}
-
-interface PeriodicSchedule {
-    type: 'Periodic';
-    period: string;
-    runAtAndAfter: string;
-    runUntil: string;
-    zone: string;
-    offset?: string;
-}
-
-type Schedule = OneOffSchedule | PeriodicSchedule;
+import uuid = require('../Uuid');
+import moment = require('moment-timezone/moment-timezone');
 
 export default class Report {
     id: string;
     name: string;
     editUri: string;
-    schedule: any;
 
-    // schedule: Schedule;
-    // source: ChromeScreenshotSource;
-    // recipients: [Recipient];
+    schedule: Schedule;
+    source: Source;
+    recipients: Recipient[];
 
     // recipients
-    constructor(id: string, name: string, schedule: any) {
+    constructor(id: string, name: string, source: any, schedule: any, recipients: object[]) {
         this.id = id;
         this.name = name;
         this.editUri = `#report/edit/${this.id}`;
-        this.schedule = schedule;
-        // this.source = source;
+
+        this.recipients = recipients.map(Recipient.fromObject);
+        this.schedule = Schedule.fromObject(schedule);
+        this.source = Source.fromObject(source);
+    }
+}
+
+enum RecipientType {
+    Email,
+}
+
+enum ReportFormat {
+    Pdf,
+    Html
+}
+
+class Recipient {
+    id: KnockoutObservable<string>;
+    type: RecipientType;
+    address: KnockoutObservable<string>;
+    format: KnockoutObservable<ReportFormat>;
+    badgeText: KnockoutComputed<string>;
+
+    constructor(type: RecipientType) {
+        this.id = ko.observable(uuid.v4());
+        this.type = type;
+        this.address = ko.observable("");
+        this.format = ko.observable(ReportFormat.Pdf);
+        this.badgeText = ko.computed(() =>
+            `${this.address()} (${ReportFormat[this.format()].toUpperCase()})`
+        );
+    }
+
+    public static fromObject(raw): Recipient {
+        const type = RecipientType.Email;
+
+        const recipient = new Recipient(type);
+        recipient.id(raw.id);
+        recipient.address(raw.address)
+
+        let format;
+        if (raw.format.type == "Html") {
+            format = ReportFormat.Html;
+        } else if (raw.format.type == "Pdf") {
+            format = ReportFormat.Pdf;
+        } else {
+            throw new Error(`Unknown format "${raw.format.type}"`);
+        }
+
+        recipient.format(format);
+        return recipient;
+    }
+}
+
+enum SourceType {
+    ChromeScreenshot,
+}
+
+class Source {
+    id = ko.observable(uuid.v4());
+    type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
+    title = ko.observable<string>("");
+    url = ko.observable<string>("");
+    eventName = ko.observable<string>("");
+    ignoreCertificateErrors = ko.observable<boolean>(false);
+    displayText = ko.computed<string>(() => {
+        const type = "Browser rendered";
+        return `${this.title()} (${type})`
+    });
+
+    public static fromObject(raw): Source {
+        const source = new Source();
+        source.id(raw.id);
+        source.url(raw.uri);
+        source.title(raw.title);
+        source.eventName(raw.triggeringEventName);
+        source.ignoreCertificateErrors(raw.ignoreCertificateErrors);
+        // FIXME(cbriones)
+        // source.type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
+        return source;
+    }
+}
+
+enum ScheduleRepetition {
+    OneOff,
+    Hourly,
+    Daily,
+    Weekly,
+    Monthly
+}
+
+class ZoneInfo {
+    value: string;
+    display: string;
+
+    constructor(value: string) {
+        this.value = value;
+        this.display = `${this.value} (${moment.tz(this.value).zoneAbbr()})`;
+    }
+
+    public abbr(): string {
+        return moment.tz(this.value).zoneAbbr();
+    }
+}
+
+class Schedule {
+    repeat = ko.observable<ScheduleRepetition>(ScheduleRepetition.OneOff);
+    start = ko.observable<moment.Moment>();
+    end = ko.observable<moment.Moment | undefined>(undefined);
+    offsetString = ko.observable<string>("");
+    offset = ko.pureComputed<moment.Duration>(() => moment.duration(this.offsetString()));
+    zone = ko.observable<ZoneInfo>(new ZoneInfo(moment.tz.guess()));
+
+    displayType = ko.computed(() => {
+        switch (this.repeat()) {
+            case ScheduleRepetition.OneOff:
+                return "One-off";
+            case ScheduleRepetition.Daily:
+                return "Daily";
+            case ScheduleRepetition.Hourly:
+                return "Hourly";
+            case ScheduleRepetition.Monthly:
+                return "Monthly";
+            case ScheduleRepetition.Weekly:
+                return "Weekly";
+        }
+    });
+
+    label = ko.computed(() => {
+        const label = [];
+        switch (this.repeat()) {
+            case ScheduleRepetition.OneOff:
+                return "asdf"
+                // return `Once at ${this.start().toDate()} (${this.zone().abbr()})`;
+            case ScheduleRepetition.Daily:
+            case ScheduleRepetition.Hourly:
+            case ScheduleRepetition.Monthly:
+            case ScheduleRepetition.Weekly:
+                const desc = ScheduleRepetition[this.repeat()].toLowerCase();
+                let start = this.start();
+                if (start !== undefined) {
+                    label.push(`Repeats ${desc} from ${start.toString()}`)
+                }
+                let end = this.end();
+                if (end !== undefined) {
+                    label.push(` to ${end.toString()}`)
+                }
+        }
+        return label.join("");
+    });
+
+    constructor() {}
+
+    public static fromObject(raw): Schedule {
+        let schedule = new Schedule();
+        let repeat = ScheduleRepetition.OneOff;
+        if (raw.type == "Periodic") {
+            switch (raw.period) {
+                case "Hourly":
+                    repeat = ScheduleRepetition.Hourly;
+                    break;
+                case "Daily":
+                    repeat = ScheduleRepetition.Daily;
+                    break;
+                case "Monthly":
+                    repeat = ScheduleRepetition.Monthly;
+                    break;
+            }
+        }
+        schedule.repeat(repeat);
+        schedule.offsetString(raw.offset);
+        schedule.zone(new ZoneInfo(raw.zone));
+        schedule.start(moment(raw.runAtAndAfter));
+        schedule.end(moment(raw.runUntil));
+        return schedule;
     }
 }

--- a/app/assets/javascripts/classes/reports/Report.ts
+++ b/app/assets/javascripts/classes/reports/Report.ts
@@ -14,197 +14,80 @@
  * limitations under the License.
  */
 import ko = require('knockout');
-import uuid = require('../Uuid');
-import moment = require('moment-timezone/moment-timezone');
+
+import {
+    Recipient,
+    ReportFormat,
+    Source,
+    Schedule,
+    ScheduleRepetition,
+} from "./Models";
 
 export default class Report {
     id: string;
     name: string;
+    schedule: ScheduleViewModel;
+    source: SourceViewModel;
+    recipients: RecipientViewModel[];
+
     editUri: string;
 
-    schedule: Schedule;
-    source: Source;
-    recipients: Recipient[];
-
-    // recipients
     constructor(id: string, name: string, source: any, schedule: any, recipients: object[]) {
         this.id = id;
         this.name = name;
-        this.editUri = `#report/edit/${this.id}`;
+        this.recipients = recipients.map((raw) => new RecipientViewModel(Recipient.fromObject(raw)));
+        this.schedule = new ScheduleViewModel(Schedule.fromObject(schedule));
+        this.source = new SourceViewModel(Source.fromObject(source));
 
-        this.recipients = recipients.map(Recipient.fromObject);
-        this.schedule = Schedule.fromObject(schedule);
-        this.source = Source.fromObject(source);
+        this.editUri = `#report/edit/${this.id}`;
     }
 }
 
-enum RecipientType {
-    Email,
-}
-
-enum ReportFormat {
-    Pdf,
-    Html
-}
-
-class Recipient {
-    id: KnockoutObservable<string>;
-    type: RecipientType;
-    address: KnockoutObservable<string>;
-    format: KnockoutObservable<ReportFormat>;
+class RecipientViewModel {
+    model: Recipient;
     badgeText: KnockoutComputed<string>;
 
-    constructor(type: RecipientType) {
-        this.id = ko.observable(uuid.v4());
-        this.type = type;
-        this.address = ko.observable("");
-        this.format = ko.observable(ReportFormat.Pdf);
+    constructor(model: Recipient) {
+        this.model = model;
         this.badgeText = ko.computed(() =>
-            `${this.address()} (${ReportFormat[this.format()].toUpperCase()})`
+            `${this.model.address()} (${ReportFormat[this.model.format()].toUpperCase()})`
         );
     }
-
-    public static fromObject(raw): Recipient {
-        const type = RecipientType.Email;
-
-        const recipient = new Recipient(type);
-        recipient.id(raw.id);
-        recipient.address(raw.address)
-
-        let format;
-        if (raw.format.type == "Html") {
-            format = ReportFormat.Html;
-        } else if (raw.format.type == "Pdf") {
-            format = ReportFormat.Pdf;
-        } else {
-            throw new Error(`Unknown format "${raw.format.type}"`);
-        }
-
-        recipient.format(format);
-        return recipient;
-    }
 }
 
-enum SourceType {
-    ChromeScreenshot,
-}
+class SourceViewModel {
+    model: Source;
+    displayText: KnockoutComputed<string>;
 
-class Source {
-    id = ko.observable(uuid.v4());
-    type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
-    title = ko.observable<string>("");
-    url = ko.observable<string>("");
-    eventName = ko.observable<string>("");
-    ignoreCertificateErrors = ko.observable<boolean>(false);
-    displayText = ko.computed<string>(() => {
-        const type = "Browser rendered";
-        return `${this.title()} (${type})`
-    });
-
-    public static fromObject(raw): Source {
-        const source = new Source();
-        source.id(raw.id);
-        source.url(raw.uri);
-        source.title(raw.title);
-        source.eventName(raw.triggeringEventName);
-        source.ignoreCertificateErrors(raw.ignoreCertificateErrors);
-        // FIXME(cbriones)
-        // source.type = ko.observable<SourceType>(SourceType.ChromeScreenshot);
-        return source;
-    }
-}
-
-enum ScheduleRepetition {
-    OneOff,
-    Hourly,
-    Daily,
-    Weekly,
-    Monthly
-}
-
-class ZoneInfo {
-    value: string;
-    display: string;
-
-    constructor(value: string) {
-        this.value = value;
-        this.display = `${this.value} (${moment.tz(this.value).zoneAbbr()})`;
+    constructor(model: Source) {
+        this.model = model;
+        this.displayText = ko.computed<string>(() => {
+            const type = "Browser rendered";
+            return `${this.model.title()} (${type})`
+        });
     }
 
-    public abbr(): string {
-        return moment.tz(this.value).zoneAbbr();
-    }
 }
 
-class Schedule {
-    repeat = ko.observable<ScheduleRepetition>(ScheduleRepetition.OneOff);
-    start = ko.observable<moment.Moment>();
-    end = ko.observable<moment.Moment | undefined>(undefined);
-    offsetString = ko.observable<string>("");
-    offset = ko.pureComputed<moment.Duration>(() => moment.duration(this.offsetString()));
-    zone = ko.observable<ZoneInfo>(new ZoneInfo(moment.tz.guess()));
+class ScheduleViewModel {
+    model: Schedule;
+    displayType: KnockoutComputed<string>;
 
-    displayType = ko.computed(() => {
-        switch (this.repeat()) {
-            case ScheduleRepetition.OneOff:
-                return "One-off";
-            case ScheduleRepetition.Daily:
-                return "Daily";
-            case ScheduleRepetition.Hourly:
-                return "Hourly";
-            case ScheduleRepetition.Monthly:
-                return "Monthly";
-            case ScheduleRepetition.Weekly:
-                return "Weekly";
-        }
-    });
-
-    label = ko.computed(() => {
-        const label = [];
-        switch (this.repeat()) {
-            case ScheduleRepetition.OneOff:
-                return "asdf"
-                // return `Once at ${this.start().toDate()} (${this.zone().abbr()})`;
-            case ScheduleRepetition.Daily:
-            case ScheduleRepetition.Hourly:
-            case ScheduleRepetition.Monthly:
-            case ScheduleRepetition.Weekly:
-                const desc = ScheduleRepetition[this.repeat()].toLowerCase();
-                let start = this.start();
-                if (start !== undefined) {
-                    label.push(`Repeats ${desc} from ${start.toString()}`)
-                }
-                let end = this.end();
-                if (end !== undefined) {
-                    label.push(` to ${end.toString()}`)
-                }
-        }
-        return label.join("");
-    });
-
-    constructor() {}
-
-    public static fromObject(raw): Schedule {
-        let schedule = new Schedule();
-        let repeat = ScheduleRepetition.OneOff;
-        if (raw.type == "Periodic") {
-            switch (raw.period) {
-                case "Hourly":
-                    repeat = ScheduleRepetition.Hourly;
-                    break;
-                case "Daily":
-                    repeat = ScheduleRepetition.Daily;
-                    break;
-                case "Monthly":
-                    repeat = ScheduleRepetition.Monthly;
-                    break;
+    constructor(model: Schedule) {
+        this.model = model;
+        this.displayType = ko.computed(() => {
+            switch (this.model.repeat()) {
+                case ScheduleRepetition.OneOff:
+                    return "One-off";
+                case ScheduleRepetition.Daily:
+                    return "Daily";
+                case ScheduleRepetition.Hourly:
+                    return "Hourly";
+                case ScheduleRepetition.Monthly:
+                    return "Monthly";
+                case ScheduleRepetition.Weekly:
+                    return "Weekly";
             }
-        }
-        schedule.repeat(repeat);
-        schedule.offsetString(raw.offset);
-        schedule.zone(new ZoneInfo(raw.zone));
-        schedule.start(moment(raw.runAtAndAfter));
-        schedule.end(moment(raw.runUntil));
-        return schedule;
+        });
     }
 }

--- a/app/assets/javascripts/classes/reports/Report.ts
+++ b/app/assets/javascripts/classes/reports/Report.ts
@@ -72,23 +72,31 @@ class SourceViewModel extends BaseSourceViewModel {
 }
 
 class ScheduleViewModel extends BaseScheduleViewModel {
-    displayType: KnockoutComputed<string>;
+    static readonly DatetimeFormat = "llll";
 
-    constructor() {
-        super();
-        this.displayType = ko.computed(() => {
-            switch (this.repeat()) {
-                case ScheduleRepetition.OneOff:
-                    return "One-off";
-                case ScheduleRepetition.Daily:
-                    return "Daily";
-                case ScheduleRepetition.Hourly:
-                    return "Hourly";
-                case ScheduleRepetition.Monthly:
-                    return "Monthly";
-                case ScheduleRepetition.Weekly:
-                    return "Weekly";
-            }
-        });
-    }
+    // Unlike EditScheduleViewModel, we use a more readable format for displaying datetimes, since
+    // this value does not need to be parsed (unlike in an editable form field).
+    startText: KnockoutComputed<string> =
+        ko.pureComputed(() => this.start().format(ScheduleViewModel.DatetimeFormat));
+    endText: KnockoutComputed<string> = ko.pureComputed(() => {
+        const end = this.end();
+        if (!end) {
+            return "–";
+        }
+        return end.format(ScheduleViewModel.DatetimeFormat);
+    });
+    displayType: KnockoutComputed<string> = ko.pureComputed(() => {
+        switch (this.repeat()) {
+            case ScheduleRepetition.ONE_OFF:
+                return "One-off";
+            case ScheduleRepetition.DAILY:
+                return "Daily";
+            case ScheduleRepetition.HOURLY:
+                return "Hourly";
+            case ScheduleRepetition.MONTHLY:
+                return "Monthly";
+            case ScheduleRepetition.WEEKLY:
+                return "Weekly";
+        }
+    });
 }

--- a/app/assets/javascripts/classes/reports/Report.ts
+++ b/app/assets/javascripts/classes/reports/Report.ts
@@ -13,14 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-class Report {
+import ko = require('knockout');
+
+interface OneOffSchedule {
+    type: 'OneOff';
+    runAtAndAfter: string;
+    runUntil: string;
+    zone: string;
+}
+
+interface PeriodicSchedule {
+    type: 'Periodic';
+    period: string;
+    runAtAndAfter: string;
+    runUntil: string;
+    zone: string;
+    offset?: string;
+}
+
+type Schedule = OneOffSchedule | PeriodicSchedule;
+
+export default class Report {
     id: string;
     name: string;
+    editUri: string;
+    schedule: any;
 
-    constructor(id: string, name: string) {
+    // schedule: Schedule;
+    // source: ChromeScreenshotSource;
+    // recipients: [Recipient];
+
+    // recipients
+    constructor(id: string, name: string, schedule: any) {
         this.id = id;
         this.name = name;
+        this.editUri = `#report/edit/${this.id}`;
+        this.schedule = schedule;
+        // this.source = source;
     }
 }
 
-export = Report
+export = Report;

--- a/app/assets/javascripts/classes/reports/ReportsViewModel.ts
+++ b/app/assets/javascripts/classes/reports/ReportsViewModel.ts
@@ -16,8 +16,13 @@
 
 import PaginatedSearchableList = require("../PaginatedSearchableList");
 import Report from "./Report";
+import csrf from '../Csrf'
 
 class ReportsList extends PaginatedSearchableList<Report> {
+    constructor() {
+        super("report");
+    }
+
     fetchData(query: any, callback) {
         $.getJSON("v1/reports/query", query, (page) => {
             const reportList: Report[] = page.data.map((rawReport)=> {

--- a/app/assets/javascripts/classes/reports/ReportsViewModel.ts
+++ b/app/assets/javascripts/classes/reports/ReportsViewModel.ts
@@ -15,12 +15,19 @@
  */
 
 import PaginatedSearchableList = require("../PaginatedSearchableList");
-import Report = require("./Report");
+import Report from "./Report";
 
 class ReportsList extends PaginatedSearchableList<Report> {
     fetchData(query: any, callback) {
-        $.getJSON("v1/reports/query", query, (reportData) => {
-            callback(reportData.data, reportData.pagination);
+        $.getJSON("v1/reports/query", query, (page) => {
+            const reportList: Report[] = page.data.map((rawReport)=> {
+                return new Report(
+                    rawReport.id,
+                    rawReport.name,
+                    rawReport.schedule,
+                )
+            });
+            callback(reportList, page.pagination);
         })
     }
 
@@ -35,4 +42,5 @@ class ReportsViewModel {
         this.reports.query();
     };
 }
+
 export = ReportsViewModel;

--- a/app/assets/javascripts/classes/reports/ReportsViewModel.ts
+++ b/app/assets/javascripts/classes/reports/ReportsViewModel.ts
@@ -20,8 +20,7 @@ import Report = require("./Report");
 class ReportsList extends PaginatedSearchableList<Report> {
     fetchData(query: any, callback) {
         $.getJSON("v1/reports/query", query, (reportData) => {
-            var hostList: Report[] = reportData.data.map((v: Report)=> { return null;});
-            callback(hostList, reportData.pagination);
+            callback(reportData.data, reportData.pagination);
         })
     }
 

--- a/app/assets/javascripts/classes/reports/ReportsViewModel.ts
+++ b/app/assets/javascripts/classes/reports/ReportsViewModel.ts
@@ -24,7 +24,9 @@ class ReportsList extends PaginatedSearchableList<Report> {
                 return new Report(
                     rawReport.id,
                     rawReport.name,
+                    rawReport.source,
                     rawReport.schedule,
+                    rawReport.recipients,
                 )
             });
             callback(reportList, page.pagination);

--- a/public/html/alerts/AlertsViewModel.html
+++ b/public/html/alerts/AlertsViewModel.html
@@ -16,46 +16,41 @@
 
 <div class="container-fluid">
     <div class="row-fluid">
-        <div class="col-md-12">
-            <h2>Alerts</h2>
-        </div>
-    </div>
-    <div class="row-fluid">
-        <div class="col-md-12">
-            <div><a href="#alert/edit" class="btn btn-default" style="margin-bottom: .5em">Create New Alert</a></div>
-            <div data-bind="compose: { model: alerts, view: '/assets/html/components/Pager.html', mode: 'templated' }">
-                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6">
-                    <div class="left">
-                        <i class="fa" data-bind="css: contextStyle"></i>
-                        <i><span data-bind="text: service"></span></i>/<b><span data-bind="text: metric"></span></b>/<span data-bind="text: statistic"></span>
-                    </div>
-                    <div class="right">
-                        <a data-bind="attr: { href: editUri }">
-                            <i class="fa fa-pencil-square-o"></i>
-                        </a>
-                        <a data-bind="click: $root.remove" href="#">
-                            <i class="fa fa-times"></i>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+        <div class="container col-md-offset-3 col-md-6">
+            <div data-bind="compose: {model: alerts, view: '/assets/html/components/Pager.html', mode: 'templated'}">
+                <!-- XXX:
+                 <tr> elements **MUST** be contained within <table> and <tbody> elements. Since Durandal creates DOMElements
+                 before binding them in the template, they must be valid elements at creation, not just when rendered.
 
-<div id="confirm-delete-modal" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title">Are you sure?</h4>
-            </div>
-            <div class="modal-body">
-                <div>Are you sure you want to delete the alert?</div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-primary" data-bind="click: confirmDelete">Confirm</button>
+                 As a hack we use an if binding that is never visible so that these <tr>'s can be specified without being
+                 mangled by the browser.
+                 -->
+                <!-- ko if: false -->
+                <table>
+                    <tbody>
+                    <!-- /ko -->
+                    <tr data-part="entityLabels">
+                        <th class="col-md-8"></th>
+                        <th class="col-md-4"></th>
+                    </tr>
+                    <tr data-part="entityRow">
+                        <td class="text-right col-md-8">
+                            <i class="fa" data-bind="css: contextStyle"></i>
+                            <i><span data-bind="text: service"></span></i>/<b><span data-bind="text: metric"></span></b>/<span data-bind="text: statistic"></span>
+                        </td>
+                        <td class="text-left col-md-4">
+                            <a data-bind="attr: { href: editUri }">
+                                <i class="fa fa-pencil-square-o"></i>
+                            </a>
+                            <a data-bind="click: $root.remove" href="#">
+                                <i class="fa fa-times"></i>
+                            </a>
+                        </td>
+                    </tr>
+                    <!-- ko if: false -->
+                    </tbody>
+                </table>
+                <!-- /ko -->
             </div>
         </div>
     </div>

--- a/public/html/components/Pager.html
+++ b/public/html/components/Pager.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017 Smartsheet.com
+  ~ Copyright 2019 Dropbox, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -13,23 +13,53 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<div class="col-md-12 col-sm-12 col-lg-12 search-header">
-    <form role="form" class="form-inline">
-        <div class="form-group has-feedback">
-            <input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
-            <span class="glyphicon glyphicon-search form-control-feedback"></span>
+<div class="container-fluid">
+    <div class="row">
+        <h2 data-bind="text: options.title"></h2>
+        <div class ="row">
+            <div class="col-md-1" data-bind="if: options.create">
+                <a data-bind="attr: {href: options.createUri}, text: options.createLabel" class="btn btn-default" style="margin-bottom: .5em"></a>
+            </div>
+            <div class="col-md-offset-7 col-md-4">
+                <form role="form" class="form-inline">
+                    <div class="form-group has-feedback pull-right">
+                        <input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
+                        <span class="glyphicon glyphicon-search form-control-feedback"></span>
+                    </div>
+                </form>
+            </div>
         </div>
-    </form>
-</div>
-<div style="font-size: large; overflow-style: scrollbar; overflow-y: auto; margin-bottom: 6em" class="col-md-12 col-sm-12 col-lg-12">
-    <div data-bind="foreach: filteredEntities" class="row">
-        <div data-part="content"></div>
+        <table class="table table-hover">
+            <thead>
+                <tr data-part="entityLabels" class="row"></tr>
+            </thead>
+            <tbody data-bind="foreach: filteredEntities">
+                <tr data-part="entityRow"></tr>
+            </tbody>
+        </table>
+        <nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
+            <div class="text-center">
+                <ul class="pagination" data-bind="foreach: pagerElements">
+                    <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
+                </ul>
+            </div>
+        </nav>
+    </div>
+    <div id="confirm-delete-modal" class="modal fade" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">Are you sure?</h4>
+                </div>
+                <div class="modal-body">
+                    <div>Are you sure you want to delete the <span data-bind="text: entityName"></span>?</div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" data-bind="click: $parent.confirmDelete">Confirm</button>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
-<nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
-    <div class="text-center">
-        <ul class="pagination" data-bind="foreach: pagerElements">
-            <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
-        </ul>
-    </div>
-</nav>

--- a/public/html/hostregistry/HostRegistryViewModel.html
+++ b/public/html/hostregistry/HostRegistryViewModel.html
@@ -1,14 +1,33 @@
 <div class="container-fluid">
     <div class="row-fluid">
-        <div class="col-md-12">
-            <h2>Host Registry</h2>
-            <div data-bind="compose: { model: hosts, view: '/assets/html/components/Pager.html', mode: 'templated' }">
-                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap" class="col-md-4 col-lg-3 col-sm-6">
-                    <button class="btn btn-default btn-xs" data-bind="enable: connectable, click: $parent.click">
-                        <i class="glyphicon" data-bind="css: connectionStyle"></i>
-                    </button>
-                    <span data-bind="text: hostname, tooltip:{ title: hostname, tooltipClass: 'host-tip'}, attr: {title: hostname}"></span>
-                </div>
+        <div class="col-md-offset-3 col-md-6">
+            <div data-bind="compose: {model: hosts, view: '/assets/html/components/Pager.html', mode: 'templated'}">
+                <!-- XXX:
+                 <tr> elements **MUST** be contained within <table> and <tbody> elements. Since Durandal creates DOMElements
+                 before binding them in the template, they must be valid elements at creation, not just when rendered.
+
+                 As a hack we use an if binding that is never visible so that these <tr>'s can be specified without being
+                 mangled by the browser.
+                 -->
+                <!-- ko if: false -->
+                <table>
+                    <tbody>
+                    <!-- /ko -->
+                    <tr data-part="entityLabels">
+                        <th></th>
+                    </tr>
+                    <tr data-part="entityRow">
+                        <td class="text-center">
+                            <button class="btn btn-default btn-xs" data-bind="enable: connectable, click: $parent.click">
+                                <i class="glyphicon" data-bind="css: connectionStyle"></i>
+                            </button>
+                            <span data-bind="text: hostname, tooltip: { title: hostname, tooltipClass: 'host-tip'}, attr: {title: hostname}"></span>
+                        </td>
+                    </tr>
+                    <!-- ko if: false -->
+                    </tbody>
+                </table>
+                <!-- /ko -->
             </div>
         </div>
     </div>

--- a/public/html/reports/EditReportViewModel.html
+++ b/public/html/reports/EditReportViewModel.html
@@ -14,101 +14,99 @@
   ~ limitations under the License.
   -->
 
-<div class="container-fluid">
+<div class="container">
     <div class="row-fluid">
-        <div class="col-md-12">
+        <div class="col-md-offset-3 col-md-12">
             <h2 data-bind="if: existingReport">Edit Report</h2>
             <h2 data-bind="ifnot: existingReport">Create Report</h2>
-            <div class="col-md-12 col-sm-12 col-lg-12">
-                <form role="form" class="container-fluid col-md-8 col-sm-12 col-lg-6">
-                    <div id="editReportAlert" class="alert alert-danger"
-                         data-bind="attr: {'hidden': alertHidden},
-                                    text: alertMessage"
-                         role="alert"></div>
-                    <div class="form-group">
-                        <label for="nameInput">Name</label>
-                        <input class="form-control" data-bind="value: name" type="text" id="nameInput" placeholder="Name">
-                    </div>
+            <form role="form" class="container-fluid col-md-8 col-sm-12 col-lg-6">
+                <div id="editReportAlert" class="alert alert-danger"
+                     data-bind="attr: {'hidden': alertHidden},
+                                text: alertMessage"
+                     role="alert"></div>
+                <div class="form-group">
+                    <label for="nameInput">Name</label>
+                    <input class="form-control" data-bind="value: name" type="text" id="nameInput" placeholder="Name">
+                </div>
 
-                    <!-- Report Source -->
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <h3 class="panel-title">Source</h3>
-                        </div>
-                        <div class="panel-body">
-                            <div data-bind="compose: {model: source, view: '/assets/html/reports/EditSourceViewModel.html'}"></div>
-                        </div>
+                <!-- Report Source -->
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Source</h3>
                     </div>
-
-                    <!-- Report Schedule -->
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <h3 class="panel-title">Schedule</h3>
-                        </div>
-                        <div class="panel-body">
-                            <div data-bind="compose: {model: schedule, view: '/assets/html/reports/EditScheduleViewModel.html'}"></div>
-                        </div>
+                    <div class="panel-body">
+                        <div data-bind="compose: {model: source, view: '/assets/html/reports/EditSourceViewModel.html'}"></div>
                     </div>
+                </div>
 
-                    <!-- Report Recipients -->
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <h3 class="panel-title">Recipients</h3>
-                        </div>
-                        <div class="panel-body">
-                            <div data-bind="foreach: recipients">
-                                <div>
-                                    <button type="button" class="close right" aria-label="Close"
-                                            data-bind="click: function() { $parent.removeRecipient($index); }">
-                                        <span class="glyphicon glyphicon-remove text-danger"></span>
-                                    </button>
-                                    <div class="form-group">
-                                        <label for="recipient" data-bind="text: label()"></label>
-                                        <input id="recipient"
-                                               class="form-control"
-                                               type="text"
-                                               data-bind="value: address, attr: {placeholder: placeholder()}">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="recipientFormat">Report Format</label>
-                                        <span class="glyphicon glyphicon-question-sign"
-                                              data-bind="popover: helpMessages['format']"
-                                              data-trigger="hover"></span>
-                                        <select id="recipientFormat"
-                                               class="form-control"
-                                               data-bind="options: availableFormats,
-                                                          optionsText: 'text',
-                                                          optionsValue: 'value',
-                                                          value: format">
-                                        </select>
-                                    </div>
-                                </div>
-                                <hr>
-                            </div>
-                            <div class="dropdown">
-                                <button class="btn btn-default dropdown-toggle"
-                                        type="button"
-                                        id="addRecipientDropdown"
-                                        data-toggle="dropdown"
-                                        aria-haspopup="true" aria-expanded="false">
-                                    Add Recipient
-                                    <span class="caret"></span>
+                <!-- Report Schedule -->
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Schedule</h3>
+                    </div>
+                    <div class="panel-body">
+                        <div data-bind="compose: {model: schedule, view: '/assets/html/reports/EditScheduleViewModel.html'}"></div>
+                    </div>
+                </div>
+
+                <!-- Report Recipients -->
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Recipients</h3>
+                    </div>
+                    <div class="panel-body">
+                        <div data-bind="foreach: recipients">
+                            <div>
+                                <button type="button" class="close right" aria-label="Close"
+                                        data-bind="click: function() { $parent.removeRecipient($index); }">
+                                    <span class="glyphicon glyphicon-remove text-danger"></span>
                                 </button>
-                                <ul class="dropdown-menu" aria-labelledby="addRecipientDropdown"
-                                    data-bind="foreach: availableRecipientTypes">
-                                    <li>
-                                        <a data-bind="click: function() { $parent.addRecipient(value); },
-                                                      text: text"></a>
-                                    </li>
-                                </ul>
+                                <div class="form-group">
+                                    <label for="recipient" data-bind="text: label()"></label>
+                                    <input id="recipient"
+                                           class="form-control"
+                                           type="text"
+                                           data-bind="value: address, attr: {placeholder: placeholder()}">
+                                </div>
+                                <div class="form-group">
+                                    <label for="recipientFormat">Report Format</label>
+                                    <span class="glyphicon glyphicon-question-sign"
+                                          data-bind="popover: helpMessages['format']"
+                                          data-trigger="hover"></span>
+                                    <select id="recipientFormat"
+                                           class="form-control"
+                                           data-bind="options: availableFormats,
+                                                      optionsText: 'text',
+                                                      optionsValue: 'value',
+                                                      value: format">
+                                    </select>
+                                </div>
                             </div>
+                            <hr>
+                        </div>
+                        <div class="dropdown">
+                            <button class="btn btn-default dropdown-toggle"
+                                    type="button"
+                                    id="addRecipientDropdown"
+                                    data-toggle="dropdown"
+                                    aria-haspopup="true" aria-expanded="false">
+                                Add Recipient
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu" aria-labelledby="addRecipientDropdown"
+                                data-bind="foreach: availableRecipientTypes">
+                                <li>
+                                    <a data-bind="click: function() { $parent.addRecipient(value); },
+                                                  text: text"></a>
+                                </li>
+                            </ul>
                         </div>
                     </div>
+                </div>
 
-                    <button type="submit" class="btn btn-primary" data-bind="click: save">Save</button>
-                    <button type="submit" class="btn btn-danger" data-bind="click: cancel">Cancel</button>
-                </form>
-            </div>
+                <button type="submit" class="btn btn-primary" data-bind="click: save">Save</button>
+                <button type="submit" class="btn btn-danger" data-bind="click: cancel">Cancel</button>
+            </form>
         </div>
     </div>
 </div>

--- a/public/html/reports/EditReportViewModel.html
+++ b/public/html/reports/EditReportViewModel.html
@@ -19,7 +19,7 @@
         <div class="col-md-offset-3 col-md-12">
             <h2 data-bind="if: existingReport">Edit Report</h2>
             <h2 data-bind="ifnot: existingReport">Create Report</h2>
-            <form role="form" class="container-fluid col-md-8 col-sm-12 col-lg-6">
+            <form id="editReportForm" role="form" class="container-fluid col-md-8 col-sm-12 col-lg-6">
                 <div id="editReportAlert" class="alert alert-danger"
                      data-bind="attr: {'hidden': alertHidden},
                                 text: alertMessage"

--- a/public/html/reports/EditReportViewModel.html
+++ b/public/html/reports/EditReportViewModel.html
@@ -18,7 +18,7 @@
     <div class="row-fluid">
         <div class="col-md-12">
             <h2 data-bind="if: existingReport">Edit Report</h2>
-            <h2 data-bind="if-not: existingReport">Create Report</h2>
+            <h2 data-bind="ifnot: existingReport">Create Report</h2>
             <div class="col-md-12 col-sm-12 col-lg-12">
                 <form role="form" class="container-fluid col-md-8 col-sm-12 col-lg-6">
                     <div id="editReportAlert" class="alert alert-danger"

--- a/public/html/reports/EditScheduleViewModel.html
+++ b/public/html/reports/EditScheduleViewModel.html
@@ -28,14 +28,6 @@
            data-bind="datetimepicker: start">
 </div>
 <div class="form-group">
-    <label for="scheduleEndDate">End Time (Optional)</label>
-    <input class="form-control"
-           type="text"
-           id="scheduleEndDate"
-           placeholder="None"
-           data-bind="datetimepicker: end">
-</div>
-<div class="form-group">
     <label for="scheduleType">Repeat</label>
     <select id="scheduleType"
             class="form-control"
@@ -45,7 +37,15 @@
                        value: repeat"></select>
 </div>
 <div class="form-group" data-bind="if: isPeriodic">
-    <label for="scheduleOffset">Repeat offset</label>
+    <label for="scheduleEndDate">End Time (Optional)</label>
+    <input class="form-control"
+           type="text"
+           id="scheduleEndDate"
+           placeholder="None"
+           data-bind="datetimepicker: end">
+</div>
+<div class="form-group" data-bind="if: isPeriodic">
+    <label for="scheduleOffset">Repeat offset (Optional)</label>
     <span class="glyphicon glyphicon-question-sign"
           data-bind="popover: helpMessages['offset']"
           data-trigger="hover"></span>

--- a/public/html/reports/EditScheduleViewModel.html
+++ b/public/html/reports/EditScheduleViewModel.html
@@ -21,14 +21,14 @@
            data-bind="typeahead: {options: getAutocompleteOpts(), value: zone}"/>
 </div>
 <div class="form-group">
-    <label for="scheduleStartDate">Start Date and Time</label>
+    <label for="scheduleStartDate">Start Time</label>
     <input class="form-control"
            type="text"
            id="scheduleStartDate"
            data-bind="datetimepicker: start">
 </div>
 <div class="form-group">
-    <label for="scheduleEndDate">End Date (Optional)</label>
+    <label for="scheduleEndDate">End Time (Optional)</label>
     <input class="form-control"
            type="text"
            id="scheduleEndDate"

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -25,6 +25,18 @@
             <div><a href="#report/edit" class="btn btn-default" style="margin-bottom: .5em">New Report</a></div>
             <div data-bind="compose: { model: reports, view: '/assets/html/components/Pager.html', mode: 'templated' }">
                 <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6">
+                    <div class="left">
+                        <span data-bind="text: id"></span>
+                        <span data-bind="text: name"></span>
+                    </div>
+                    <div class="right">
+                        <a data-bind="attr: { href: editUri }">
+                            <i class="fa fa-pencil-square-o"></i>
+                        </a>
+                        <!--<a data-bind="click: $root.remove" href="#">-->
+                            <!--<i class="fa fa-times"></i>-->
+                        <!--</a>-->
+                    </div>
                 </div>
             </div>
         </div>

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -35,8 +35,8 @@
                     <th class="col-md-1">Name</td>
                     <th class="col-md-1">Source</td>
                     <th class="col-md-1">Schedule Type</td>
-                    <th class="col-md-2">From</td>
-                    <th class="col-md-2">Until</td>
+                    <th class="col-md-2">Start Time</td>
+                    <th class="col-md-2">End Time</td>
                     <th class="col-md-2">Recipients</td>
                     <th></th>
                 </tr>
@@ -66,7 +66,8 @@
                         <span data-bind="text: schedule.start"></span>
                     </td>
                     <td>
-                        <span data-bind="text: schedule.end"></span>
+                        <span data-bind="if schedule; text: schedule.end"></span>
+                        <span data-bind="if-not schedule">–</span>
                     </td>
                     <td data-bind="foreach: recipients">
                         <span class="badge" data-bind="text: badgeText"></span>

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -15,30 +15,69 @@
   -->
 
 <div class="container-fluid">
-    <div class="row-fluid">
-        <div class="col-md-12">
+    <div class="row">
+        <div class="container col-md-offset-1 col-md-10">
             <h2>Reports</h2>
-        </div>
-    </div>
-    <div class="row-fluid">
-        <div class="col-md-12">
+            <!--Header for search-->
+            <!--<div class="col-md-12 col-sm-12 col-lg-12 search-header">-->
+                <!--<form role="form" class="form-inline">-->
+                    <!--<div class="form-group has-feedback">-->
+                        <!--<input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">-->
+                        <!--<span class="glyphicon glyphicon-search form-control-feedback"></span>-->
+                    <!--</div>-->
+                <!--</form>-->
+            <!--</div>-->
             <div><a href="#report/edit" class="btn btn-default" style="margin-bottom: .5em">New Report</a></div>
-            <div data-bind="compose: { model: reports, view: '/assets/html/components/Pager.html', mode: 'templated' }">
-                <div data-part="content" style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" class="col-md-4 col-lg-3 col-sm-6">
-                    <div class="left">
-                        <span data-bind="text: id"></span>
-                        <span data-bind="text: name"></span>
-                    </div>
-                    <div class="right">
+            <table class="table table-hover">
+                <tr class="row">
+                    <th class="col-md-3">ID</th>
+                    <th class="col-md-1">Name</td>
+                    <th class="col-md-1">Source</td>
+                    <th class="col-md-1">Schedule Type</td>
+                    <th class="col-md-2">From</td>
+                    <th class="col-md-2">Until</td>
+                    <th class="col-md-2">Recipients</td>
+                    <th class="hidden"></th>
+                </tr>
+                <!-- ko foreach: reports.filteredEntities -->
+                <tr class="row">
+                    <td data-bind="text: id"></td>
+                    <td data-bind="text: name"></td>
+                    <td>
+                        <span data-bind="text: source.title"></span>
+                        <div class="popover-content hidden" data-bind="attr: {'data-id': 'source-'+id}">
+                            <dl class="container col-md-12 dl-horizontal">
+                                <dt>url:</dt><dd data-bind="text: source.url"></dd>
+                                <dt>event:</dt><dd data-bind="text: source.eventName"></dd>
+                                <dt>ignore cert errors:</dt><dd data-bind="text: source.ignoreCertificateErrors"></dd>
+                            </dl>
+                        </div>
+                        <span class="glyphicon glyphicon-info-sign"
+                              data-title="Source details"
+                              data-html="true"
+                              data-bind="popover: {id: 'source-'+id}"
+                              data-trigger="hover"></span>
+                    </td>
+                    <td>
+                        <span data-bind="text: schedule.displayType"></span>
+                    </td>
+                    <td>
+                        <span data-bind="text: schedule.start"></span>
+                    </td>
+                    <td>
+                        <span data-bind="text: schedule.end"></span>
+                    </td>
+                    <td data-bind="foreach: recipients">
+                        <span class="badge" data-bind="text: badgeText"></span>
+                    </td>
+                    <td>
                         <a data-bind="attr: { href: editUri }">
                             <i class="fa fa-pencil-square-o"></i>
                         </a>
-                        <!--<a data-bind="click: $root.remove" href="#">-->
-                            <!--<i class="fa fa-times"></i>-->
-                        <!--</a>-->
-                    </div>
-                </div>
-            </div>
+                    </td>
+                </tr>
+                <!-- /ko -->
+            </table>
         </div>
     </div>
 </div>

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2018 Dropbox, Inc.
+  ~ Copyright 2019 Dropbox, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -13,79 +13,72 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <div class="container-fluid">
     <div class="row">
         <div class="container col-md-offset-1 col-md-10">
-            <h2>Reports</h2>
-            <div class ="row">
-                <div class="col-md-1"><a href="#report/edit" class="btn btn-default" style="margin-bottom: .5em">New Report</a></div>
-                <div class="col-md-offset-7 col-md-4">
-                    <form role="form" class="form-inline">
-                        <div class="form-group has-feedback pull-right">
-                            <input class="form-control" data-bind="value: reports.searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
-                            <span class="glyphicon glyphicon-search form-control-feedback"></span>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <table class="table table-hover">
-                <tr class="row">
-                    <th class="col-md-3">ID</th>
-                    <th class="col-md-1">Name</td>
-                    <th class="col-md-1">Source</td>
-                    <th class="col-md-1">Schedule Type</td>
-                    <th class="col-md-2">Start Time</td>
-                    <th class="col-md-2">End Time</td>
-                    <th class="col-md-2">Recipients</td>
-                    <th></th>
-                </tr>
-                <!-- ko foreach: reports.filteredEntities -->
-                <tr class="row">
-                    <td data-bind="text: id"></td>
-                    <td data-bind="text: name"></td>
-                    <td>
-                        <span data-bind="text: source.title"></span>
-                        <div class="popover-content hidden" data-bind="attr: {'data-id': 'source-'+id}">
-                            <dl class="container col-md-12 dl-horizontal">
-                                <dt>url:</dt><dd data-bind="text: source.url"></dd>
-                                <dt>event:</dt><dd data-bind="text: source.eventName"></dd>
-                                <dt>ignore cert errors:</dt><dd data-bind="text: source.ignoreCertificateErrors"></dd>
-                            </dl>
-                        </div>
-                        <span class="glyphicon glyphicon-info-sign"
-                              data-title="Source details"
-                              data-html="true"
-                              data-bind="popover: {id: 'source-'+id}"
-                              data-trigger="hover"></span>
-                    </td>
-                    <td>
-                        <span data-bind="text: schedule.displayType"></span>
-                    </td>
-                    <td>
-                        <span data-bind="text: schedule.startText"></span>
-                    </td>
-                    <td>
-                        <span data-bind="text: schedule.endText"></span>
-                    </td>
-                    <td data-bind="foreach: recipients">
-                        <span class="badge" data-bind="text: badgeText"></span>
-                    </td>
-                    <td>
-                        <a data-bind="attr: { href: editUri }">
-                            <i class="fa fa-pencil-square-o"></i>
-                        </a>
-                    </td>
-                </tr>
+            <div data-bind="compose: {model: reports, view: '/assets/html/components/Pager.html', mode: 'templated'}">
+                <!-- XXX:
+                 <tr> elements **MUST** be contained within <table> and <tbody> elements. Since Durandal creates DOMElements
+                 before binding them in the template, they must be valid elements at creation, not just when rendered.
+
+                 As a hack we use an if binding that is never visible so that these <tr>'s can be specified without being
+                 mangled by the browser.
+                 -->
+                <!-- ko if: false -->
+                <table>
+                    <tbody>
                 <!-- /ko -->
-            </table>
-            <nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
-                <div class="text-center">
-                    <ul class="pagination" data-bind="foreach: reports.pagerElements">
-                        <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
-                    </ul>
-                </div>
-            </nav>
+                    <tr class="row" data-part="entityLabels">
+                        <th class="col-md-3">ID</th>
+                        <th class="col-md-1">Name</td>
+                        <th class="col-md-1">Source</td>
+                        <th class="col-md-1">Schedule Type</td>
+                        <th class="col-md-2">Start Time</td>
+                        <th class="col-md-2">End Time</td>
+                        <th class="col-md-2">Recipients</td>
+                        <th></th>
+                    </tr>
+                    <tr class="row" data-part="entityRow">
+                        <td data-bind="text: id"></td>
+                        <td data-bind="text: name"></td>
+                        <td>
+                            <span data-bind="text: source.title"></span>
+                            <div class="popover-content hidden" data-bind="attr: {'data-id': 'source-'+id}">
+                                <dl class="container col-md-12 dl-horizontal">
+                                    <dt>url:</dt><dd data-bind="text: source.url"></dd>
+                                    <dt>event:</dt><dd data-bind="text: source.eventName"></dd>
+                                    <dt>ignore cert errors:</dt><dd data-bind="text: source.ignoreCertificateErrors"></dd>
+                                </dl>
+                            </div>
+                            <span class="glyphicon glyphicon-info-sign"
+                                  data-title="Source details"
+                                  data-html="true"
+                                  data-bind="popover: {id: 'source-'+id}"
+                                  data-trigger="hover"></span>
+                        </td>
+                        <td>
+                            <span data-bind="text: schedule.displayType"></span>
+                        </td>
+                        <td>
+                            <span data-bind="text: schedule.startText"></span>
+                        </td>
+                        <td>
+                            <span data-bind="text: schedule.endText"></span>
+                        </td>
+                        <td data-bind="foreach: recipients">
+                            <span class="badge" data-bind="text: badgeText"></span>
+                        </td>
+                        <td>
+                            <a data-bind="attr: { href: editUri }">
+                                <i class="fa fa-pencil-square-o"></i>
+                            </a>
+                        </td>
+                    </tr>
+                <!-- ko if: false -->
+                    </tbody>
+                </table>
+                <!-- /ko -->
+            </div>
         </div>
     </div>
 </div>

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -18,16 +18,17 @@
     <div class="row">
         <div class="container col-md-offset-1 col-md-10">
             <h2>Reports</h2>
-            <!--Header for search-->
-            <!--<div class="col-md-12 col-sm-12 col-lg-12 search-header">-->
-                <!--<form role="form" class="form-inline">-->
-                    <!--<div class="form-group has-feedback">-->
-                        <!--<input class="form-control" data-bind="value: searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">-->
-                        <!--<span class="glyphicon glyphicon-search form-control-feedback"></span>-->
-                    <!--</div>-->
-                <!--</form>-->
-            <!--</div>-->
-            <div><a href="#report/edit" class="btn btn-default" style="margin-bottom: .5em">New Report</a></div>
+            <div class ="row">
+                <div class="col-md-1"><a href="#report/edit" class="btn btn-default" style="margin-bottom: .5em">New Report</a></div>
+                <div class="col-md-offset-7 col-md-4">
+                    <form role="form" class="form-inline">
+                        <div class="form-group has-feedback pull-right">
+                            <input class="form-control" data-bind="value: reports.searchExpression, valueUpdate: 'keyup'" type="text" placeholder="Search">
+                            <span class="glyphicon glyphicon-search form-control-feedback"></span>
+                        </div>
+                    </form>
+                </div>
+            </div>
             <table class="table table-hover">
                 <tr class="row">
                     <th class="col-md-3">ID</th>
@@ -37,7 +38,7 @@
                     <th class="col-md-2">From</td>
                     <th class="col-md-2">Until</td>
                     <th class="col-md-2">Recipients</td>
-                    <th class="hidden"></th>
+                    <th></th>
                 </tr>
                 <!-- ko foreach: reports.filteredEntities -->
                 <tr class="row">
@@ -78,6 +79,13 @@
                 </tr>
                 <!-- /ko -->
             </table>
+            <nav class="navbar navbar-inverse navbar-fixed-bottom col-md-12 footer">
+                <div class="text-center">
+                    <ul class="pagination" data-bind="foreach: reports.pagerElements">
+                        <li data-bind="css: {active: active, disabled: disabled}"><a href="#" data-bind="text: name, click: $parent.gotoPage"></a></li>
+                    </ul>
+                </div>
+            </nav>
         </div>
     </div>
 </div>

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -66,8 +66,7 @@
                         <span data-bind="text: schedule.start"></span>
                     </td>
                     <td>
-                        <span data-bind="if schedule; text: schedule.end"></span>
-                        <span data-bind="if-not schedule">–</span>
+                        <span data-bind="text: schedule.end ? schedule.end : '–'"></span>
                     </td>
                     <td data-bind="foreach: recipients">
                         <span class="badge" data-bind="text: badgeText"></span>

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -63,10 +63,10 @@
                         <span data-bind="text: schedule.displayType"></span>
                     </td>
                     <td>
-                        <span data-bind="text: schedule.start"></span>
+                        <span data-bind="text: schedule.startText"></span>
                     </td>
                     <td>
-                        <span data-bind="text: schedule.end ? schedule.end : '–'"></span>
+                        <span data-bind="text: schedule.endText"></span>
                     </td>
                     <td data-bind="foreach: recipients">
                         <span class="badge" data-bind="text: badgeText"></span>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -244,3 +244,8 @@ body {
 .right {
   float:right
 }
+
+.popover {
+  max-width: 100%;
+  width: auto;
+}


### PR DESCRIPTION
Adds a paginated list view for the reports page, and factors out shared `Base*ViewModel` types from both the `EditReportViewModel` and `ReportViewModel`.

~An open problem is how to unify the html template with the pager from `AlertsViewModel`. The durandal components were incompatible because of how the template is structured; this has several templatized portions while `AlertsViewModel` has only one. I had attempted to extract out the entity-agnostic functionality but due to the way durandal binds components after the DOM is created, `<tr>` elements seem to disappear or get hoisted upwards since they are not yet enclosed in a `<table>`.~

UPDATE: In somewhat of a hack, I was able to include the new paging template after all by embedding the row elements into a temporary table that is only present at component binding time (and removed after by knockout bindings). See `ReportsViewModel.html` and `components/Pager.html` for details.

See #191 for the associated backend changes.