### PR TITLE
have Renderer populate a builder rather than returning a full RenderedReport

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/RenderedReport.java
+++ b/app/com/arpnetworking/metrics/portal/reports/RenderedReport.java
@@ -16,13 +16,10 @@
 
 package com.arpnetworking.metrics.portal.reports;
 
-import com.arpnetworking.commons.builder.OvalBuilder;
 import models.internal.reports.ReportFormat;
-import net.sf.oval.constraint.NotNull;
 
 import java.io.InputStream;
 import java.time.Instant;
-import java.util.function.Function;
 
 /**
  * A document containing the results of a particular rendering of a particular {@link models.internal.reports.Report}.
@@ -64,22 +61,10 @@ public interface RenderedReport {
      *
      * Builder implementation that constructs {@code DefaultReport}.
      *
-     * @param <B>
-     * @param <S>
+     * @param <B> The concrete type of this builder.
+     * @param <R> The type of RenderedReport to build.
      */
-    abstract class Builder<B extends Builder<B, S>, S extends RenderedReport> extends OvalBuilder<S> {
-
-        protected Builder(final Function<B, S> targetConstructor) {
-            super(targetConstructor);
-        }
-
-        /**
-         * Called by setters to always return appropriate subclass of
-         * {@link Builder}, even from setters of base class.
-         *
-         * @return instance with correct {@link Builder} class type.
-         */
-        protected abstract B self();
+    interface Builder<B extends Builder<B, R>, R extends RenderedReport> extends com.arpnetworking.commons.builder.Builder<R> {
 
         /**
          * Set the report bytes. Required. Cannot be null.
@@ -87,10 +72,7 @@ public interface RenderedReport {
          * @param bytes The report bytes.
          * @return This instance of {@code Builder}.
          */
-        public B setBytes(final byte[] bytes) {
-            _bytes = bytes.clone();
-            return self();
-        }
+        B setBytes(byte[] bytes);
 
         /**
          * Set the report bytes. Required. Cannot be null.
@@ -98,10 +80,7 @@ public interface RenderedReport {
          * @param scheduledFor The report scheduledFor.
          * @return This instance of {@code Builder}.
          */
-        public B setScheduledFor(final Instant scheduledFor) {
-            _scheduledFor = scheduledFor;
-            return self();
-        }
+        B setScheduledFor(Instant scheduledFor);
 
         /**
          * Set the report generatedAt. Required. Cannot be null.
@@ -109,10 +88,7 @@ public interface RenderedReport {
          * @param generatedAt The report generatedAt.
          * @return This instance of {@code Builder}.
          */
-        public B setGeneratedAt(final Instant generatedAt) {
-            _generatedAt = generatedAt;
-            return self();
-        }
+        B setGeneratedAt(Instant generatedAt);
 
         /**
          * Set the report format. Required. Cannot be null.
@@ -120,34 +96,6 @@ public interface RenderedReport {
          * @param format The report format.
          * @return This instance of {@code Builder}.
          */
-        public B setFormat(final ReportFormat format) {
-            _format = format;
-            return self();
-        }
-
-        public byte[] getBytes() {
-            return _bytes;
-        }
-
-        public Instant getScheduledFor() {
-            return _scheduledFor;
-        }
-
-        public Instant getGeneratedAt() {
-            return _generatedAt;
-        }
-
-        public ReportFormat getFormat() {
-            return _format;
-        }
-
-        @NotNull
-        private byte[] _bytes;
-        @NotNull
-        private Instant _scheduledFor;
-        @NotNull
-        private Instant _generatedAt;
-        @NotNull
-        private ReportFormat _format;
+        B setFormat(ReportFormat format);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/RenderedReport.java
+++ b/app/com/arpnetworking/metrics/portal/reports/RenderedReport.java
@@ -16,10 +16,13 @@
 
 package com.arpnetworking.metrics.portal.reports;
 
+import com.arpnetworking.commons.builder.OvalBuilder;
 import models.internal.reports.ReportFormat;
+import net.sf.oval.constraint.NotNull;
 
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.function.Function;
 
 /**
  * A document containing the results of a particular rendering of a particular {@link models.internal.reports.Report}.
@@ -55,4 +58,96 @@ public interface RenderedReport {
      * @return The instant.
      */
     Instant getGeneratedAt();
+
+
+    /**
+     *
+     * Builder implementation that constructs {@code DefaultReport}.
+     *
+     * @param <B>
+     * @param <S>
+     */
+    abstract class Builder<B extends Builder<B, S>, S extends RenderedReport> extends OvalBuilder<S> {
+
+        protected Builder(final Function<B, S> targetConstructor) {
+            super(targetConstructor);
+        }
+
+        /**
+         * Called by setters to always return appropriate subclass of
+         * {@link Builder}, even from setters of base class.
+         *
+         * @return instance with correct {@link Builder} class type.
+         */
+        protected abstract B self();
+
+        /**
+         * Set the report bytes. Required. Cannot be null.
+         *
+         * @param bytes The report bytes.
+         * @return This instance of {@code Builder}.
+         */
+        public B setBytes(final byte[] bytes) {
+            _bytes = bytes.clone();
+            return self();
+        }
+
+        /**
+         * Set the report bytes. Required. Cannot be null.
+         *
+         * @param scheduledFor The report scheduledFor.
+         * @return This instance of {@code Builder}.
+         */
+        public B setScheduledFor(final Instant scheduledFor) {
+            _scheduledFor = scheduledFor;
+            return self();
+        }
+
+        /**
+         * Set the report generatedAt. Required. Cannot be null.
+         *
+         * @param generatedAt The report generatedAt.
+         * @return This instance of {@code Builder}.
+         */
+        public B setGeneratedAt(final Instant generatedAt) {
+            _generatedAt = generatedAt;
+            return self();
+        }
+
+        /**
+         * Set the report format. Required. Cannot be null.
+         *
+         * @param format The report format.
+         * @return This instance of {@code Builder}.
+         */
+        public B setFormat(final ReportFormat format) {
+            _format = format;
+            return self();
+        }
+
+        public byte[] getBytes() {
+            return _bytes;
+        }
+
+        public Instant getScheduledFor() {
+            return _scheduledFor;
+        }
+
+        public Instant getGeneratedAt() {
+            return _generatedAt;
+        }
+
+        public ReportFormat getFormat() {
+            return _format;
+        }
+
+        @NotNull
+        private byte[] _bytes;
+        @NotNull
+        private Instant _scheduledFor;
+        @NotNull
+        private Instant _generatedAt;
+        @NotNull
+        private ReportFormat _format;
+    }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/RenderedReport.java
+++ b/app/com/arpnetworking/metrics/portal/reports/RenderedReport.java
@@ -66,8 +66,7 @@ public interface RenderedReport {
 
 
     /**
-     *
-     * Builder implementation that constructs {@code DefaultReport}.
+     * Interface for Builders that construct {@link RenderedReport}s.
      *
      * @param <B> The concrete type of this builder.
      * @param <R> The type of RenderedReport to build.

--- a/app/com/arpnetworking/metrics/portal/reports/Renderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/Renderer.java
@@ -34,13 +34,15 @@ public interface Renderer<S extends ReportSource, F extends ReportFormat> {
      * Render a ReportSource.
      *
      * @param source The source to render.
+     * @param format The format to render into.
      * @param builder Will be used to construct a report. All implementations of {@code render} must call `setBytes()`.
      * @param <B> The type of builder provided.
      * @param <R> The type of report to generate.
      * @return A {@link CompletionStage} that completes when the report has been rendered.
      */
-    <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
+    <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
             S source,
-            RenderedReport.Builder<B, R> builder
+            F format,
+            B builder
     );
 }

--- a/app/com/arpnetworking/metrics/portal/reports/Renderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/Renderer.java
@@ -19,7 +19,6 @@ package com.arpnetworking.metrics.portal.reports;
 import models.internal.reports.ReportFormat;
 import models.internal.reports.ReportSource;
 
-import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -35,9 +34,13 @@ public interface Renderer<S extends ReportSource, F extends ReportFormat> {
      * Render a ReportSource.
      *
      * @param source The source to render.
-     * @param format The format to render into.
-     * @param scheduled The instant that the report-job was scheduled for.
-     * @return A CompletionStage that completes when the report has been rendered.
+     * @param builder Will be used to construct a report. All implementations of {@code render} must call `setBytes()`.
+     * @param <B> The type of builder provided.
+     * @param <R> The type of report to generate.
+     * @return A {@link CompletionStage} that completes when the report has been rendered.
      */
-    CompletionStage<RenderedReport> render(S source, F format, Instant scheduled);
+    <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
+            S source,
+            RenderedReport.Builder<B, R> builder
+    );
 }

--- a/app/com/arpnetworking/metrics/portal/reports/Renderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/Renderer.java
@@ -19,6 +19,7 @@ package com.arpnetworking.metrics.portal.reports;
 import models.internal.reports.ReportFormat;
 import models.internal.reports.ReportSource;
 
+import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -35,6 +36,7 @@ public interface Renderer<S extends ReportSource, F extends ReportFormat> {
      *
      * @param source The source to render.
      * @param format The format to render into.
+     * @param scheduled The instant that the report-job was scheduled for.
      * @param builder Will be used to construct a report. All implementations of {@code render} must call `setBytes()`.
      * @param <B> The type of builder provided.
      * @param <R> The type of report to generate.
@@ -43,6 +45,7 @@ public interface Renderer<S extends ReportSource, F extends ReportFormat> {
     <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
             S source,
             F format,
+            Instant scheduled,
             B builder
     );
 }

--- a/app/com/arpnetworking/metrics/portal/reports/Renderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/Renderer.java
@@ -39,10 +39,9 @@ public interface Renderer<S extends ReportSource, F extends ReportFormat> {
      * @param scheduled The instant that the report-job was scheduled for.
      * @param builder Will be used to construct a report. All implementations of {@code render} must call `setBytes()`.
      * @param <B> The type of builder provided.
-     * @param <R> The type of report to generate.
      * @return A {@link CompletionStage} that completes when the report has been rendered.
      */
-    <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
+    <B extends RenderedReport.Builder<B, ?>> CompletionStage<B> render(
             S source,
             F format,
             Instant scheduled,

--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
@@ -115,7 +115,7 @@ public final class ReportExecutionContext {
                 .stream()
                 .map(format ->
                         getRenderer(report.getSource(), format)
-                        .render(report.getSource(), format, new DefaultRenderedReport.Builder()
+                        .render(report.getSource(), format, scheduled, new DefaultRenderedReport.Builder()
                                 .setReport(report)
                                 .setFormat(format)
                                 .setGeneratedAt(_clock.instant())

--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
@@ -74,7 +74,7 @@ public final class ReportExecutionContext {
             verifyDependencies(report);
             return null;
         }).thenCompose(nothing ->
-                renderAll(formatToRecipients.keySet(), report.getSource(), scheduled)
+                renderAll(formatToRecipients.keySet(), report, scheduled)
         ).thenCompose(formatToRendered ->
                 sendAll(report, recipientToFormats, formatToRendered, scheduled)
         ).thenApply(nothing ->
@@ -107,15 +107,16 @@ public final class ReportExecutionContext {
      */
     /* package private */ CompletionStage<ImmutableMap<ReportFormat, RenderedReport>> renderAll(
             final ImmutableSet<ReportFormat> formats,
-            final ReportSource source,
+            final Report report,
             final Instant scheduled
     ) {
         final Map<ReportFormat, RenderedReport> result = Maps.newConcurrentMap();
         final CompletableFuture<?>[] resultSettingFutures = formats
                 .stream()
                 .map(format ->
-                        getRenderer(source, format)
-                        .render(source, new DefaultRenderedReport.Builder()
+                        getRenderer(report.getSource(), format)
+                        .render(report.getSource(), format, new DefaultRenderedReport.Builder()
+                                .setReport(report)
                                 .setFormat(format)
                                 .setGeneratedAt(_clock.instant())
                                 .setScheduledFor(scheduled))

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletionStage;
     protected abstract byte[] getPageContent(WebPageReportSource source, F format, Object todo);
 
     @Override
-    public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
+    public <B extends RenderedReport.Builder<B, ?>> CompletionStage<B> render(
             final WebPageReportSource source,
             final F format,
             final Instant scheduled,

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
@@ -34,9 +34,10 @@ import java.util.concurrent.CompletionStage;
     protected abstract byte[] getPageContent(WebPageReportSource source, F format, Object todo);
 
     @Override
-    public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
+    public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
             final WebPageReportSource source,
-            final RenderedReport.Builder<B, R> builder
+            final F format,
+            final B builder
     ) {
         return CompletableFuture.completedFuture(
                 builder.setBytes(new byte[0])// TODO(spencerpearson)

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
@@ -18,11 +18,9 @@ package com.arpnetworking.metrics.portal.reports.impl.chrome;
 
 import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.arpnetworking.metrics.portal.reports.Renderer;
-import models.internal.impl.DefaultRenderedReport;
 import models.internal.impl.WebPageReportSource;
 import models.internal.reports.ReportFormat;
 
-import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -36,16 +34,12 @@ import java.util.concurrent.CompletionStage;
     protected abstract byte[] getPageContent(WebPageReportSource source, F format, Object todo);
 
     @Override
-    public CompletionStage<RenderedReport> render(
+    public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
             final WebPageReportSource source,
-            final F format,
-            final Instant scheduled
+            final RenderedReport.Builder<B, R> builder
     ) {
-        return CompletableFuture.completedFuture(new DefaultRenderedReport.Builder()
-                .setScheduledFor(scheduled)
-                .setGeneratedAt(Instant.now())
-                .setFormat(format)
-                .build()  // TODO(spencerpearson)
+        return CompletableFuture.completedFuture(
+                builder.setBytes(new byte[0])// TODO(spencerpearson)
         );
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
@@ -21,6 +21,7 @@ import com.arpnetworking.metrics.portal.reports.Renderer;
 import models.internal.impl.WebPageReportSource;
 import models.internal.reports.ReportFormat;
 
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -37,6 +38,7 @@ import java.util.concurrent.CompletionStage;
     public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
             final WebPageReportSource source,
             final F format,
+            final Instant scheduled,
             final B builder
     ) {
         return CompletableFuture.completedFuture(

--- a/app/models/internal/impl/DefaultRenderedReport.java
+++ b/app/models/internal/impl/DefaultRenderedReport.java
@@ -16,10 +16,12 @@
 
 package models.internal.impl;
 
+import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.google.common.base.MoreObjects;
 import models.internal.reports.ReportFormat;
+import net.sf.oval.constraint.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -87,10 +89,10 @@ public final class DefaultRenderedReport implements RenderedReport {
     }
 
     private DefaultRenderedReport(final Builder builder) {
-        _bytes = builder.getBytes();
-        _scheduledFor = builder.getScheduledFor();
-        _generatedAt = builder.getGeneratedAt();
-        _format = builder.getFormat();
+        _bytes = builder._bytes;
+        _scheduledFor = builder._scheduledFor;
+        _generatedAt = builder._generatedAt;
+        _format = builder._format;
     }
 
     private final byte[] _bytes;
@@ -101,7 +103,9 @@ public final class DefaultRenderedReport implements RenderedReport {
     /**
      * Builder implementation that constructs {@code DefaultReport}.
      */
-    public static final class Builder extends RenderedReport.Builder<Builder, DefaultRenderedReport> {
+    public static final class Builder
+            extends OvalBuilder<DefaultRenderedReport>
+            implements RenderedReport.Builder<Builder, DefaultRenderedReport> {
         /**
          * Public Constructor.
          */
@@ -109,9 +113,57 @@ public final class DefaultRenderedReport implements RenderedReport {
             super(DefaultRenderedReport::new);
         }
 
-        @Override
-        protected Builder self() {
+        /**
+         * Set the report bytes. Required. Cannot be null.
+         *
+         * @param bytes The report bytes.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setBytes(final byte[] bytes) {
+            _bytes = bytes.clone();
             return this;
         }
+
+        /**
+         * Set the report bytes. Required. Cannot be null.
+         *
+         * @param scheduledFor The report scheduledFor.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setScheduledFor(final Instant scheduledFor) {
+            _scheduledFor = scheduledFor;
+            return this;
+        }
+
+        /**
+         * Set the report generatedAt. Required. Cannot be null.
+         *
+         * @param generatedAt The report generatedAt.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setGeneratedAt(final Instant generatedAt) {
+            _generatedAt = generatedAt;
+            return this;
+        }
+
+        /**
+         * Set the report format. Required. Cannot be null.
+         *
+         * @param format The report format.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setFormat(final ReportFormat format) {
+            _format = format;
+            return this;
+        }
+
+        @NotNull
+        private byte[] _bytes;
+        @NotNull
+        private Instant _scheduledFor;
+        @NotNull
+        private Instant _generatedAt;
+        @NotNull
+        private ReportFormat _format;
     }
 }

--- a/app/models/internal/impl/DefaultRenderedReport.java
+++ b/app/models/internal/impl/DefaultRenderedReport.java
@@ -16,12 +16,10 @@
 
 package models.internal.impl;
 
-import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.google.common.base.MoreObjects;
 import models.internal.reports.ReportFormat;
-import net.sf.oval.constraint.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -89,10 +87,10 @@ public final class DefaultRenderedReport implements RenderedReport {
     }
 
     private DefaultRenderedReport(final Builder builder) {
-        _bytes = builder._bytes;
-        _scheduledFor = builder._scheduledFor;
-        _generatedAt = builder._generatedAt;
-        _format = builder._format;
+        _bytes = builder.getBytes();
+        _scheduledFor = builder.getScheduledFor();
+        _generatedAt = builder.getGeneratedAt();
+        _format = builder.getFormat();
     }
 
     private final byte[] _bytes;
@@ -103,7 +101,7 @@ public final class DefaultRenderedReport implements RenderedReport {
     /**
      * Builder implementation that constructs {@code DefaultReport}.
      */
-    public static final class Builder extends OvalBuilder<DefaultRenderedReport> {
+    public static final class Builder extends RenderedReport.Builder<Builder, DefaultRenderedReport> {
         /**
          * Public Constructor.
          */
@@ -111,57 +109,9 @@ public final class DefaultRenderedReport implements RenderedReport {
             super(DefaultRenderedReport::new);
         }
 
-        /**
-         * Set the report bytes. Required. Cannot be null.
-         *
-         * @param bytes The report bytes.
-         * @return This instance of {@code Builder}.
-         */
-        public Builder setBytes(final byte[] bytes) {
-            _bytes = bytes.clone();
+        @Override
+        protected Builder self() {
             return this;
         }
-
-        /**
-         * Set the report bytes. Required. Cannot be null.
-         *
-         * @param scheduledFor The report scheduledFor.
-         * @return This instance of {@code Builder}.
-         */
-        public Builder setScheduledFor(final Instant scheduledFor) {
-            _scheduledFor = scheduledFor;
-            return this;
-        }
-
-        /**
-         * Set the report generatedAt. Required. Cannot be null.
-         *
-         * @param generatedAt The report generatedAt.
-         * @return This instance of {@code Builder}.
-         */
-        public Builder setGeneratedAt(final Instant generatedAt) {
-            _generatedAt = generatedAt;
-            return this;
-        }
-
-        /**
-         * Set the report format. Required. Cannot be null.
-         *
-         * @param format The report format.
-         * @return This instance of {@code Builder}.
-         */
-        public Builder setFormat(final ReportFormat format) {
-            _format = format;
-            return this;
-        }
-
-        @NotNull
-        private byte[] _bytes;
-        @NotNull
-        private Instant _scheduledFor;
-        @NotNull
-        private Instant _generatedAt;
-        @NotNull
-        private ReportFormat _format;
     }
 }

--- a/test/java/com/arpnetworking/metrics/portal/reports/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/EmailSenderTest.java
@@ -53,7 +53,7 @@ public class EmailSenderTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        _sender = new EmailSender(_mailer, ConfigFactory.parseMap(ImmutableMap.of(
+        _sender = new EmailSender(ConfigFactory.parseMap(ImmutableMap.of(
                 "type", "com.arpnetworking.metrics.portal.reports.impl.EmailSender",
                 "fromAddress", "me@invalid.net"
         )));

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -262,6 +262,7 @@ public class ReportExecutionContextTest {
         public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
                 final WebPageReportSource source,
                 final HtmlReportFormat format,
+                final Instant scheduled,
                 final B builder
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));
@@ -273,6 +274,7 @@ public class ReportExecutionContextTest {
         public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
                 final WebPageReportSource source,
                 final PdfReportFormat format,
+                final Instant scheduled,
                 final B builder
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -259,9 +259,10 @@ public class ReportExecutionContextTest {
 
     private static final class MockHtmlRenderer implements Renderer<WebPageReportSource, HtmlReportFormat> {
         @Override
-        public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
+        public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
                 final WebPageReportSource source,
-                final RenderedReport.Builder<B, R> builder
+                final HtmlReportFormat format,
+                final B builder
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));
         }
@@ -269,9 +270,10 @@ public class ReportExecutionContextTest {
 
     private static final class MockPdfRenderer implements Renderer<WebPageReportSource, PdfReportFormat> {
         @Override
-        public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
+        public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
                 final WebPageReportSource source,
-                final RenderedReport.Builder<B, R> builder
+                final PdfReportFormat format,
+                final B builder
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));
         }

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -250,8 +250,8 @@ public class ReportExecutionContextTest {
     private static final class MockHtmlRenderer implements Renderer<WebPageReportSource, HtmlReportFormat> {
         @Override
         public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
-                WebPageReportSource source,
-                RenderedReport.Builder<B, R> builder
+                final WebPageReportSource source,
+                final RenderedReport.Builder<B, R> builder
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));
         }
@@ -260,8 +260,8 @@ public class ReportExecutionContextTest {
     private static final class MockPdfRenderer implements Renderer<WebPageReportSource, PdfReportFormat> {
         @Override
         public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<RenderedReport.Builder<B, R>> render(
-                WebPageReportSource source,
-                RenderedReport.Builder<B, R> builder
+                final WebPageReportSource source,
+                final RenderedReport.Builder<B, R> builder
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));
         }

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -259,7 +259,7 @@ public class ReportExecutionContextTest {
 
     private static final class MockHtmlRenderer implements Renderer<WebPageReportSource, HtmlReportFormat> {
         @Override
-        public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
+        public <B extends RenderedReport.Builder<B, ?>> CompletionStage<B> render(
                 final WebPageReportSource source,
                 final HtmlReportFormat format,
                 final Instant scheduled,
@@ -271,7 +271,7 @@ public class ReportExecutionContextTest {
 
     private static final class MockPdfRenderer implements Renderer<WebPageReportSource, PdfReportFormat> {
         @Override
-        public <B extends RenderedReport.Builder<B, R>, R extends RenderedReport> CompletionStage<B> render(
+        public <B extends RenderedReport.Builder<B, ?>> CompletionStage<B> render(
                 final WebPageReportSource source,
                 final PdfReportFormat format,
                 final Instant scheduled,


### PR DESCRIPTION
This avoids forcing every implementation to contain the boilerplate `new DefaultRenderedReport.Builder().setFormat(format).setGeneratedAt(Instant.now()).setScheduledFor(scheduled)`.

Implemented by:
- moving `DefaultRenderedReport.Builder` to `RenderedReport.Builder`
- add `RenderedReport.Builder` argument to `Renderer#render`
- dependency-injecting a `Clock` into `ReportExecutionContext` since it now needs to be able to compute `now()`
