### PR TITLE
Add sharding support to status cache.

### DIFF
--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefDeserializer.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefDeserializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.jackson.databind.module.akka;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import com.arpnetworking.logback.annotations.LogValue;
+import com.arpnetworking.steno.LogValueMapFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Deserializer for an Akka ActorRef.
+ *
+ * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
+ */
+public final class ActorRefDeserializer extends JsonDeserializer<ActorRef> {
+    /**
+     * Public constructor.
+     *
+     * @param system actor system used to resolve references
+     */
+    public ActorRefDeserializer(final ActorSystem system) {
+        _system = system;
+    }
+
+    @Override
+    public ActorRef deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
+        return _system.provider().resolveActorRef(p.getValueAsString());
+    }
+
+    /**
+     * Generate a Steno log compatible representation.
+     *
+     * @return Steno log compatible representation.
+     */
+    @LogValue
+    public Object toLogValue() {
+        return LogValueMapFactory.builder(this)
+                .put("actorSystem", _system)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return toLogValue().toString();
+    }
+
+    private final ActorSystem _system;
+}

--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefLoggingSerializer.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefLoggingSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.jackson.databind.module.akka;
+
+import akka.actor.ActorRef;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Serializer for an Akka ActorRef.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class ActorRefLoggingSerializer extends JsonSerializer<ActorRef> {
+
+    /**
+     * Public constructor.
+     */
+    public ActorRefLoggingSerializer() { }
+
+    @Override
+    public void serialize(
+            final ActorRef value,
+            final JsonGenerator gen,
+            final SerializerProvider serializers) throws IOException {
+        gen.writeString(value.toString());
+    }
+}

--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefSerializer.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.jackson.databind.module.akka;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import com.arpnetworking.logback.annotations.LogValue;
+import com.arpnetworking.steno.LogValueMapFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Serializer for an Akka ActorRef.
+ *
+ * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
+ */
+public final class ActorRefSerializer extends JsonSerializer<ActorRef> {
+    /**
+     * Public constructor.
+     *
+     * @param system actor system to use to resolve references
+     */
+    public ActorRefSerializer(final ActorSystem system) {
+        _system = system;
+    }
+
+    @Override
+    public void serialize(
+            final ActorRef value,
+            final JsonGenerator gen,
+            final SerializerProvider serializers) throws IOException {
+        gen.writeString(value.path().toStringWithAddress(_system.provider().getDefaultAddress()));
+    }
+
+    /**
+     * Generate a Steno log compatible representation.
+     *
+     * @return Steno log compatible representation.
+     */
+    @LogValue
+    public Object toLogValue() {
+        return LogValueMapFactory.builder(this)
+                .put("actorSystem", _system)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return toLogValue().toString();
+    }
+
+    private final ActorSystem _system;
+}

--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefSerializer.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/ActorRefSerializer.java
@@ -16,9 +16,7 @@
 package com.arpnetworking.commons.jackson.databind.module.akka;
 
 import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import com.arpnetworking.logback.annotations.LogValue;
-import com.arpnetworking.steno.LogValueMapFactory;
+import akka.serialization.Serialization;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -31,39 +29,12 @@ import java.io.IOException;
  * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
  */
 public final class ActorRefSerializer extends JsonSerializer<ActorRef> {
-    /**
-     * Public constructor.
-     *
-     * @param system actor system to use to resolve references
-     */
-    public ActorRefSerializer(final ActorSystem system) {
-        _system = system;
-    }
 
     @Override
     public void serialize(
             final ActorRef value,
             final JsonGenerator gen,
             final SerializerProvider serializers) throws IOException {
-        gen.writeString(value.path().toStringWithAddress(_system.provider().getDefaultAddress()));
+        gen.writeString(Serialization.serializedActorPath(value));
     }
-
-    /**
-     * Generate a Steno log compatible representation.
-     *
-     * @return Steno log compatible representation.
-     */
-    @LogValue
-    public Object toLogValue() {
-        return LogValueMapFactory.builder(this)
-                .put("actorSystem", _system)
-                .build();
-    }
-
-    @Override
-    public String toString() {
-        return toLogValue().toString();
-    }
-
-    private final ActorSystem _system;
 }

--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/AkkaLoggingModule.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/AkkaLoggingModule.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.jackson.databind.module.akka;
+
+import akka.actor.ActorRef;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Jackson module for serializing Akka objects for use in JSON/Jackson based
+ * logger serializers(e.g. logback-steno).
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class AkkaLoggingModule extends SimpleModule {
+
+    /**
+     * Public constructor.
+     */
+    public AkkaLoggingModule() { }
+
+    @Override
+    public void setupModule(final SetupContext context) {
+        addSerializer(ActorRef.class, new ActorRefLoggingSerializer());
+        super.setupModule(context);
+    }
+
+    private static final long serialVersionUID = 6984539942087839964L;
+}

--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/AkkaModule.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/AkkaModule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.commons.jackson.databind.module.akka;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import com.arpnetworking.logback.annotations.LogValue;
+import com.arpnetworking.steno.LogValueMapFactory;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Jackson module for serializing and deserializing Akka objects.
+ *
+ * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
+ */
+public final class AkkaModule extends SimpleModule {
+
+    /**
+     * Public constructor.
+     *
+     * @param system the actor system to resolve references
+     */
+    public AkkaModule(final ActorSystem system) {
+        _system = system;
+    }
+
+    @Override
+    public void setupModule(final SetupContext context) {
+        addSerializer(ActorRef.class, new ActorRefSerializer(_system));
+        addDeserializer(ActorRef.class, new ActorRefDeserializer(_system));
+        super.setupModule(context);
+    }
+
+    /**
+     * Generate a Steno log compatible representation.
+     *
+     * @return Steno log compatible representation.
+     */
+    @LogValue
+    public Object toLogValue() {
+        return LogValueMapFactory.builder(this)
+                .put("actorSystem", _system)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return toLogValue().toString();
+    }
+
+    @SuppressFBWarnings("SE_BAD_FIELD")
+    private final ActorSystem _system;
+
+    private static final long serialVersionUID = 4294591813352245070L;
+}

--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/AkkaModule.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/AkkaModule.java
@@ -40,7 +40,7 @@ public final class AkkaModule extends SimpleModule {
 
     @Override
     public void setupModule(final SetupContext context) {
-        addSerializer(ActorRef.class, new ActorRefSerializer(_system));
+        addSerializer(ActorRef.class, new ActorRefSerializer());
         addDeserializer(ActorRef.class, new ActorRefDeserializer(_system));
         super.setupModule(context);
     }

--- a/app/com/arpnetworking/commons/jackson/databind/module/akka/package-info.java
+++ b/app/com/arpnetworking/commons/jackson/databind/module/akka/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.commons.jackson.databind.module.akka;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/main/config/logback-console.xml
+++ b/main/config/logback-console.xml
@@ -21,6 +21,7 @@
       <compressLoggerName>true</compressLoggerName>
       <jacksonModule class="com.fasterxml.jackson.datatype.guava.GuavaModule" />
       <jacksonModule class="com.fasterxml.jackson.datatype.jdk8.Jdk8Module" />
+      <jacksonModule class="com.arpnetworking.commons.jackson.databind.module.akka.AkkaLoggingModule" />
       <injectBeanIdentifier>true</injectBeanIdentifier>
     </encoder>
   </appender>

--- a/main/config/logback.xml
+++ b/main/config/logback.xml
@@ -31,6 +31,7 @@
       <compressLoggerName>true</compressLoggerName>
       <jacksonModule class="com.fasterxml.jackson.datatype.guava.GuavaModule" />
       <jacksonModule class="com.fasterxml.jackson.datatype.jdk8.Jdk8Module" />
+      <jacksonModule class="com.arpnetworking.commons.jackson.databind.module.akka.AkkaLoggingModule" />
       <injectBeanIdentifier>true</injectBeanIdentifier>
     </encoder>
   </appender>

--- a/test/java/com/arpnetworking/commons/jackson/databind/module/package-info.java
+++ b/test/java/com/arpnetworking/commons/jackson/databind/module/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.commons.jackson.databind.module;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
`/status` now includes:

```
"allocations": [
{
"incomingShards": {
"count": 0
},
"outgoingShards": {
"count": 0
},
"shardRegion": "akka.tcp://mportal@127.0.0.1:2558/system/sharding/JobExecutor",
"currentShards": {
"count": 0
},
"host": "localhost"
}
],
```