### PR TITLE
Fixed issue with rollup override (_!) not returning tags.

### DIFF
--- a/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
+++ b/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
@@ -57,7 +57,8 @@ public class KairosDbServiceImpl implements KairosDbService {
 
 
     /**
-     * Public constructor. *
+     * Public constructor.
+     *
      * @param kairosDbClient Client to use to make requests to backend kairosdb
      * @param metricsFactory MetricsFactory instance for recording service metrics
      */
@@ -226,6 +227,7 @@ public class KairosDbServiceImpl implements KairosDbService {
                         .setName(metricName.substring(0, metricName.length() - 2))
                         .build();
             } else {
+                metrics.incrementCounter("kairosService/useRollups/bypass", 0);
                 final ImmutableList<String> filteredMetrics = filterMetricNames(metricNames, Optional.of(metricName), false);
                 final List<String> rollupMetrics = filteredMetrics
                         .stream()

--- a/app/controllers/KairosDbProxyController.java
+++ b/app/controllers/KairosDbProxyController.java
@@ -124,7 +124,14 @@ public class KairosDbProxyController extends Controller {
      * @return Proxied queryTags response.
      */
     public CompletionStage<Result> queryTags() {
-        return proxy();
+        try {
+            final MetricsQuery metricsQuery = _mapper.treeToValue(request().body().asJson(), MetricsQuery.class);
+            return _kairosService.queryMetricTags(metricsQuery)
+                    .<JsonNode>thenApply(_mapper::valueToTree)
+                    .thenApply(Results::ok);
+        } catch (final IOException e) {
+            return CompletableFuture.completedFuture(Results.internalServerError(e.getMessage()));
+        }
     }
 
     /**

--- a/test/java/com/arpnetworking/kairos/service/KairosDbServiceImplTest.java
+++ b/test/java/com/arpnetworking/kairos/service/KairosDbServiceImplTest.java
@@ -80,6 +80,32 @@ public class KairosDbServiceImplTest {
     }
 
     @Test
+    public void testFiltersRollupOverrideForTagsQueries() throws Exception {
+        when(_mockClient.queryMetricTags(any())).thenReturn(
+                CompletableFuture.completedFuture(
+                        OBJECT_MAPPER.readValue(
+                                readResource("testFiltersRollupOverrideForTagsQueries.backend_response"),
+                                MetricsQueryResponse.class)
+                )
+        );
+
+        _service.queryMetricTags(
+                OBJECT_MAPPER.readValue(
+                        readResource("testFiltersRollupOverrideForTagsQueries.request"),
+                        MetricsQuery.class)
+        );
+
+        final ArgumentCaptor<MetricsQuery> captor = ArgumentCaptor.forClass(MetricsQuery.class);
+        verify(_mockClient, times(1)).queryMetricTags(captor.capture());
+        final MetricsQuery request = captor.getValue();
+        assertEquals(Instant.ofEpochMilli(0), request.getStartTime());
+        assertEquals(1, request.getMetrics().size());
+        final Metric metric = request.getMetrics().get(0);
+        assertEquals("foo", metric.getName());
+    }
+
+
+    @Test
     public void testFiltersRollupMetrics() throws Exception {
         final CompletionStage<KairosMetricNamesQueryResponse> future = _service.queryMetricNames(Optional.empty(), true);
         final KairosMetricNamesQueryResponse response = future.toCompletableFuture().get();

--- a/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testFiltersRollupOverrideForTagsQueries.backend_response.json
+++ b/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testFiltersRollupOverrideForTagsQueries.backend_response.json
@@ -1,0 +1,11 @@
+{
+  "queries": [
+    {
+      "results": [{
+        "name": "foo_1h",
+        "values": [],
+        "tags": {}
+      }]
+    }
+  ]
+}

--- a/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testFiltersRollupOverrideForTagsQueries.request.json
+++ b/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testFiltersRollupOverrideForTagsQueries.request.json
@@ -1,0 +1,9 @@
+{
+  "start_absolute": 0,
+  "metrics": [
+    {
+      "name": "foo_!",
+      "tags": {}
+    }
+  ]
+}

--- a/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testSelectsRollupMetricsBasedOnAggregate.backend_response.json
+++ b/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testSelectsRollupMetricsBasedOnAggregate.backend_response.json
@@ -1,11 +1,40 @@
 {
   "queries": [
     {
-      "results": [{
-        "name": "foo_1h",
-        "values": [],
-        "tags": {}
-      }]
+      "results": [
+        {
+          "name": "foo",
+          "tags": {
+            "browser_name": [
+              "Chrome",
+              "Firefox",
+              "Internet Explorer",
+              "Opera",
+              "Safari"
+            ],
+            "office_ip": [
+              "False",
+              "True"
+            ],
+            "os_name": [
+              "ChromeOS",
+              "Linux",
+              "Mac",
+              "Windows"
+            ],
+            "region": [
+              "Africa",
+              "Asia",
+              "Europe",
+              "Latin America and the Caribbean",
+              "Northern America",
+              "Oceania",
+              "unknown"
+            ]
+          },
+          "values": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
In grafana, if you tried to use the rollup override suffix you'd get no tags back as it wasn't a valid metric name.  This modifies the proxy to remove the _! suffix if it sees it on a queryMetricTags request.