### PR TITLE
Added period based chunking, fixed period evaluation bug and added count aggregator to rollup query.

### DIFF
--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -73,11 +73,11 @@ public class RollupGenerator extends AbstractActorWithTimers {
     /**
      * RollupGenerator actor constructor.
      *
-     * @param configuration    play configuration
+     * @param configuration play configuration
      * @param metricsDiscovery actor ref to metrics discovery actor
-     * @param kairosDbClient   kairosdb client
-     * @param clock            clock to use for time calculations
-     * @param metrics          periodic metrics instance
+     * @param kairosDbClient kairosdb client
+     * @param clock clock to use for time calculations
+     * @param metrics periodic metrics instance
      */
     @Inject
     public RollupGenerator(
@@ -320,7 +320,8 @@ public class RollupGenerator extends AbstractActorWithTimers {
         if (!message.getTags().isEmpty()) {
             metricBuilder.setGroupBy(ImmutableList.of(
                     new MetricsQuery.GroupBy.Builder()
-                            .setName("tag").addOtherArg("tags", message.getTags())
+                            .setName("tag")
+                            .addOtherArg("tags", message.getTags())
                             .build()
             ));
         }

--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -35,7 +35,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.time.Clock;

--- a/app/com/arpnetworking/rollups/RollupPeriod.java
+++ b/app/com/arpnetworking/rollups/RollupPeriod.java
@@ -42,13 +42,23 @@ public enum RollupPeriod {
     }
 
     /**
-     * Calculates the most recent period aligned time relative to the instant provided.
+     * Calculates the most recent period end aligned time relative to the instant provided.
      *
      * @param time instant to use when calculating recent end time
      * @return most recent end time for supplied instant
      */
     public Instant recentEndTime(final Instant time) {
         return time.truncatedTo(_truncationUnit);
+    }
+
+    /**
+     * Calculates the most recent period start aligned time relative to the instant provided.
+     *
+     * @param time instant to use when calculating recent start time
+     * @return most recent end time for supplied instant
+     */
+    public Instant recentStartTime(final Instant time) {
+        return recentEndTime(time).minus(1, _truncationUnit);
     }
 
     /**


### PR DESCRIPTION
This addresses a few issues with rollups:

1. Backfills could be expensive because multiple periods would try to be rolled up in a single saveas query.  This was addressed by chunking the saveAs queries into one query per period.

2. When the saveAs was moved to save data at the startTime there was a mismatch with how the calculations were made to determine if a rollup needed to occur.  Previously we checked against the end of the most recently closed period, now we check against the start of the most recently closed period.

3. The saveAs query could return a sizable payload for histograms.  This is because saveAs is done through the normal query mechanism and simply passes the datapoints that were saved back to the caller.  In the case of histograms this would be the entire serialized histogram.  By adding a 'count' aggregator after the saveAs we now get a single datapoint per tag combination.