### PR TITLE
for ReportFormat#getMimeType, use real MediaType class instead of strings

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Maps;
+import com.google.common.net.MediaType;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.typesafe.config.Config;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -182,24 +184,36 @@ public final class ReportExecutionContext {
     @Inject
     public ReportExecutionContext(final Injector injector, final Environment environment, final Config config) {
         if (config.hasPath("reporting")) {
-            _renderers = this.<Renderer>loadMapMapObject(injector, environment, config.getObject("reporting.renderers"))
-                    .entrySet()
-                    .stream()
-                    .collect(ImmutableMap.toImmutableMap(
-                            e -> SourceType.valueOf(e.getKey()),
-                            Map.Entry::getValue
-                    ));
-            _senders = this.<Sender>loadMapObject(injector, environment, config.getObject("reporting.senders"))
-                    .entrySet()
-                    .stream()
-                    .collect(ImmutableMap.toImmutableMap(
-                            e -> RecipientType.valueOf(e.getKey()),
-                            Map.Entry::getValue
-                    ));
+            _renderers = transformMap(
+                    this.<Renderer>loadMapMapObject(injector, environment, config.getObject("reporting.renderers")),
+                    SourceType::valueOf,
+                    v -> transformMap(v, MediaType::parse, v2 -> v2)
+            );
+            _senders = transformMap(
+                    this.<Sender>loadMapObject(injector, environment, config.getObject("reporting.senders")),
+                    RecipientType::valueOf,
+                    v -> v
+            );
         } else {
             _renderers = ImmutableMap.of();
             _senders = ImmutableMap.of();
         }
+    }
+
+    // CHECKSTYLE.OFF: MethodTypeParameterNameCheck
+    private static <K1, K2, V1, V2> ImmutableMap<K2, V2> transformMap(
+            final Map<K1, V1> map,
+            final Function<K1, K2> k,
+            final Function<V1, V2> v
+    ) {
+    // CHECKSTYLE.ON: MethodTypeParameterNameCheck
+        return map
+                .entrySet()
+                .stream()
+                .collect(ImmutableMap.toImmutableMap(
+                        e -> k.apply(e.getKey()),
+                        e -> v.apply(e.getValue())
+                ));
     }
 
     /**
@@ -232,7 +246,7 @@ public final class ReportExecutionContext {
         ));
     }
 
-    private final ImmutableMap<SourceType, ImmutableMap<String, Renderer>> _renderers;
+    private final ImmutableMap<SourceType, ImmutableMap<MediaType, Renderer>> _renderers;
     private final ImmutableMap<RecipientType, Sender> _senders;
 
 }

--- a/app/models/internal/impl/HtmlReportFormat.java
+++ b/app/models/internal/impl/HtmlReportFormat.java
@@ -19,6 +19,7 @@ package models.internal.impl;
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.google.common.base.MoreObjects;
+import com.google.common.net.MediaType;
 import models.internal.reports.ReportFormat;
 
 /**
@@ -33,8 +34,8 @@ public final class HtmlReportFormat implements ReportFormat {
     private HtmlReportFormat(final Builder builder) {}
 
     @Override
-    public String getMimeType() {
-        return "text/html";
+    public MediaType getMimeType() {
+        return MediaType.HTML_UTF_8;
     }
 
     @Override

--- a/app/models/internal/impl/PdfReportFormat.java
+++ b/app/models/internal/impl/PdfReportFormat.java
@@ -19,6 +19,7 @@ package models.internal.impl;
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.google.common.base.MoreObjects;
+import com.google.common.net.MediaType;
 import models.internal.reports.ReportFormat;
 import net.sf.oval.constraint.Min;
 import net.sf.oval.constraint.NotNull;
@@ -43,8 +44,8 @@ public final class PdfReportFormat implements ReportFormat {
     }
 
     @Override
-    public String getMimeType() {
-        return "application/pdf";
+    public MediaType getMimeType() {
+        return MediaType.PDF;
     }
 
     /**

--- a/app/models/internal/reports/ReportFormat.java
+++ b/app/models/internal/reports/ReportFormat.java
@@ -16,6 +16,7 @@
 
 package models.internal.reports;
 
+import com.google.common.net.MediaType;
 import models.internal.impl.HtmlReportFormat;
 import models.internal.impl.PdfReportFormat;
 
@@ -31,7 +32,7 @@ public interface ReportFormat {
      *
      * @return The MIME type.
      */
-    String getMimeType();
+    MediaType getMimeType();
 
     /**
      * Applies a {@code Visitor} to this format. This should delegate the to the appropriate {@code Visitor#visit} overload.

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -117,7 +117,7 @@ public class ReportExecutionContextTest {
         _environment = Environment.simple();
 
         _config = ConfigFactory.parseMap(ImmutableMap.of(
-                "reporting.renderers.WEB_PAGE.\"text/html\".type", getClass().getName() + "$MockHtmlRenderer",
+                "reporting.renderers.WEB_PAGE.\"text/html; charset=utf-8\".type", getClass().getName() + "$MockHtmlRenderer",
                 "reporting.renderers.WEB_PAGE.\"application/pdf\".type", getClass().getName() + "$MockPdfRenderer",
                 "reporting.senders.EMAIL.type", getClass().getName() + "$MockEmailSender"
         ));
@@ -137,7 +137,7 @@ public class ReportExecutionContextTest {
         final ReportExecutionContext context = new ReportExecutionContext(
                 _injector,
                 _environment,
-                _config.withoutPath("reporting.renderers.WEB_PAGE.\"text/html\"")
+                _config.withoutPath("reporting.renderers.WEB_PAGE.\"text/html; charset=utf-8\"")
         );
         unwrapAsyncThrow(context.execute(EXAMPLE_REPORT, T0), IllegalArgumentException.class);
     }


### PR DESCRIPTION
Pros: avoiding string typing.

(Arguable) Cons: now must be very picky about string representations of media types (e.g. `text/html; charset=utf-8` instead of merely `text/html`).

I opine that that "con" isn't much of a con: HTML is a way of parsing _strings_, not _bytes_, and I'm actually kind of happy that this change forces greater specificity of how our content is byte-encoded.