### PR TITLE
add missing email-sending dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,6 @@
         <configuration>
           <ignoredDependencies combine.children="append">
             <ignoredDependency>com.typesafe.play:play-java_${scala.package.version}:jar:*</ignoredDependency>
-            <ignoredDependency>net.markenwerk:utils-mail-dkim:jar:1.1.12</ignoredDependency>
           </ignoredDependencies>
         </configuration>
       </plugin>
@@ -748,6 +747,7 @@
       <groupId>net.markenwerk</groupId>
       <artifactId>utils-mail-dkim</artifactId>
       <version>${dkimutils.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@
         <configuration>
           <ignoredDependencies combine.children="append">
             <ignoredDependency>com.typesafe.play:play-java_${scala.package.version}:jar:*</ignoredDependency>
+            <ignoredDependency>net.markenwerk:utils-mail-dkim:jar:1.1.12</ignoredDependency>
           </ignoredDependencies>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -746,12 +746,6 @@
       <artifactId>utils-mail-dkim</artifactId>
       <version>1.1.12</version>
     </dependency>
-    <dependency>
-      <groupId>com.github.kirviq</groupId>
-      <artifactId>dumbster</artifactId>
-      <version>1.7.1</version>
-      <scope>test</scope>
-    </dependency>
 
 
     <!-- Akka -->
@@ -1146,6 +1140,12 @@
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
       <version>${thrift.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.kirviq</groupId>
+      <artifactId>dumbster</artifactId>
+      <version>1.7.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <chrisomeara.pillar.version>2.3.0</chrisomeara.pillar.version>
     <commons.codec.version>1.10</commons.codec.version>
     <dkimutils.version>1.1.12</dkimutils.version>
+    <dumbster.version>1.7.1</dumbster.version>
     <ebean.version>11.15.4</ebean.version>
     <ebean.annotation.version>3.11</ebean.annotation.version>
     <ebean.api.version>2.2.1</ebean.api.version>
@@ -1148,7 +1149,7 @@
     <dependency>
       <groupId>com.github.kirviq</groupId>
       <artifactId>dumbster</artifactId>
-      <version>1.7.1</version>
+      <version>${dumbster.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <cglib.version>3.2.1</cglib.version>
     <chrisomeara.pillar.version>2.3.0</chrisomeara.pillar.version>
     <commons.codec.version>1.10</commons.codec.version>
+    <dkimutils.version>1.1.12</dkimutils.version>
     <ebean.version>11.15.4</ebean.version>
     <ebean.annotation.version>3.11</ebean.annotation.version>
     <ebean.api.version>2.2.1</ebean.api.version>
@@ -116,6 +117,7 @@
     <scala.version>2.11.12</scala.version>
     <scala.java8.version>0.8.0</scala.java8.version>
     <scala.xml.version>1.0.6</scala.xml.version>
+    <simplejavamail.version>5.1.7</simplejavamail.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs.annotations.version>3.1.12</spotbugs.annotations.version>
     <twirl.api.version>1.3.14</twirl.api.version>
@@ -740,12 +742,12 @@
     <dependency>
       <groupId>org.simplejavamail</groupId>
       <artifactId>simple-java-mail</artifactId>
-      <version>5.0.0</version>
+      <version>${simplejavamail.version}</version>
     </dependency>
     <dependency>
       <groupId>net.markenwerk</groupId>
       <artifactId>utils-mail-dkim</artifactId>
-      <version>1.1.12</version>
+      <version>${dkimutils.version}</version>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -741,6 +741,18 @@
       <artifactId>simple-java-mail</artifactId>
       <version>5.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>net.markenwerk</groupId>
+      <artifactId>utils-mail-dkim</artifactId>
+      <version>1.1.12</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.kirviq</groupId>
+      <artifactId>dumbster</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
+
 
     <!-- Akka -->
     <dependency>

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -20,20 +20,14 @@ import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.dumbster.smtp.SimpleSmtpServer;
 import com.dumbster.smtp.SmtpMessage;
 import com.google.common.collect.ImmutableMap;
-import com.sun.mail.util.MailConnectException;
 import com.typesafe.config.ConfigFactory;
 import models.internal.TimeRange;
 import models.internal.impl.HtmlReportFormat;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.simplejavamail.MailException;
-import org.simplejavamail.email.Email;
 import org.simplejavamail.mailer.Mailer;
 import org.simplejavamail.mailer.MailerBuilder;
 
@@ -82,7 +76,7 @@ public class EmailSenderTest {
                 ImmutableMap.of(report.getFormat(), report)
         ).toCompletableFuture().get();
 
-        List<SmtpMessage> emails = _server.getReceivedEmails();
+        final List<SmtpMessage> emails = _server.getReceivedEmails();
         Assert.assertEquals(1, emails.size());
         final SmtpMessage email = emails.get(0);
 
@@ -118,7 +112,7 @@ public class EmailSenderTest {
     }
 
     private static int getFreePort() throws IOException {
-        try (final ServerSocket socket = new ServerSocket(0)) {
+        try (ServerSocket socket = new ServerSocket(0)) {
             socket.setReuseAddress(true);
             return socket.getLocalPort();
         }


### PR DESCRIPTION
Apparently `simplejavamail` has a sneaky dependency on `net.markenwerk.utils.mail.dkim`. I pulled it in, and added a mock SMTP server library for testing, so that messages actually get sent through `simplejavamail` instead of it being mocked out the whole time. (Maybe this should be an integration test? It seems conceptually very similar to using WireMock, so I made it a unit test.)