### PR TITLE
improve logging for time-related stuff

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.scheduling;
 
+import com.arpnetworking.logback.annotations.Loggable;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
@@ -34,6 +35,7 @@ import java.util.concurrent.CompletionStage;
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
+@Loggable
 public final class CachedJob<T> implements Job<T> {
     private final JobRef<T> _ref;
     private final PeriodicMetrics _periodicMetrics;

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
@@ -15,6 +15,8 @@
  */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
+import com.arpnetworking.logback.annotations.Loggable;
+
 import java.time.Instant;
 import java.util.Optional;
 
@@ -23,6 +25,7 @@ import java.util.Optional;
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
+@Loggable
 public final class NeverSchedule extends BaseSchedule {
 
     /**

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/OneOffSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/OneOffSchedule.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
+import com.arpnetworking.logback.annotations.Loggable;
 import com.google.common.base.MoreObjects;
 
 import java.time.Instant;
@@ -25,6 +26,7 @@ import java.util.Optional;
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
+@Loggable
 public final class OneOffSchedule extends BaseSchedule {
 
     private OneOffSchedule(final Builder builder) {

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
+import com.arpnetworking.logback.annotations.Loggable;
 import com.google.common.base.MoreObjects;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.sf.oval.constraint.NotNull;
@@ -33,6 +34,7 @@ import java.util.Optional;
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
+@Loggable
 public final class PeriodicSchedule extends BaseSchedule {
 
     private final ChronoUnit _period;

--- a/main/config/logback-console.xml
+++ b/main/config/logback-console.xml
@@ -21,6 +21,7 @@
       <compressLoggerName>true</compressLoggerName>
       <jacksonModule class="com.fasterxml.jackson.datatype.guava.GuavaModule" />
       <jacksonModule class="com.fasterxml.jackson.datatype.jdk8.Jdk8Module" />
+      <jacksonModule class="com.fasterxml.jackson.datatype.jsr310.JavaTimeModule" />
       <jacksonModule class="com.arpnetworking.commons.jackson.databind.module.akka.AkkaLoggingModule" />
       <injectBeanIdentifier>true</injectBeanIdentifier>
     </encoder>

--- a/main/config/logback.xml
+++ b/main/config/logback.xml
@@ -31,6 +31,7 @@
       <compressLoggerName>true</compressLoggerName>
       <jacksonModule class="com.fasterxml.jackson.datatype.guava.GuavaModule" />
       <jacksonModule class="com.fasterxml.jackson.datatype.jdk8.Jdk8Module" />
+      <jacksonModule class="com.fasterxml.jackson.datatype.jsr310.JavaTimeModule" />
       <jacksonModule class="com.arpnetworking.commons.jackson.databind.module.akka.AkkaLoggingModule" />
       <injectBeanIdentifier>true</injectBeanIdentifier>
     </encoder>

--- a/pom.xml
+++ b/pom.xml
@@ -923,6 +923,12 @@
       <version>${jackson.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- Framework -->
     <dependency>


### PR DESCRIPTION
Before, logging a `CachedJob`:
```json
{
  "time": "2019-07-03T22:29:53.507Z",
  "name": "log",
  "level": "info",
  "data": {
    "message": "job has no more scheduled runs",
    "cachedJob": {
      "_id": "a2b66b0",
      "_class": "com.arpnetworking.metrics.portal.scheduling.CachedJob"
    }
  },
  "context": {
    "host": "f1434c837e0b",
    "processId": "1",
    "threadId": "mportal-akka.actor.default-dispatcher-16",
    "logger": "c.a.m.p.s.JobExecutorActor",
    "line": "236",
    "file": "JobExecutorActor.java",
    "class": "com.arpnetworking.metrics.portal.scheduling.JobExecutorActor"
  },
  "id": "48d707ae-a1ec-4f33-be30-7d48e67dc665",
  "version": "0"
}
```
(Why does it think there no scheduled runs? What are the parameters of the schedule?)

After:
```json
{
  "time": "2019-07-03T22:37:48.931Z",
  "name": "log",
  "level": "info",
  "data": {
    "message": "job has no more scheduled runs",
    "cachedJob": {
      "_id": "62c05c6c",
      "_class": "com.arpnetworking.metrics.portal.scheduling.CachedJob",
      "schedule": {
        "_id": "645fe195",
        "_class": "com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule",
        "whenRun": "2019-07-01T21:44:43.821Z",
        "runUntil": null,
        "runAtAndAfter": "2019-07-01T21:44:43.821Z"
      },
      "job": {
        "_id": "713a821",
        "_class": "models.internal.impl.DefaultReport",
        "schedule": {
          "_id": "645fe195",
          "_class": "com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule",
          "whenRun": "2019-07-01T21:44:43.821Z",
          "runUntil": null,
          "runAtAndAfter": "2019-07-01T21:44:43.821Z"
        },
        "recipientsByFormat": {
          "HtmlReportFormat{}": [
            {
              "_id": "66e998b6",
              "_class": "models.internal.impl.DefaultRecipient"
            }
          ]
        },
        "source": {
          "_id": "2ef69ee3",
          "_class": "models.internal.impl.WebPageReportSource",
          "uri": "http://example.com/",
          "title": "my title",
          "triggeringEventName": "my event",
          "id": "b2ccb0af-0a00-4a90-b92e-f863f4ef1509",
          "type": "WEB_PAGE"
        },
        "etag": "6f93748830c593c3d8348e76dc028bba0755e9c4",
        "name": "my name",
        "id": "e4426618-4dc8-4137-9322-1246e25d9f80"
      },
      "etag": "6f93748830c593c3d8348e76dc028bba0755e9c4",
      "lastRun": "2019-07-03T22:37:48.898Z",
      "id": "e4426618-4dc8-4137-9322-1246e25d9f80",
      "ref": {
        "_id": "3135628d",
        "_class": "com.arpnetworking.metrics.portal.scheduling.JobRef",
        "jobId": "e4426618-4dc8-4137-9322-1246e25d9f80",
        "repositoryType": "com.arpnetworking.metrics.portal.reports.ReportRepository",
        "organization": {
          "_id": "7e22dac8",
          "_class": "models.internal.impl.DefaultOrganization",
          "id": "0eb03110-2a36-4cb1-861f-7375afc98b9b"
        }
      }
    }
  },
  "context": {
    "host": "6e7996f2b7f9",
    "processId": "1",
    "threadId": "mportal-akka.actor.default-dispatcher-15",
    "logger": "c.a.m.p.s.JobExecutorActor",
    "line": "236",
    "file": "JobExecutorActor.java",
    "class": "com.arpnetworking.metrics.portal.scheduling.JobExecutorActor"
  },
  "id": "703a03ef-db74-4773-9f03-d1484f223ae2",
  "version": "0"
}
