### PR TITLE
Switch KairosDbRequestException to Java URI

### DIFF
--- a/app/com/arpnetworking/kairos/client/KairosDbClientImpl.java
+++ b/app/com/arpnetworking/kairos/client/KairosDbClientImpl.java
@@ -139,7 +139,7 @@ public final class KairosDbClientImpl implements KairosDbClient {
                         throw new KairosDbRequestException(
                                 httpResponse.status().intValue(),
                                 httpResponse.status().reason(),
-                                request.getUri());
+                                URI.create(request.getUri().toString()));
                     }
                     return httpResponse.entity()
                             .toStrict(_readTimeout.toMillis(), _materializer)

--- a/app/com/arpnetworking/kairos/client/KairosDbRequestException.java
+++ b/app/com/arpnetworking/kairos/client/KairosDbRequestException.java
@@ -15,8 +15,9 @@
  */
 package com.arpnetworking.kairos.client;
 
-import akka.http.javadsl.model.Uri;
 import com.arpnetworking.logback.annotations.Loggable;
+
+import java.net.URI;
 
 /**
  * An exception that represents a non-2xx KairosDB request.
@@ -34,7 +35,7 @@ public class KairosDbRequestException extends RuntimeException {
         return _httpMessage;
     }
 
-    public Uri getRequestUri() {
+    public URI getRequestUri() {
         return _requestUri;
     }
 
@@ -45,7 +46,7 @@ public class KairosDbRequestException extends RuntimeException {
      * @param httpMessage the status message from the http response
      * @param requestUri the uri requested
      */
-    public KairosDbRequestException(final int httpStatus, final String httpMessage, final Uri requestUri) {
+    public KairosDbRequestException(final int httpStatus, final String httpMessage, final URI requestUri) {
         super(String.format("KairosDb request to %s failed because %s (%d)", requestUri, httpMessage, httpStatus));
         _httpStatus = httpStatus;
         _httpMessage = httpMessage;
@@ -60,7 +61,7 @@ public class KairosDbRequestException extends RuntimeException {
      * @param httpMessage the status message from the http response
      * @param requestUri the uri requested
      */
-    public KairosDbRequestException(final String message, final int httpStatus, final String httpMessage, final Uri requestUri) {
+    public KairosDbRequestException(final String message, final int httpStatus, final String httpMessage, final URI requestUri) {
         super(message);
         _httpStatus = httpStatus;
         _httpMessage = httpMessage;
@@ -76,11 +77,12 @@ public class KairosDbRequestException extends RuntimeException {
      * @param httpMessage the status message from the http response
      * @param requestUri the uri requested
      */
-    public KairosDbRequestException(final String message,
-                                    final Throwable cause,
-                                    final int httpStatus,
-                                    final String httpMessage,
-                                    final Uri requestUri) {
+    public KairosDbRequestException(
+            final String message,
+            final Throwable cause,
+            final int httpStatus,
+            final String httpMessage,
+            final URI requestUri) {
         super(message, cause);
         _httpStatus = httpStatus;
         _httpMessage = httpMessage;
@@ -89,6 +91,6 @@ public class KairosDbRequestException extends RuntimeException {
 
     private final int _httpStatus;
     private final String _httpMessage;
-    private final Uri _requestUri;
+    private final URI _requestUri;
     private static final long serialVersionUID = 6622759488133086527L;
 }


### PR DESCRIPTION
Convert the `KairosDbRequestException` exception type to use Java's URI instead of Akka's URI to improve encapsulation of Akka in Metrics Portal as well as to improve serialization of the exception since Jackson natively supports Java URI encoding but does not support Akka URI encoding with Steno. This was not apparent in testing because KeyValueEncoder (used in testing) forces all values output with `toString()`. However, it was obvious in prod. Here is some test output when forced to use the production encoder configuration.

With Akka URI:
```
{"time":"2019-05-15T15:47:52.763Z","name":"log","level":"warn","data":{"message":"TEST 1","url":{"_id":"dc79225","_class":"akka.http.impl.model.JavaUri"}},"context":{"host":"vkoskela-mbp.corp.dropbox.com","processId":"49857","threadId":"main","logger":"Test"},"id":"3e4b3dd5-704d-4bab-bd4d-7ce06abb9dc0","version":"0"}
```

With Java URI:
```
{"time":"2019-05-15T15:47:52.814Z","name":"log","level":"warn","data":{"message":"TEST 2","url":"http://www.example.com:443/foo"},"context":{"host":"vkoskela-mbp.corp.dropbox.com","processId":"49857","threadId":"main","logger":"Test"},"id":"0f6f1f81-df16-445a-b6da-5c0278057429","version":"0"}
```
