### PR TITLE
make EmailSender take lazily instantiated Mailer

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
@@ -116,12 +116,23 @@ public class EmailSender implements Sender {
      */
     @Inject
     public EmailSender(@Assisted final Config config) {
+        this(
+                MailerBuilder
+                        .withSMTPServer(
+                                config.hasPath("smtp.host") ? config.getString("smtp.host") : "localhost",
+                                config.hasPath("smtp.port") ? config.getInt("smtp.port") : 25
+                        )
+                        .buildMailer(),
+                config
+        );
+    }
+
+    /**
+     * Constructor for tests, allowing dependency injection of the {@link Mailer}.
+     */
+    /* package private */ EmailSender(final Mailer mailer, final Config config) {
         _fromAddress = config.getString("fromAddress");
-        final String host = config.hasPath("smtp.host") ? config.getString("smtp.host") : "localhost";
-        final Integer port = config.hasPath("smtp.port") ? config.getInt("smtp.port") : 25;
-        _mailer = MailerBuilder
-                .withSMTPServer(host, port)
-                .buildMailer();
+        _mailer = mailer;
     }
 
     private final Mailer _mailer;

--- a/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
@@ -20,7 +20,6 @@ import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.arpnetworking.metrics.portal.reports.Sender;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 import com.google.common.net.MediaType;
@@ -43,7 +42,6 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 
 /**
  * Sends reports over email.
@@ -91,7 +89,7 @@ public class EmailSender implements Sender {
                 .addData("recipient", recipient)
                 .log();
 
-        _mailer.get().sendMail(builder.buildEmail());
+        _mailer.sendMail(builder.buildEmail());
     }
 
     private String getSubject(final Report report, final Instant scheduled) {
@@ -118,13 +116,13 @@ public class EmailSender implements Sender {
      */
     @Inject
     public EmailSender(@Assisted final Config config) {
-        this(Suppliers.memoize(() -> buildMailer(config)), config);
+        this(buildMailer(config), config);
     }
 
     /**
      * Constructor for tests, allowing dependency injection of the {@link Mailer}.
      */
-    /* package private */ EmailSender(final Supplier<Mailer> mailer, final Config config) {
+    /* package private */ EmailSender(final Mailer mailer, final Config config) {
         _fromAddress = config.getString("fromAddress");
         _mailer = mailer;
     }
@@ -138,7 +136,7 @@ public class EmailSender implements Sender {
                 .buildMailer();
     }
 
-    private final Supplier<Mailer> _mailer;
+    private final Mailer _mailer;
     private final String _fromAddress;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailSender.class);

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -53,7 +53,7 @@ public class EmailSenderTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        _sender = new EmailSender(() -> _mailer, ConfigFactory.parseMap(ImmutableMap.of(
+        _sender = new EmailSender(_mailer, ConfigFactory.parseMap(ImmutableMap.of(
                 "type", "com.arpnetworking.metrics.portal.reports.impl.EmailSender",
                 "fromAddress", "me@invalid.net"
         )));

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -53,7 +53,7 @@ public class EmailSenderTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        _sender = new EmailSender(ConfigFactory.parseMap(ImmutableMap.of(
+        _sender = new EmailSender(() -> _mailer, ConfigFactory.parseMap(ImmutableMap.of(
                 "type", "com.arpnetworking.metrics.portal.reports.impl.EmailSender",
                 "fromAddress", "me@invalid.net"
         )));

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.arpnetworking.metrics.portal.reports;
+package com.arpnetworking.metrics.portal.reports.impl;
 
 import com.arpnetworking.metrics.portal.TestBeanFactory;
-import com.arpnetworking.metrics.portal.reports.impl.EmailSender;
+import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.ConfigFactory;
 import models.internal.impl.HtmlReportFormat;

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/package-info.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.arpnetworking.metrics.portal.reports.impl;
+
+import com.arpnetworking.commons.javax.annotation.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
I'm not sure how the email branch was green in CI -- after its merge, master has build errors.

`EmailSender` needs to have a `Mailer` dependency-injected into it, or else running the tests will try to make real-life SMTP connections. I've made it a lazily instantiated Mailer in order to avoid making connections before any reports actually need sending.