### PR TITLE
Make rollup value snap to the start of the period rather than end.

### DIFF
--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -325,7 +325,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
                                         .setUnit(message.getPeriod().getSamplingUnit())
                                         .build())
                         .setAlignSampling(true)
-                        .setAlignEndTime(true)
+                        .setAlignStartTime(true)
                         .build(),
                 new Aggregator.Builder()
                         .setName("save_as")

--- a/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
@@ -371,9 +371,9 @@ public class RollupGeneratorTest {
         assertEquals("merge", metric.getAggregators().get(0).getName());
         assertTrue(metric.getAggregators().get(0).getAlignSampling().isPresent());
         assertTrue(metric.getAggregators().get(0).getAlignSampling().get());
-        assertTrue(metric.getAggregators().get(0).getAlignEndTime().isPresent());
-        assertTrue(metric.getAggregators().get(0).getAlignEndTime().get());
-        assertFalse(metric.getAggregators().get(0).getAlignStartTime().isPresent());
+        assertTrue(metric.getAggregators().get(0).getAlignStartTime().isPresent());
+        assertTrue(metric.getAggregators().get(0).getAlignStartTime().get());
+        assertFalse(metric.getAggregators().get(0).getAlignEndTime().isPresent());
         assertTrue(metric.getAggregators().get(0).getSampling().isPresent());
         assertEquals(1L, metric.getAggregators().get(0).getSampling().get().getValue());
         assertEquals(SamplingUnit.HOURS, metric.getAggregators().get(0).getSampling().get().getUnit());


### PR DESCRIPTION
The rollups were having their datapoints snapped to the end of the time period.  This is inconsistent with grafana's default to have the datapoint snapped to the start of the period.  I switched to using alignStartTime to fix the inconsistency.