### PR TITLE
add ChromeScreenshotReportSource.{timeout,jsRunOnLoad}

### DIFF
--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -182,6 +182,8 @@ class EditSourceViewModel extends BaseSourceViewModel {
             uri: this.url(),
             title: this.title(),
             ignoreCertificateErrors: this.ignoreCertificateErrors(),
+            timeout: this.timeout(),
+            jsRunOnLoad: this.jsRunOnLoad(),
             triggeringEventName: this.eventName(),
         }
     }

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -44,6 +44,8 @@ export class BaseSourceViewModel {
     title = ko.observable<string>("");
     url = ko.observable<string>("");
     eventName = ko.observable<string>("");
+    timeout = ko.observable<number>(0);
+    jsRunOnLoad = ko.observable<string>("");
     ignoreCertificateErrors = ko.observable<boolean>(false);
 
     public load(raw): this {
@@ -51,6 +53,8 @@ export class BaseSourceViewModel {
         this.url(raw.uri);
         this.title(raw.title);
         this.eventName(raw.triggeringEventName);
+        this.timeout(raw.timeout);
+        this.jsRunOnLoad(raw.jsRunOnLoad);
         this.ignoreCertificateErrors(raw.ignoreCertificateErrors);
 
         const type = SourceType[raw.type as string];

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -494,7 +494,7 @@ public final class DatabaseReportRepository implements ReportRepository {
             ebeanSource.setUri(internalWebSource.getUri());
             ebeanSource.setTriggeringEventName(internalWebSource.getTriggeringEventName());
             ebeanSource.setTitle(internalWebSource.getTitle());
-            ebeanSource.setTimeout(internalWebSource.getTimeout());
+            ebeanSource.setTimeout(internalWebSource.getTimeout().toNanos());
             ebeanSource.setJsRunOnLoad(internalWebSource.getJsRunOnLoad());
             return ebeanSource;
         }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -494,6 +494,8 @@ public final class DatabaseReportRepository implements ReportRepository {
             ebeanSource.setUri(internalWebSource.getUri());
             ebeanSource.setTriggeringEventName(internalWebSource.getTriggeringEventName());
             ebeanSource.setTitle(internalWebSource.getTitle());
+            ebeanSource.setTimeout(internalWebSource.getTimeout());
+            ebeanSource.setJsRunOnLoad(internalWebSource.getJsRunOnLoad());
             return ebeanSource;
         }
         throw new IllegalArgumentException("Unsupported internal model: " + reportSource.getClass());

--- a/app/models/ebean/WebPageReportSource.java
+++ b/app/models/ebean/WebPageReportSource.java
@@ -44,8 +44,8 @@ public class WebPageReportSource extends ReportSource {
     @Column(name = "ignore_certificate_errors")
     private boolean ignoreCertificateErrors;
 
-    @Column(name = "timeout")
-    private Duration timeout;
+    @Column(name = "timeout_nanos")
+    private long timeoutNanos;
 
     @Column(name = "js_run_on_load")
     private String jsRunOnLoad;
@@ -77,12 +77,12 @@ public class WebPageReportSource extends ReportSource {
         ignoreCertificateErrors = value;
     }
 
-    public Duration getTimeout() {
-        return timeout;
+    public long getTimeout() {
+        return timeoutNanos;
     }
 
-    public void setTimeout(final Duration value) {
-        timeout = value;
+    public void setTimeout(final long value) {
+        timeoutNanos = value;
     }
 
     public String getJsRunOnLoad() {
@@ -108,7 +108,7 @@ public class WebPageReportSource extends ReportSource {
                 .setUri(uri)
                 .setTitle(title)
                 .setIgnoreCertificateErrors(ignoreCertificateErrors)
-                .setTimeout(timeout)
+                .setTimeout(Duration.ofNanos(timeoutNanos))
                 .setJsRunOnLoad(jsRunOnLoad)
                 .setTriggeringEventName(triggeringEventName)
                 .build();

--- a/app/models/ebean/WebPageReportSource.java
+++ b/app/models/ebean/WebPageReportSource.java
@@ -16,6 +16,7 @@
 package models.ebean;
 
 import java.net.URI;
+import java.time.Duration;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -42,6 +43,12 @@ public class WebPageReportSource extends ReportSource {
 
     @Column(name = "ignore_certificate_errors")
     private boolean ignoreCertificateErrors;
+
+    @Column(name = "timeout")
+    private Duration timeout;
+
+    @Column(name = "js_run_on_load")
+    private String jsRunOnLoad;
 
     @Column(name = "triggering_event_name")
     private String triggeringEventName;
@@ -70,6 +77,22 @@ public class WebPageReportSource extends ReportSource {
         ignoreCertificateErrors = value;
     }
 
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(final Duration value) {
+        timeout = value;
+    }
+
+    public String getJsRunOnLoad() {
+        return jsRunOnLoad;
+    }
+
+    public void setJsRunOnLoad(final String value) {
+        jsRunOnLoad = value;
+    }
+
     public String getTriggeringEventName() {
         return triggeringEventName;
     }
@@ -85,6 +108,8 @@ public class WebPageReportSource extends ReportSource {
                 .setUri(uri)
                 .setTitle(title)
                 .setIgnoreCertificateErrors(ignoreCertificateErrors)
+                .setTimeout(timeout)
+                .setJsRunOnLoad(jsRunOnLoad)
                 .setTriggeringEventName(triggeringEventName)
                 .build();
     }

--- a/app/models/internal/impl/WebPageReportSource.java
+++ b/app/models/internal/impl/WebPageReportSource.java
@@ -19,12 +19,15 @@ package models.internal.impl;
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.google.common.base.MoreObjects;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import models.internal.reports.ReportSource;
 import net.sf.oval.constraint.AssertURL;
 import net.sf.oval.constraint.AssertURLCheck;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
+import net.sf.oval.constraint.ValidateWithMethod;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Objects;
@@ -240,6 +243,11 @@ public final class WebPageReportSource implements ReportSource {
             return this;
         }
 
+        @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "invoked reflectively by @ValidateWithMethod")
+        private boolean validateTimeoutIsPositive(@Nullable final Duration timeout) {
+            return (timeout != null) && (timeout.toNanos() > 0);
+        }
+
         @NotNull
         private UUID _id;
         @NotNull
@@ -252,6 +260,7 @@ public final class WebPageReportSource implements ReportSource {
         @NotEmpty
         private String _triggeringEventName;
         @NotNull
+        @ValidateWithMethod(methodName = "validateTimeoutIsPositive", parameterType = Duration.class)
         private Duration _timeout;
         @NotNull
         private String _jsRunOnLoad = "";

--- a/app/models/internal/impl/WebPageReportSource.java
+++ b/app/models/internal/impl/WebPageReportSource.java
@@ -27,11 +27,11 @@ import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 import net.sf.oval.constraint.ValidateWithMethod;
 
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 /**
  * Internal model for a report source that pulls content from a web page.

--- a/app/models/internal/impl/WebPageReportSource.java
+++ b/app/models/internal/impl/WebPageReportSource.java
@@ -26,6 +26,7 @@ import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -40,6 +41,8 @@ public final class WebPageReportSource implements ReportSource {
     private final URI _uri;
     private final String _title;
     private final boolean _ignoreCertificateErrors;
+    private final Duration _timeout;
+    private final String _jsRunOnLoad;
     private final String _triggeringEventName;
 
     private WebPageReportSource(final Builder builder) {
@@ -47,6 +50,8 @@ public final class WebPageReportSource implements ReportSource {
         _uri = builder._uri;
         _title = builder._title;
         _ignoreCertificateErrors = builder._ignoreCertificateErrors;
+        _timeout = builder._timeout;
+        _jsRunOnLoad = builder._jsRunOnLoad;
         _triggeringEventName = builder._triggeringEventName;
     }
 
@@ -57,6 +62,8 @@ public final class WebPageReportSource implements ReportSource {
                 .add("url", _uri)
                 .add("title", _title)
                 .add("ignoreCertificateErrors", _ignoreCertificateErrors)
+                .add("timeout", _timeout)
+                .add("jsRunOnLoad", _jsRunOnLoad)
                 .add("triggeringEventName", _triggeringEventName)
                 .toString();
     }
@@ -94,6 +101,24 @@ public final class WebPageReportSource implements ReportSource {
     }
 
     /**
+     * The timeout to wait before giving up on rendering the report.
+     *
+     * @return the timeout.
+     */
+    public Duration getTimeout() {
+        return _timeout;
+    }
+
+    /**
+     * Any JavaScript to run immediately after page load.
+     *
+     * @return the JavaScript.
+     */
+    public String getJsRunOnLoad() {
+        return _jsRunOnLoad;
+    }
+
+    /**
      * Get the browser event name used to trigger this report source.
      *
      * The report will be considered generated once an event with this name is registered
@@ -118,12 +143,13 @@ public final class WebPageReportSource implements ReportSource {
                 && Objects.equals(_id, that._id)
                 && Objects.equals(_uri, that._uri)
                 && Objects.equals(_title, that._title)
+                && Objects.equals(_jsRunOnLoad, that._jsRunOnLoad)
                 && Objects.equals(_triggeringEventName, that._triggeringEventName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_id, _uri, _title, _ignoreCertificateErrors, _triggeringEventName);
+        return Objects.hash(_id, _uri, _title, _ignoreCertificateErrors, _jsRunOnLoad, _triggeringEventName);
     }
 
     /**
@@ -171,6 +197,28 @@ public final class WebPageReportSource implements ReportSource {
         }
 
         /**
+         * The timeout to wait before giving up on rendering the report. Required. Cannot be null.
+         *
+         * @param timeout The timeout.
+         * @return This instance of {@code Builder}
+         */
+        public Builder setTimeout(final Duration timeout) {
+            _timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Any JavaScript to run when the page has loaded. Optional. Defaults to empty.
+         *
+         * @param js The JavaScript.
+         * @return This instance of {@code Builder}
+         */
+        public Builder setJsRunOnLoad(final String js) {
+            _jsRunOnLoad = js;
+            return this;
+        }
+
+        /**
          * The triggering event name for the source. Required. Cannot be null or empty.
          *
          * @param triggeringEventName The event name.
@@ -203,6 +251,10 @@ public final class WebPageReportSource implements ReportSource {
         @NotNull
         @NotEmpty
         private String _triggeringEventName;
+        @NotNull
+        private Duration _timeout;
+        @NotNull
+        private String _jsRunOnLoad = "";
         @NotNull
         private Boolean _ignoreCertificateErrors = false;
 

--- a/app/models/view/impl/WebPageReportSource.java
+++ b/app/models/view/impl/WebPageReportSource.java
@@ -130,6 +130,8 @@ public final class WebPageReportSource implements ReportSource {
                 .add("url", _uri)
                 .add("title", _title)
                 .add("ignoreCertificateErrors", _ignoreCertificateErrors)
+                .add("timeout", _timeout)
+                .add("jsRunOnLoad", _jsRunOnLoad)
                 .add("triggeringEventName", _triggeringEventName)
                 .toString();
     }

--- a/app/models/view/impl/WebPageReportSource.java
+++ b/app/models/view/impl/WebPageReportSource.java
@@ -22,6 +22,7 @@ import com.google.common.base.MoreObjects;
 import models.view.reports.ReportSource;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -67,6 +68,22 @@ public final class WebPageReportSource implements ReportSource {
         _ignoreCertificateErrors = value;
     }
 
+    public Duration getTimeout() {
+        return _timeout;
+    }
+
+    public void setTimeout(final Duration value) {
+        _timeout = value;
+    }
+
+    public String getJsRunOnLoad() {
+        return _jsRunOnLoad;
+    }
+
+    public void setJsRunOnLoad(final String value) {
+        _jsRunOnLoad = value;
+    }
+
     public String getTriggeringEventName() {
         return _triggeringEventName;
     }
@@ -82,6 +99,8 @@ public final class WebPageReportSource implements ReportSource {
                 .setUri(_uri)
                 .setTitle(_title)
                 .setIgnoreCertificateErrors(_ignoreCertificateErrors)
+                .setTimeout(_timeout)
+                .setJsRunOnLoad(_jsRunOnLoad)
                 .setTriggeringEventName(_triggeringEventName)
                 .build();
     }
@@ -98,6 +117,8 @@ public final class WebPageReportSource implements ReportSource {
         viewSource.setUri(source.getUri());
         viewSource.setTitle(source.getTitle());
         viewSource.setTriggeringEventName(source.getTriggeringEventName());
+        viewSource.setTimeout(source.getTimeout());
+        viewSource.setJsRunOnLoad(source.getJsRunOnLoad());
         viewSource.setIgnoreCertificateErrors(source.ignoresCertificateErrors());
         return viewSource;
     }
@@ -126,6 +147,8 @@ public final class WebPageReportSource implements ReportSource {
                 && Objects.equals(_id, otherWebPageReportSource._id)
                 && Objects.equals(_uri, otherWebPageReportSource._uri)
                 && Objects.equals(_title, otherWebPageReportSource._title)
+                && Objects.equals(_timeout, otherWebPageReportSource._timeout)
+                && Objects.equals(_jsRunOnLoad, otherWebPageReportSource._jsRunOnLoad)
                 && Objects.equals(_triggeringEventName, otherWebPageReportSource._triggeringEventName);
     }
 
@@ -143,6 +166,10 @@ public final class WebPageReportSource implements ReportSource {
     private String _title;
     @JsonProperty("ignoreCertificateErrors")
     private boolean _ignoreCertificateErrors;
+    @JsonProperty("timeout")
+    private Duration _timeout;
+    @JsonProperty("jsRunOnLoad")
+    private String _jsRunOnLoad;
     @JsonProperty("triggeringEventName")
     private String _triggeringEventName;
 }

--- a/conf/db/migration/metrics_portal_ddl/V18__report_add_interactive_web_columns.sql
+++ b/conf/db/migration/metrics_portal_ddl/V18__report_add_interactive_web_columns.sql
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-ALTER TABLE portal.report_sources ADD COLUMN timeout DECIMAL;
+ALTER TABLE portal.report_sources ADD COLUMN timeout BIGINT;
 ALTER TABLE portal.report_sources ADD COLUMN js_run_on_load VARCHAR(8191);

--- a/conf/db/migration/metrics_portal_ddl/V18__report_add_interactive_web_columns.sql
+++ b/conf/db/migration/metrics_portal_ddl/V18__report_add_interactive_web_columns.sql
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-ALTER TABLE portal.report_sources ADD COLUMN timeout BIGINT;
+ALTER TABLE portal.report_sources ADD COLUMN timeout_nanos BIGINT;
 ALTER TABLE portal.report_sources ADD COLUMN js_run_on_load VARCHAR(8191);

--- a/conf/db/migration/metrics_portal_ddl/V18__report_add_interactive_web_columns.sql
+++ b/conf/db/migration/metrics_portal_ddl/V18__report_add_interactive_web_columns.sql
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE portal.report_sources ADD COLUMN timeout DECIMAL;
+ALTER TABLE portal.report_sources ADD COLUMN js_run_on_load VARCHAR(8191);

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -158,7 +158,7 @@ public final class TestBeanFactory {
                                 .setId(UUID.randomUUID())
                                 .setTriggeringEventName(TEST_EVENT + UUID.randomUUID().toString())
                                 .setUri(URI.create("http://" + UUID.randomUUID().toString().replace("-", "") + ".example.com"))
-                                .setTimeout(Duration.ofMillis((long)(10000 * RANDOM.nextFloat())))
+                                .setTimeout(Duration.ofMillis((long) (10000 * RANDOM.nextFloat())))
                                 .setJsRunOnLoad(jsRunOnLoad)
                                 .setIgnoreCertificateErrors(true)
                                 .build())

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -146,6 +146,8 @@ public final class TestBeanFactory {
                                 .setId(UUID.randomUUID())
                                 .setTriggeringEventName(TEST_EVENT + UUID.randomUUID().toString())
                                 .setUri(URI.create("http://" + UUID.randomUUID().toString().replace("-", "") + ".example.com"))
+                                .setTimeout(Duration.ofSeconds(123))
+                                .setJsRunOnLoad("some_javascript()")
                                 .setIgnoreCertificateErrors(true)
                                 .build())
                 .setSchedule(schedule);

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -129,6 +129,18 @@ public final class TestBeanFactory {
             default:
                 schedule = NeverSchedule.getInstance();
         }
+        final String jsRunOnLoad;
+        switch (RANDOM.nextInt(3)) {
+            case 2:
+                jsRunOnLoad = "";
+                break;
+            case 1:
+                jsRunOnLoad = "some_javascript()";
+                break;
+            case 0:
+            default:
+                jsRunOnLoad = "(() => {console.log({foo: 'bar', baz: new Quux()})})()";
+        }
         return new DefaultReport.Builder()
                 .setId(UUID.randomUUID())
                 .setETag(TEST_ETAG + UUID.randomUUID().toString())
@@ -146,8 +158,8 @@ public final class TestBeanFactory {
                                 .setId(UUID.randomUUID())
                                 .setTriggeringEventName(TEST_EVENT + UUID.randomUUID().toString())
                                 .setUri(URI.create("http://" + UUID.randomUUID().toString().replace("-", "") + ".example.com"))
-                                .setTimeout(Duration.ofSeconds(123))
-                                .setJsRunOnLoad("some_javascript()")
+                                .setTimeout(Duration.ofMillis((long)(10000 * RANDOM.nextFloat())))
+                                .setJsRunOnLoad(jsRunOnLoad)
                                 .setIgnoreCertificateErrors(true)
                                 .build())
                 .setSchedule(schedule);

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
@@ -237,6 +237,8 @@ public class DatabaseReportRepositoryIT {
                 new WebPageReportSource.Builder()
                         .setId(UUID.randomUUID())
                         .setTitle("Test title")
+                        .setTimeout(Duration.ofSeconds(123))
+                        .setJsRunOnLoad("some_javascript()")
                         .setTriggeringEventName("onload")
                         .setUri(URI.create("https://foo.test.com"));
 

--- a/test/java/models/view/ReportSerializationTest.java
+++ b/test/java/models/view/ReportSerializationTest.java
@@ -55,6 +55,8 @@ public final class ReportSerializationTest {
         expectedSource.setUri(URI.create("https://example.com"));
         expectedSource.setTitle("My Report Title");
         expectedSource.setIgnoreCertificateErrors(false);
+        expectedSource.setTimeout(Duration.ofSeconds(123));
+        expectedSource.setJsRunOnLoad("some_javascript()");
         expectedSource.setTriggeringEventName("myTriggeringEventName");
         expected.setSource(expectedSource);
 

--- a/test/resources/models/view/ReportSerializationTest.testValidReport.json
+++ b/test/resources/models/view/ReportSerializationTest.testValidReport.json
@@ -6,6 +6,8 @@
     "id": "22222222-2222-2222-2222-222222222222",
     "uri": "https://example.com",
     "title": "My Report Title",
+    "timeout": 123,
+    "jsRunOnLoad": "some_javascript()",
     "ignoreCertificateErrors": false,
     "triggeringEventName": "myTriggeringEventName"
   },


### PR DESCRIPTION
The ability to run JS on page-load is necessary to hook our reporting system into Grafana.

Having a timeout isn't necessary, merely prudent-seeming.