### PR TITLE
when ReportController adds/updates/deletes a job, reload it immediately

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -449,7 +449,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
             /**
              * Public constructor.
              */
-            Builder() {
+            public Builder() {
                 super(Reload<T>::new);
             }
 


### PR DESCRIPTION
Currently, we have to wait for the anti-entropy mechanism to run before the job gets picked up.

Tested manually. Will soon be able to write an automated integration test (#243).