### PR TITLE
Fix filtering logic and add unit tests.

### DIFF
--- a/app/com/arpnetworking/rollups/MetricsDiscovery.java
+++ b/app/com/arpnetworking/rollups/MetricsDiscovery.java
@@ -30,13 +30,10 @@ import com.typesafe.config.Config;
 import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 
 /**
@@ -114,10 +111,7 @@ public final class MetricsDiscovery extends AbstractActorWithTimers {
     }
 
     private void updateMetricsSet(final KairosMetricNamesQueryResponse response) {
-        response.getResults().stream()
-                .filter(ROLLUP_METRIC_PREDICATE.negate())
-                .filter(_whiteList.or(_blackList.negate())) // If on the whitelist or not on the blacklist
-                .forEach(_metricsSet::add);
+        filterMetricNames(response.getResults(), _whiteList, _blackList).forEach(_metricsSet::add);
         _setIterator = _metricsSet.iterator();
     }
 
@@ -133,7 +127,17 @@ public final class MetricsDiscovery extends AbstractActorWithTimers {
         return Optional.ofNullable(next);
     }
 
-    private Predicate<String> toPredicate(final List<String> regexList, final boolean defaultResult) {
+    static Stream<String> filterMetricNames(
+            final Collection<String> metricNames,
+            final Predicate<String> whiteList,
+            final Predicate<String> blackList) {
+        return metricNames.stream()
+                .filter(ROLLUP_METRIC_PREDICATE.negate())
+                .filter(whiteList)
+                .filter(blackList.negate());
+    }
+
+    static Predicate<String> toPredicate(final List<String> regexList, final boolean defaultResult) {
         return regexList
                 .stream()
                 .map(Pattern::compile)

--- a/app/com/arpnetworking/rollups/MetricsDiscovery.java
+++ b/app/com/arpnetworking/rollups/MetricsDiscovery.java
@@ -30,7 +30,12 @@ import com.typesafe.config.Config;
 import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;

--- a/test/java/com/arpnetworking/rollups/MetricsDiscoveryTest.java
+++ b/test/java/com/arpnetworking/rollups/MetricsDiscoveryTest.java
@@ -106,9 +106,9 @@ public final class MetricsDiscoveryTest {
     public void testNoMoreMetrics() {
         when(_config.getStringList(eq("rollup.metric.whitelist")))
                 .thenReturn(ImmutableList.of(
-                        "^cmf/web_perf/.*$",
-                        "^cmf/test/.*$"));
-        when(_config.getStringList(eq("rollup.metric.blacklist"))).thenReturn(ImmutableList.of("^cmf/.*$"));
+                        "^metric([\\d])*$",
+                        "^cmf/.*$"));
+        when(_config.getStringList(eq("rollup.metric.blacklist"))).thenReturn(ImmutableList.of("^cmf/foo/.*$"));
         when(_kairosDbClient.queryMetricNames())
                 .thenReturn(CompletableFuture
                         .completedFuture(new KairosMetricNamesQueryResponse.Builder()


### PR DESCRIPTION
Please validate that the unit tests describe the desired behavior. It makes logical sense to me at first pass, but I may have missed something.

Before the change the unit tests would fail with this:

```
java.lang.AssertionError: 
Expected :[web_perf/foo]
Actual   :[web_perf/foo, desktop/bar, mobile/abc]
<Click to see difference>


	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at com.arpnetworking.rollups.MetricsDiscoveryTest.testFilterMetricNames(MetricsDiscoveryTest.java:223)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```