### PR TITLE
Fixed endTime inclusivity issue with rollup queries.

### DIFF
--- a/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
@@ -291,6 +291,7 @@ public class RollupGeneratorTest {
         assertEquals("metric_1h", hourlyQuery.getMetrics().get(0).getName());
         assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()).minus(RollupPeriod.HOURLY.periodCountToDuration(4)),
                 hourlyQuery.getStartTime());
+        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()), hourlyQuery.getEndTime().get());
 
         final LastDataPointMessage lastDataPointMessage1 = _probe.expectMsgClass(LastDataPointMessage.class);
         assertTrue(lastDataPointMessage1.isFailure());
@@ -360,7 +361,7 @@ public class RollupGeneratorTest {
         assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()).minus(RollupPeriod.HOURLY.periodCountToDuration(4)),
                 rollupQuery.getStartTime());
         assertTrue(rollupQuery.getEndTime().isPresent());
-        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()), rollupQuery.getEndTime().get());
+        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()).minusMillis(1), rollupQuery.getEndTime().get());
         assertEquals(1, rollupQuery.getMetrics().size());
         final Metric metric = rollupQuery.getMetrics().get(0);
         assertEquals(1, metric.getGroupBy().size());
@@ -434,7 +435,7 @@ public class RollupGeneratorTest {
         assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()).minus(RollupPeriod.HOURLY.periodCountToDuration(4)),
                 rollupQuery.getStartTime());
         assertTrue(rollupQuery.getEndTime().isPresent());
-        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()), rollupQuery.getEndTime().get());
+        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()).minusMillis(1), rollupQuery.getEndTime().get());
 
         _probe.expectNoMessage();
     }
@@ -493,7 +494,7 @@ public class RollupGeneratorTest {
         assertEquals("metric", rollupQuery.getMetrics().get(0).getName());
         assertEquals(lastDataPoint, rollupQuery.getStartTime());
         assertTrue(rollupQuery.getEndTime().isPresent());
-        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()), rollupQuery.getEndTime().get());
+        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()).minusMillis(1), rollupQuery.getEndTime().get());
 
         _probe.expectNoMessage();
     }
@@ -564,7 +565,7 @@ public class RollupGeneratorTest {
         assertEquals("metric", rollupQuery.getMetrics().get(0).getName());
         assertEquals(lastDataPoint, rollupQuery.getStartTime());
         assertTrue(rollupQuery.getEndTime().isPresent());
-        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()), rollupQuery.getEndTime().get());
+        assertEquals(RollupPeriod.HOURLY.recentEndTime(_clock.instant()).minusMillis(1), rollupQuery.getEndTime().get());
 
         _probe.expectNoMessage();
     }

--- a/test/java/com/arpnetworking/rollups/RollupPeriodTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupPeriodTest.java
@@ -17,6 +17,7 @@ package com.arpnetworking.rollups;
 
 import org.junit.Test;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import static org.junit.Assert.assertEquals;
@@ -28,12 +29,12 @@ public class RollupPeriodTest {
     @Test
     public void testRecentEndTimeMillis() {
         assertEquals(
-                Instant.parse("2019-01-30T05:00:00Z"),
-                RollupPeriod.HOURLY.nextPeriodStart(Instant.parse("2019-01-30T04:20:00Z")));
+                Instant.parse("2019-01-30T04:00:00Z"),
+                RollupPeriod.HOURLY.recentEndTime(Instant.parse("2019-01-30T04:20:00Z")));
 
         assertEquals(
-                Instant.parse("2019-01-31T00:00:00Z"),
-                RollupPeriod.DAILY.nextPeriodStart(Instant.parse("2019-01-30T04:20:00Z")));
+                Instant.parse("2019-01-30T00:00:00Z"),
+                RollupPeriod.DAILY.recentEndTime(Instant.parse("2019-01-30T04:20:00Z")));
     }
 
     @Test
@@ -45,5 +46,14 @@ public class RollupPeriodTest {
         assertEquals(
                 Instant.parse("2019-02-01T00:00:00Z"),
                 RollupPeriod.DAILY.nextPeriodStart(Instant.parse("2019-01-31T03:24:00Z")));
+    }
+
+    @Test
+    public void testPeriodCountToDuration() {
+        assertEquals(Duration.ofHours(4),
+                RollupPeriod.HOURLY.periodCountToDuration(4));
+
+        assertEquals(Duration.ofDays(4),
+                RollupPeriod.DAILY.periodCountToDuration(4));
     }
 }


### PR DESCRIPTION
There was an issue with rollups generating data for the next period due to the fact that endTime is inclusive for KairosDB. 

To fix this I did two things, first I exclude any future data points for the 'LastDatapoint' query by adding an endtime.  Second, I subtract one millisecond from the rollup query endtime so that we don't accidentally save a rollup for an incomplete period...