### PR TITLE
Make reports respect timeouts

### DIFF
--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -39,9 +39,11 @@ class EditReportViewModel {
     name = ko.observable<string>("");
     source = new EditSourceViewModel();
     schedule = new EditScheduleViewModel();
-    timeout = ko.pureComputed<moment.Duration>(() => moment.duration(this.timeoutString()));
+    renderTimeout = ko.pureComputed<moment.Duration>(() => moment.duration(this.renderTimeoutString()));
+    sendTimeout = ko.pureComputed<moment.Duration>(() => moment.duration(this.sendTimeoutString()));
 
-    timeoutString = ko.observable<string>("PT10M");
+    renderTimeoutString = ko.observable<string>("PT10M");
+    sendTimeoutString = ko.observable<string>("PT10S");
 
     // Recipients
     recipients = ko.observableArray<EditRecipientViewModel>();
@@ -69,7 +71,8 @@ class EditReportViewModel {
             this.existingReport(true);
             this.source.load(rawReport.source);
             this.schedule.load(rawReport.schedule);
-            this.timeoutString(rawReport.timeout);
+            this.renderTimeoutString(rawReport.renderTimeout);
+            this.sendTimeoutString(rawReport.sendTimeout);
 
             rawReport.recipients.forEach((raw) => {
                 const model = new EditRecipientViewModel();
@@ -125,7 +128,8 @@ class EditReportViewModel {
             id: this.id(),
             name: this.name(),
             schedule: this.schedule.toRequest(),
-            timeout: this.timeout(),
+            renderTimeout: this.renderTimeout(),
+            sendTimeout: this.sendTimeout(),
             source: this.source.toRequest(),
             recipients: this.recipients().map((r) => r.toRequest()),
         }
@@ -136,7 +140,8 @@ class EditReportViewModel {
     ];
 
     readonly helpMessages = {
-        timeout: "Time that can be spent rendering/sending the report before forcibly halting execution. HH:MM:SS or ISO-8601.",
+        renderTimeout: "Time that can be spent rendering the report before forcibly halting execution. HH:MM:SS or ISO-8601.",
+        sendTimeout: "Time that can be spent sending the report to its recipients before forcibly halting execution. HH:MM:SS or ISO-8601.",
     }
 }
 

--- a/app/assets/javascripts/classes/reports/Report.ts
+++ b/app/assets/javascripts/classes/reports/Report.ts
@@ -30,13 +30,14 @@ export default class Report {
     name: string;
 
     schedule: ScheduleViewModel;
-    timeout: moment.Duration;
+    renderTimeout: moment.Duration;
+    sendTimeout: moment.Duration;
     source: SourceViewModel;
     recipients: RecipientViewModel[];
 
     editUri: string;
 
-    constructor(id: string, name: string, source: any, schedule: any, timeout: string, recipients: object[]) {
+    constructor(id: string, name: string, source: any, schedule: any, renderTimeout: string, sendTimeout: string, recipients: object[]) {
         this.id = id;
         this.name = name;
 
@@ -44,7 +45,8 @@ export default class Report {
             new RecipientViewModel().load(raw)
         );
         this.schedule = new ScheduleViewModel().load(schedule);
-        this.timeout = moment.duration(timeout);
+        this.renderTimeout = moment.duration(renderTimeout);
+        this.sendTimeout = moment.duration(sendTimeout);
         this.source = new SourceViewModel().load(source);
 
         this.editUri = `#report/edit/${this.id}`;

--- a/app/assets/javascripts/classes/reports/ReportsViewModel.ts
+++ b/app/assets/javascripts/classes/reports/ReportsViewModel.ts
@@ -31,7 +31,8 @@ class ReportsList extends PaginatedSearchableList<Report> {
                     rawReport.name,
                     rawReport.source,
                     rawReport.schedule,
-                    rawReport.timeout,
+                    rawReport.renderTimeout,
+                    rawReport.sendTimeout,
                     rawReport.recipients,
                 )
             });

--- a/app/com/arpnetworking/metrics/portal/reports/Renderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/Renderer.java
@@ -20,6 +20,7 @@ import models.internal.TimeRange;
 import models.internal.reports.ReportFormat;
 import models.internal.reports.ReportSource;
 
+import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -38,6 +39,7 @@ public interface Renderer<S extends ReportSource, F extends ReportFormat> {
      * @param format The format to render into.
      * @param timeRange The time range to describe in the report.
      * @param builder Will be used to construct a report. All implementations of {@code render} must call `setBytes()`.
+     * @param timeout How long the renderer should be allowed to run before aborting.
      * @param <B> The type of builder provided.
      * @return A {@link CompletionStage} that completes when the report has been rendered.
      */
@@ -45,6 +47,7 @@ public interface Renderer<S extends ReportSource, F extends ReportFormat> {
             S source,
             F format,
             TimeRange timeRange,
-            B builder
+            B builder,
+            Duration timeout
     );
 }

--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
@@ -126,11 +126,17 @@ public final class ReportExecutionContext {
                 .stream()
                 .map(format ->
                         getRenderer(report.getSource(), format)
-                        .render(report.getSource(), format, timeRange, new DefaultRenderedReport.Builder()
-                                .setReport(report)
-                                .setFormat(format)
-                                .setGeneratedAt(_clock.instant())
-                                .setTimeRange(timeRange))
+                        .render(
+                                report.getSource(),
+                                format,
+                                timeRange,
+                                new DefaultRenderedReport.Builder()
+                                        .setReport(report)
+                                        .setFormat(format)
+                                        .setGeneratedAt(_clock.instant())
+                                        .setTimeRange(timeRange),
+                                report.getTimeout()
+                        )
                         .thenApply(builder -> result.put(format, builder.build()))
                         .toCompletableFuture())
                 .toArray(CompletableFuture[]::new);

--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
@@ -163,7 +163,7 @@ public final class ReportExecutionContext {
                 .entrySet()
                 .stream()
                 .map(entry -> getSender(entry.getKey())
-                        .send(entry.getKey(), mask(formatToRendered, entry.getValue()))
+                        .send(entry.getKey(), mask(formatToRendered, entry.getValue()), report.getTimeout())
                         .toCompletableFuture())
                 .toArray(CompletableFuture[]::new);
         return CompletableFuture.allOf(futures);

--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
@@ -135,7 +135,7 @@ public final class ReportExecutionContext {
                                         .setFormat(format)
                                         .setGeneratedAt(_clock.instant())
                                         .setTimeRange(timeRange),
-                                report.getTimeout()
+                                report.getRenderTimeout()
                         )
                         .thenApply(builder -> result.put(format, builder.build()))
                         .toCompletableFuture())
@@ -163,7 +163,7 @@ public final class ReportExecutionContext {
                 .entrySet()
                 .stream()
                 .map(entry -> getSender(entry.getKey())
-                        .send(entry.getKey(), mask(formatToRendered, entry.getValue()), report.getTimeout())
+                        .send(entry.getKey(), mask(formatToRendered, entry.getValue()), report.getSendTimeout())
                         .toCompletableFuture())
                 .toArray(CompletableFuture[]::new);
         return CompletableFuture.allOf(futures);

--- a/app/com/arpnetworking/metrics/portal/reports/Sender.java
+++ b/app/com/arpnetworking/metrics/portal/reports/Sender.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import models.internal.reports.Recipient;
 import models.internal.reports.ReportFormat;
 
+import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -33,10 +34,12 @@ public interface Sender {
      *
      * @param recipient The recipient to notify.
      * @param formatsToSend The reports to send. Must be non-empty.
+     * @param timeout The amount of time to let sending run for before aborting.
      * @return A CompletionStage that completes when the transmission has completed.
      */
     CompletionStage<Void> send(
             Recipient recipient,
-            ImmutableMap<ReportFormat, RenderedReport> formatsToSend
+            ImmutableMap<ReportFormat, RenderedReport> formatsToSend,
+            Duration timeout
     );
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -453,7 +453,8 @@ public final class DatabaseReportRepository implements ReportRepository {
         beanReport.setUuid(internalReport.getId());
         beanReport.setName(internalReport.getName());
         beanReport.setSchedule(schedule);
-        beanReport.setTimeout(internalReport.getTimeout().toNanos());
+        beanReport.setRenderTimeout(internalReport.getRenderTimeout().toNanos());
+        beanReport.setSendTimeout(internalReport.getSendTimeout().toNanos());
         beanReport.setReportSource(source);
         beanReport.setRecipients(internalModelToBean(internalReport.getRecipientsByFormat()));
         return beanReport;

--- a/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
@@ -69,7 +69,7 @@ public class EmailSender implements Sender {
             return null;
         });
 
-        _timeoutExecutor.schedule(() -> result.cancel(true), timeout.toNanos(), TimeUnit.NANOSECONDS);
+        _executor.schedule(() -> result.cancel(true), timeout.toNanos(), TimeUnit.NANOSECONDS);
 
         return result;
     }
@@ -123,20 +123,20 @@ public class EmailSender implements Sender {
      * Public constructor.
      *
      * @param config The configuration for this sender.
-     * @param timeoutExecutor Used to schedule timeouts on individual send operations.
+     * @param executor Used to schedule timeouts on individual send operations.
      */
     @Inject
-    public EmailSender(@Assisted final Config config, @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor) {
-        this(buildMailer(config), config, timeoutExecutor);
+    public EmailSender(@Assisted final Config config, @ChromeReportRenderingExecutorService final ScheduledExecutorService executor) {
+        this(buildMailer(config), config, executor);
     }
 
     /**
      * Constructor for tests, allowing dependency injection of the {@link Mailer}.
      */
-    /* package private */ EmailSender(final Mailer mailer, final Config config, final ScheduledExecutorService timeoutExecutor) {
+    /* package private */ EmailSender(final Mailer mailer, final Config config, final ScheduledExecutorService executor) {
         _fromAddress = config.getString("fromAddress");
         _mailer = mailer;
-        _timeoutExecutor = timeoutExecutor;
+        _executor = executor;
     }
 
     private static Mailer buildMailer(final Config config) {
@@ -150,7 +150,7 @@ public class EmailSender implements Sender {
 
     private final Mailer _mailer;
     private final String _fromAddress;
-    private final ScheduledExecutorService _timeoutExecutor;
+    private final ScheduledExecutorService _executor;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailSender.class);
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
@@ -35,7 +35,6 @@ import org.simplejavamail.email.EmailPopulatingBuilder;
 import org.simplejavamail.mailer.Mailer;
 import org.simplejavamail.mailer.MailerBuilder;
 
-import javax.inject.Named;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -46,6 +45,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Named;
 
 /**
  * Sends reports over email.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/EmailSender.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.portal.reports.impl;
 
 import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.arpnetworking.metrics.portal.reports.Sender;
+import com.arpnetworking.metrics.portal.reports.impl.chrome.ChromeReportRenderingExecutorService;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
 import com.google.common.collect.ImmutableMap;
@@ -45,7 +46,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.inject.Named;
 
 /**
  * Sends reports over email.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
@@ -100,7 +100,7 @@ public abstract class BaseScreenshotRenderer<S extends ReportSource, F extends R
         );
 
         final CompletableFuture<B> result = createDts.thenCompose(dts ->
-                dts.navigate(getUri(source).toString()).thenCompose(nothing -> {
+                dts.navigate(getUri(source).toString(), _executor).thenCompose(nothing -> {
                     LOGGER.debug()
                             .setMessage("page load completed")
                             .addData("source", source)

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseScreenshotRenderer.java
@@ -20,23 +20,18 @@ import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.arpnetworking.metrics.portal.reports.Renderer;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
-import com.google.inject.Inject;
-import com.google.inject.assistedinject.Assisted;
 import com.typesafe.config.Config;
 import models.internal.TimeRange;
 import models.internal.reports.ReportFormat;
 import models.internal.reports.ReportSource;
 
-import javax.inject.Named;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -147,10 +142,9 @@ public abstract class BaseScreenshotRenderer<S extends ReportSource, F extends R
      * </ul>
      * @param timeoutExecutor used to schedule timeouts on individual send operations
      */
-    @Inject
     protected BaseScreenshotRenderer(
-            @Assisted final Config config,
-            @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor
+            final Config config,
+            final ScheduledExecutorService timeoutExecutor
     ) {
         _devToolsFactory = new DevToolsFactory(config.getString("chromePath"));
         _chromeArgs = config.getObject("chromeArgs").unwrapped();

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/ChromeReportRenderingExecutorService.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/ChromeReportRenderingExecutorService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@BindingAnnotation
+@Target({ ElementType.PARAMETER, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ChromeReportRenderingExecutorService {
+}

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/ChromeReportRenderingExecutorService.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/ChromeReportRenderingExecutorService.java
@@ -23,6 +23,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Guice annotation identifying the executor service that is used for all Chrome-related execution.
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
 @BindingAnnotation
 @Target({ ElementType.PARAMETER, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsService.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsService.java
@@ -16,6 +16,7 @@
 package com.arpnetworking.metrics.portal.reports.impl.chrome;
 
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 /**
@@ -46,9 +47,10 @@ public interface DevToolsService {
      * Forces the tab to navigate to a new URL.
      *
      * @param url The URL to navigate to.
+     * @param executor The {@link Executor} to use to schedule the navigation and firing the load event.
      * @return A {@link CompletionStage} that completes when the page has loaded.
      */
-    CompletionStage<Void> navigate(String url);
+    CompletionStage<Void> navigate(String url, Executor executor);
 
     /**
      * Closes the dev tools. After close() is called, any further interaction is illegal.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
@@ -25,6 +25,7 @@ import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 /**
@@ -81,7 +82,7 @@ public class DevToolsServiceWrapper implements DevToolsService {
     }
 
     @Override
-    public CompletionStage<Void> navigate(final String url) {
+    public CompletionStage<Void> navigate(final String url, final Executor executor) {
         final CompletableFuture<Void> result = new CompletableFuture<>();
         _dts.getPage().enable();
         _dts.getPage().onLoadEventFired(e -> {
@@ -91,14 +92,17 @@ public class DevToolsServiceWrapper implements DevToolsService {
                     .log();
             result.complete(null);
         });
-        return CompletableFuture.supplyAsync(() -> {
-            LOGGER.debug()
-                    .setMessage("navigating to")
-                    .addData("url", url)
-                    .log();
-            _dts.getPage().navigate(url);
-            return null;
-        }).thenCompose(nothing -> result);
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    LOGGER.debug()
+                            .setMessage("navigating to")
+                            .addData("url", url)
+                            .log();
+                    _dts.getPage().navigate(url);
+                    return null;
+                },
+                executor
+        ).thenCompose(nothing -> result);
     }
 
     @Override

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
@@ -81,12 +81,14 @@ public class DevToolsServiceWrapper implements DevToolsService {
                     .log();
             result.complete(null);
         });
-        LOGGER.debug()
-                .setMessage("navigating to")
-                .addData("url", url)
-                .log();
-        _dts.getPage().navigate(url);
-        return result;
+        return CompletableFuture.supplyAsync(() -> {
+            LOGGER.debug()
+                    .setMessage("navigating to")
+                    .addData("url", url)
+                    .log();
+            _dts.getPage().navigate(url);
+            return null;
+        }).thenCompose(nothing -> result);
     }
 
     @Override

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRenderer.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -68,10 +67,13 @@ public final class HtmlScreenshotRenderer extends BaseScreenshotRenderer<WebPage
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
-     * @param timeoutExecutor used to schedule timeouts on individual send operations
+     * @param executor used to schedule timeouts on individual send operations
      */
     @Inject
-    public HtmlScreenshotRenderer(@Assisted final Config config, @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor) {
-        super(config, timeoutExecutor);
+    public HtmlScreenshotRenderer(
+            @Assisted final Config config,
+            @ChromeReportRenderingExecutorService final ScheduledExecutorService executor
+    ) {
+        super(config, executor);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRenderer.java
@@ -24,10 +24,12 @@ import models.internal.TimeRange;
 import models.internal.impl.HtmlReportFormat;
 import models.internal.impl.WebPageReportSource;
 
+import javax.inject.Named;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -66,9 +68,10 @@ public final class HtmlScreenshotRenderer extends BaseScreenshotRenderer<WebPage
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
+     * @param timeoutExecutor used to schedule timeouts on individual send operations
      */
     @Inject
-    public HtmlScreenshotRenderer(@Assisted final Config config) {
-        super(config);
+    public HtmlScreenshotRenderer(@Assisted final Config config, @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor) {
+        super(config, timeoutExecutor);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRenderer.java
@@ -24,12 +24,12 @@ import models.internal.TimeRange;
 import models.internal.impl.HtmlReportFormat;
 import models.internal.impl.WebPageReportSource;
 
-import javax.inject.Named;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRenderer.java
@@ -24,11 +24,11 @@ import models.internal.TimeRange;
 import models.internal.impl.PdfReportFormat;
 import models.internal.impl.WebPageReportSource;
 
-import javax.inject.Named;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as PDF.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRenderer.java
@@ -24,9 +24,11 @@ import models.internal.TimeRange;
 import models.internal.impl.PdfReportFormat;
 import models.internal.impl.WebPageReportSource;
 
+import javax.inject.Named;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Uses a headless Chrome instance to render a page as PDF.
@@ -65,9 +67,10 @@ public final class PdfScreenshotRenderer extends BaseScreenshotRenderer<WebPageR
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
+     * @param timeoutExecutor used to schedule timeouts on individual send operations
      */
     @Inject
-    public PdfScreenshotRenderer(@Assisted final Config config) {
-        super(config);
+    public PdfScreenshotRenderer(@Assisted final Config config, @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor) {
+        super(config, timeoutExecutor);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRenderer.java
@@ -28,7 +28,6 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as PDF.
@@ -67,10 +66,13 @@ public final class PdfScreenshotRenderer extends BaseScreenshotRenderer<WebPageR
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
-     * @param timeoutExecutor used to schedule timeouts on individual send operations
+     * @param executor used to schedule timeouts on individual send operations
      */
     @Inject
-    public PdfScreenshotRenderer(@Assisted final Config config, @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor) {
-        super(config, timeoutExecutor);
+    public PdfScreenshotRenderer(
+            @Assisted final Config config,
+            @ChromeReportRenderingExecutorService final ScheduledExecutorService executor
+    ) {
+        super(config, executor);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/BaseGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/BaseGrafanaScreenshotRenderer.java
@@ -27,8 +27,10 @@ import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.reports.ReportFormat;
 
+import javax.inject.Named;
 import java.net.URI;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -111,10 +113,14 @@ public abstract class BaseGrafanaScreenshotRenderer<F extends ReportFormat>
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
+     * @param timeoutExecutor used to schedule timeouts on individual send operations
      */
     @Inject
-    /* package private */ BaseGrafanaScreenshotRenderer(@Assisted final Config config) {
-        super(config);
+    /* package private */ BaseGrafanaScreenshotRenderer(
+            @Assisted final Config config,
+            @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor
+    ) {
+        super(config, timeoutExecutor);
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseGrafanaScreenshotRenderer.class);

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/BaseGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/BaseGrafanaScreenshotRenderer.java
@@ -20,14 +20,11 @@ import com.arpnetworking.metrics.portal.reports.RenderedReport;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.DevToolsService;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
-import com.google.inject.Inject;
-import com.google.inject.assistedinject.Assisted;
 import com.typesafe.config.Config;
 import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.reports.ReportFormat;
 
-import javax.inject.Named;
 import java.net.URI;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
@@ -115,10 +112,9 @@ public abstract class BaseGrafanaScreenshotRenderer<F extends ReportFormat>
      * </ul>
      * @param timeoutExecutor used to schedule timeouts on individual send operations
      */
-    @Inject
     /* package private */ BaseGrafanaScreenshotRenderer(
-            @Assisted final Config config,
-            @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor
+            final Config config,
+            final ScheduledExecutorService timeoutExecutor
     ) {
         super(config, timeoutExecutor);
     }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/BaseGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/BaseGrafanaScreenshotRenderer.java
@@ -110,13 +110,13 @@ public abstract class BaseGrafanaScreenshotRenderer<F extends ReportFormat>
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
-     * @param timeoutExecutor used to schedule timeouts on individual send operations
+     * @param executor used to schedule timeouts on individual send operations
      */
     /* package private */ BaseGrafanaScreenshotRenderer(
             final Config config,
-            final ScheduledExecutorService timeoutExecutor
+            final ScheduledExecutorService executor
     ) {
-        super(config, timeoutExecutor);
+        super(config, executor);
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseGrafanaScreenshotRenderer.class);

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlGrafanaScreenshotRenderer.java
@@ -17,6 +17,7 @@
 package com.arpnetworking.metrics.portal.reports.impl.chrome.grafana;
 
 import com.arpnetworking.metrics.portal.reports.RenderedReport;
+import com.arpnetworking.metrics.portal.reports.impl.chrome.ChromeReportRenderingExecutorService;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.DevToolsService;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -29,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -59,13 +59,13 @@ public final class HtmlGrafanaScreenshotRenderer extends BaseGrafanaScreenshotRe
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
-     * @param timeoutExecutor used to schedule timeouts on individual send operations
+     * @param executor used to schedule timeouts on individual send operations
      */
     @Inject
     public HtmlGrafanaScreenshotRenderer(
             @Assisted final Config config,
-            @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor
+            @ChromeReportRenderingExecutorService final ScheduledExecutorService executor
     ) {
-        super(config, timeoutExecutor);
+        super(config, executor);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlGrafanaScreenshotRenderer.java
@@ -25,11 +25,11 @@ import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.impl.HtmlReportFormat;
 
-import javax.inject.Named;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlGrafanaScreenshotRenderer.java
@@ -25,9 +25,11 @@ import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.impl.HtmlReportFormat;
 
+import javax.inject.Named;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -57,9 +59,13 @@ public final class HtmlGrafanaScreenshotRenderer extends BaseGrafanaScreenshotRe
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
+     * @param timeoutExecutor used to schedule timeouts on individual send operations
      */
     @Inject
-    public HtmlGrafanaScreenshotRenderer(@Assisted final Config config) {
-        super(config);
+    public HtmlGrafanaScreenshotRenderer(
+            @Assisted final Config config,
+            @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor
+    ) {
+        super(config, timeoutExecutor);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfGrafanaScreenshotRenderer.java
@@ -25,11 +25,11 @@ import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.impl.PdfReportFormat;
 
-import javax.inject.Named;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfGrafanaScreenshotRenderer.java
@@ -25,9 +25,11 @@ import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.impl.PdfReportFormat;
 
+import javax.inject.Named;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -72,9 +74,13 @@ public final class PdfGrafanaScreenshotRenderer extends BaseGrafanaScreenshotRen
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
+     * @param timeoutExecutor used to schedule timeouts on individual send operations
      */
     @Inject
-    public PdfGrafanaScreenshotRenderer(@Assisted final Config config) {
-        super(config);
+    public PdfGrafanaScreenshotRenderer(
+            @Assisted final Config config,
+            @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor
+    ) {
+        super(config, timeoutExecutor);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfGrafanaScreenshotRenderer.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfGrafanaScreenshotRenderer.java
@@ -17,6 +17,7 @@
 package com.arpnetworking.metrics.portal.reports.impl.chrome.grafana;
 
 import com.arpnetworking.metrics.portal.reports.RenderedReport;
+import com.arpnetworking.metrics.portal.reports.impl.chrome.ChromeReportRenderingExecutorService;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.DevToolsService;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -29,7 +30,6 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.inject.Named;
 
 /**
  * Uses a headless Chrome instance to render a page as HTML.
@@ -74,13 +74,13 @@ public final class PdfGrafanaScreenshotRenderer extends BaseGrafanaScreenshotRen
      * <ul>
      *   <li>{@code chromePath} -- the path to the Chrome binary to use to render pages.</li>
      * </ul>
-     * @param timeoutExecutor used to schedule timeouts on individual send operations
+     * @param executor used to schedule timeouts on individual send operations
      */
     @Inject
     public PdfGrafanaScreenshotRenderer(
             @Assisted final Config config,
-            @Named("report-cleanup") final ScheduledExecutorService timeoutExecutor
+            @ChromeReportRenderingExecutorService final ScheduledExecutorService executor
     ) {
-        super(config, timeoutExecutor);
+        super(config, executor);
     }
 }

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -92,6 +92,8 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -186,6 +188,14 @@ public class MainModule extends AbstractModule {
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD") // Invoked reflectively by Guice
     private Features getFeatures(final Config configuration) {
         return new DefaultFeatures(configuration);
+    }
+
+    @Provides
+    @Singleton
+    @Named("report-cleanup")
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Invoked reflectively by Guice")
+    private ScheduledExecutorService getScheduledExecutorService() {
+        return new ScheduledThreadPoolExecutor(1);
     }
 
     @Provides

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -49,6 +49,7 @@ import com.arpnetworking.metrics.portal.query.QueryExecutor;
 import com.arpnetworking.metrics.portal.query.QueryExecutorRegistry;
 import com.arpnetworking.metrics.portal.reports.ReportExecutionContext;
 import com.arpnetworking.metrics.portal.reports.ReportRepository;
+import com.arpnetworking.metrics.portal.reports.impl.chrome.ChromeReportRenderingExecutorService;
 import com.arpnetworking.metrics.portal.scheduling.JobCoordinator;
 import com.arpnetworking.metrics.portal.scheduling.JobExecutorActor;
 import com.arpnetworking.metrics.portal.scheduling.JobMessageExtractor;
@@ -192,7 +193,7 @@ public class MainModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named("report-cleanup")
+    @ChromeReportRenderingExecutorService
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Invoked reflectively by Guice")
     private ScheduledExecutorService getScheduledExecutorService() {
         return new ScheduledThreadPoolExecutor(1);

--- a/app/models/ebean/Report.java
+++ b/app/models/ebean/Report.java
@@ -92,8 +92,11 @@ public class Report {
     @JoinColumn(name = "report_schedule_id")
     private ReportSchedule schedule;
 
-    @Column(name = "timeout_nanos")
-    private long timeoutNanos;
+    @Column(name = "render_timeout_nanos")
+    private long renderTimeoutNanos;
+
+    @Column(name = "send_timeout_nanos")
+    private long sendTimeoutNanos;
 
     @SoftDelete
     @Column(name = "deleted")
@@ -151,12 +154,20 @@ public class Report {
         schedule = value;
     }
 
-    public long getTimeout() {
-        return timeoutNanos;
+    public long getRenderTimeout() {
+        return renderTimeoutNanos;
     }
 
-    public void setTimeout(final long value) {
-        timeoutNanos = value;
+    public void setRenderTimeout(final long value) {
+        renderTimeoutNanos = value;
+    }
+
+    public long getSendTimeout() {
+        return sendTimeoutNanos;
+    }
+
+    public void setSendTimeout(final long value) {
+        sendTimeoutNanos = value;
     }
 
     public Set<Recipient> getRecipients() {
@@ -231,7 +242,8 @@ public class Report {
                 .setName(name)
                 .setRecipients(internalRecipients)
                 .setSchedule(schedule.toInternal())
-                .setTimeout(Duration.ofNanos(timeoutNanos))
+                .setRenderTimeout(Duration.ofNanos(renderTimeoutNanos))
+                .setSendTimeout(Duration.ofNanos(sendTimeoutNanos))
                 .setReportSource(reportSource.toInternal())
                 .build();
     }

--- a/app/models/internal/impl/DefaultReport.java
+++ b/app/models/internal/impl/DefaultReport.java
@@ -81,7 +81,7 @@ public final class DefaultReport implements Report {
 
     @Override
     public Duration getTimeout() {
-        return _renderTimeout.plus(_sendTimeout).plus(TIMEOUT_SLOP);
+        return ReportExecutionContext.getTimeout(this);
     }
 
     @Override
@@ -136,15 +136,6 @@ public final class DefaultReport implements Report {
     private final ReportSource _source;
 
     private final ImmutableSetMultimap<ReportFormat, Recipient> _recipients;
-
-    /**
-     * {@link #execute}ing a report involves: rendering it; sending it; and a little bit of miscellaneous work.
-     * The render- and send-timeouts are configurable on a per-report basis.
-     * The miscellaneous work is trivial, but we still need to account for it in {@link #getTimeout()},
-     *   or else {@link #execute} might get cancelled before we've given both those stages a fair shot.
-     * The non-rendering, non-sending work done by {@link #execute} should bevirtually guaranteed to finish in less than this much time.
-     */
-    private static final Duration TIMEOUT_SLOP = Duration.ofSeconds(5);
 
     @Override
     public boolean equals(final Object o) {

--- a/app/models/internal/impl/DefaultReport.java
+++ b/app/models/internal/impl/DefaultReport.java
@@ -138,7 +138,11 @@ public final class DefaultReport implements Report {
     private final ImmutableSetMultimap<ReportFormat, Recipient> _recipients;
 
     /**
-     * Running a job involves: rendering it;
+     * {@link #execute}ing a report involves: rendering it; sending it; and a little bit of miscellaneous work.
+     * The render- and send-timeouts are configurable on a per-report basis.
+     * The miscellaneous work is trivial, but we still need to account for it in {@link #getTimeout()},
+     *   or else {@link #execute} might get cancelled before we've given both those stages a fair shot.
+     * The non-rendering, non-sending work done by {@link #execute} should bevirtually guaranteed to finish in less than this much time.
      */
     private static final Duration TIMEOUT_SLOP = Duration.ofSeconds(5);
 

--- a/app/models/internal/reports/Report.java
+++ b/app/models/internal/reports/Report.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import models.internal.impl.DefaultReportResult;
 import models.internal.scheduling.Job;
 
+import java.time.Duration;
 import java.util.Collection;
 
 /**
@@ -50,6 +51,20 @@ public interface Report extends Job<Report.Result> {
      * @return A mapping of each {@link ReportFormat} to its recipients
      */
     ImmutableMap<ReportFormat, Collection<Recipient>> getRecipientsByFormat();
+
+    /**
+     * Get the duration to wait for this report to render.
+     *
+     * @return The the source for this report.
+     */
+    Duration getRenderTimeout();
+
+    /**
+     * Get the duration to wait for this report to send.
+     *
+     * @return The the source for this report.
+     */
+    Duration getSendTimeout();
 
     /**
      * Internal model for a result created from a report.

--- a/app/models/internal/reports/Report.java
+++ b/app/models/internal/reports/Report.java
@@ -53,16 +53,16 @@ public interface Report extends Job<Report.Result> {
     ImmutableMap<ReportFormat, Collection<Recipient>> getRecipientsByFormat();
 
     /**
-     * Get the duration to wait for this report to render.
+     * Get the duration to wait for this report to render before aborting rendering.
      *
-     * @return The the source for this report.
+     * @return The timeout.
      */
     Duration getRenderTimeout();
 
     /**
-     * Get the duration to wait for this report to send.
+     * Get the duration to wait for this report to send before aborting sending.
      *
-     * @return The the source for this report.
+     * @return The timeout.
      */
     Duration getSendTimeout();
 

--- a/app/models/view/reports/Report.java
+++ b/app/models/view/reports/Report.java
@@ -69,12 +69,20 @@ public final class Report {
         this._schedule = schedule;
     }
 
-    public Duration getTimeout() {
-        return _timeout;
+    public Duration getRenderTimeout() {
+        return _renderTimeout;
     }
 
-    public void setTimeout(final Duration timeout) {
-        this._timeout = timeout;
+    public void setRenderTimeout(final Duration timeout) {
+        this._renderTimeout = timeout;
+    }
+
+    public Duration getSendTimeout() {
+        return _sendTimeout;
+    }
+
+    public void setSendTimeout(final Duration timeout) {
+        this._sendTimeout = timeout;
     }
 
     public void setRecipients(final List<Recipient> recipients) {
@@ -104,7 +112,8 @@ public final class Report {
                 .setName(_name)
                 .setReportSource(_source.toInternal())
                 .setSchedule(_schedule.toInternal())
-                .setTimeout(_timeout)
+                .setRenderTimeout(_renderTimeout)
+                .setSendTimeout(_sendTimeout)
                 .setRecipients(internalRecipients)
                 .build();
     }
@@ -120,7 +129,8 @@ public final class Report {
         viewReport.setId(report.getId());
         viewReport.setName(report.getName());
         viewReport.setSource(ReportSource.fromInternal(report.getSource()));
-        viewReport.setTimeout(report.getTimeout());
+        viewReport.setRenderTimeout(report.getRenderTimeout());
+        viewReport.setSendTimeout(report.getSendTimeout());
         viewReport.setSchedule(Schedule.fromInternal(report.getSchedule()));
         final List<models.view.reports.Recipient> recipients =
                 report.getRecipientsByFormat()
@@ -154,7 +164,8 @@ public final class Report {
                 && Objects.equals(_name, otherReport._name)
                 && Objects.equals(_source, otherReport._source)
                 && Objects.equals(_schedule, otherReport._schedule)
-                && Objects.equals(_timeout, otherReport._timeout)
+                && Objects.equals(_renderTimeout, otherReport._renderTimeout)
+                && Objects.equals(_sendTimeout, otherReport._sendTimeout)
                 && Objects.equals(_recipients, otherReport._recipients);
     }
 
@@ -170,7 +181,8 @@ public final class Report {
                 .add("_name", _name)
                 .add("_source", _source)
                 .add("_schedule", _schedule)
-                .add("_timeout", _timeout)
+                .add("_renderTimeout", _renderTimeout)
+                .add("_sendTimeout", _sendTimeout)
                 .add("_recipients", _recipients)
                 .toString();
     }
@@ -179,6 +191,7 @@ public final class Report {
     private String _name;
     private ReportSource _source;
     private Schedule _schedule;
-    private Duration _timeout;
+    private Duration _renderTimeout;
+    private Duration _sendTimeout;
     private List<Recipient> _recipients;
 }

--- a/conf/db/migration/metrics_portal_ddl/V19__report_send_timeout.sql
+++ b/conf/db/migration/metrics_portal_ddl/V19__report_send_timeout.sql
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE portal.reports RENAME COLUMN timeout_nanos TO render_timeout_nanos;
+
+ALTER TABLE portal.reports ADD COLUMN send_timeout_nanos BIGINT;
+UPDATE portal.reports SET send_timeout_nanos = 10e9;

--- a/public/html/reports/EditReportViewModel.html
+++ b/public/html/reports/EditReportViewModel.html
@@ -29,11 +29,19 @@
                     <input class="form-control" data-bind="value: name" type="text" id="nameInput" placeholder="Name">
                 </div>
                 <div class="form-group">
-                    <label for="timeoutString">Timeout</label>
+                    <label for="renderTimeoutString">Rendering Timeout</label>
                     <span class="glyphicon glyphicon-question-sign"
-                          data-bind="popover: helpMessages['timeout']"
+                          data-bind="popover: helpMessages['renderTimeout']"
                           data-trigger="hover"></span>
-                    <input class="form-control" type="text" id="timeoutString"
+                    <input class="form-control" type="text" id="renderTimeoutString"
+                           value=""
+                           placeholder="HH:MM:SS, or an ISO 8601 duration."
+                           data-bind="value: timeoutString">
+                    <label for="sendTimeoutString">Sending Timeout</label>
+                    <span class="glyphicon glyphicon-question-sign"
+                          data-bind="popover: helpMessages['sendTimeout']"
+                          data-trigger="hover"></span>
+                    <input class="form-control" type="text" id="sendTimeoutString"
                            value=""
                            placeholder="HH:MM:SS, or an ISO 8601 duration."
                            data-bind="value: timeoutString">

--- a/public/html/reports/EditReportViewModel.html
+++ b/public/html/reports/EditReportViewModel.html
@@ -36,7 +36,7 @@
                     <input class="form-control" type="text" id="renderTimeoutString"
                            value=""
                            placeholder="HH:MM:SS, or an ISO 8601 duration."
-                           data-bind="value: timeoutString">
+                           data-bind="value: renderTimeoutString">
                     <label for="sendTimeoutString">Sending Timeout</label>
                     <span class="glyphicon glyphicon-question-sign"
                           data-bind="popover: helpMessages['sendTimeout']"
@@ -44,7 +44,7 @@
                     <input class="form-control" type="text" id="sendTimeoutString"
                            value=""
                            placeholder="HH:MM:SS, or an ISO 8601 duration."
-                           data-bind="value: timeoutString">
+                           data-bind="value: sendTimeoutString">
                 </div>
 
                 <!-- Report Source -->

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -137,7 +137,8 @@ public final class TestBeanFactory {
                 .setId(UUID.randomUUID())
                 .setETag(TEST_ETAG + UUID.randomUUID().toString())
                 .setName(TEST_NAME + UUID.randomUUID().toString())
-                .setTimeout(Duration.ofSeconds(1 + RANDOM.nextInt(120)))
+                .setRenderTimeout(Duration.ofSeconds(1 + RANDOM.nextInt(120)))
+                .setSendTimeout(Duration.ofSeconds(1 + RANDOM.nextInt(120)))
                 .setRecipients(ImmutableSetMultimap.of(
                         format,
                         new DefaultRecipient.Builder()

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -268,7 +268,8 @@ public class ReportExecutionContextTest {
                 final WebPageReportSource source,
                 final HtmlReportFormat format,
                 final TimeRange timeRange,
-                final B builder
+                final B builder,
+                final Duration timeout
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));
         }
@@ -280,7 +281,8 @@ public class ReportExecutionContextTest {
                 final WebPageReportSource source,
                 final PdfReportFormat format,
                 final TimeRange timeRange,
-                final B builder
+                final B builder,
+                final Duration timeout
         ) {
             return CompletableFuture.completedFuture(builder.setBytes(new byte[0]));
         }

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -93,7 +93,8 @@ public class ReportExecutionContextTest {
                     .build()
             )
             .setSchedule(new OneOffSchedule.Builder().setRunAtAndAfter(T0).build())
-            .setTimeout(Duration.ofSeconds(30))
+            .setRenderTimeout(Duration.ofSeconds(30))
+            .setSendTimeout(Duration.ofSeconds(10))
             .setRecipients(ImmutableSetMultimap.<ReportFormat, Recipient>builder()
                     .put(HTML, ALICE)
                     .put(HTML, BOB)
@@ -155,12 +156,12 @@ public class ReportExecutionContextTest {
         Mockito.verify(_emailSender).send(
                 ALICE,
                 ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE)),
-                Duration.ofSeconds(30)
+                Duration.ofSeconds(10)
         );
         Mockito.verify(_emailSender).send(
                 BOB,
                 ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE), PDF, mockRendered(EXAMPLE_REPORT, PDF, TIME_RANGE)),
-                Duration.ofSeconds(30)
+                Duration.ofSeconds(10)
         );
     }
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -81,6 +81,9 @@ public class ReportExecutionContextTest {
     private static final Instant T0 = ChronoUnit.DAYS.addTo(T1, -1);
     private static final TimeRange TIME_RANGE = new TimeRange(T0, T1);
     private static final ManualClock CLOCK = new ManualClock(T1, Duration.ofSeconds(1), ZoneId.of("UTC"));
+    public static final Duration RENDER_TIMEOUT = Duration.ofSeconds(30);
+    public static final Duration SEND_TIMEOUT = Duration.ofSeconds(10);
+
     private static final Report EXAMPLE_REPORT = new DefaultReport.Builder()
             .setId(UUID.randomUUID())
             .setName("My Name")
@@ -93,8 +96,8 @@ public class ReportExecutionContextTest {
                     .build()
             )
             .setSchedule(new OneOffSchedule.Builder().setRunAtAndAfter(T0).build())
-            .setRenderTimeout(Duration.ofSeconds(30))
-            .setSendTimeout(Duration.ofSeconds(10))
+            .setRenderTimeout(RENDER_TIMEOUT)
+            .setSendTimeout(SEND_TIMEOUT)
             .setRecipients(ImmutableSetMultimap.<ReportFormat, Recipient>builder()
                     .put(HTML, ALICE)
                     .put(HTML, BOB)
@@ -156,12 +159,12 @@ public class ReportExecutionContextTest {
         Mockito.verify(_emailSender).send(
                 ALICE,
                 ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE)),
-                Duration.ofSeconds(10)
+                SEND_TIMEOUT
         );
         Mockito.verify(_emailSender).send(
                 BOB,
                 ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE), PDF, mockRendered(EXAMPLE_REPORT, PDF, TIME_RANGE)),
-                Duration.ofSeconds(10)
+                SEND_TIMEOUT
         );
     }
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -115,6 +115,7 @@ public class ReportExecutionContextTest {
         MockitoAnnotations.initMocks(this);
         Mockito.doReturn(CompletableFuture.completedFuture("done")).when(_emailSender).send(
                 Mockito.any(),
+                Mockito.any(),
                 Mockito.any()
         );
 
@@ -153,11 +154,13 @@ public class ReportExecutionContextTest {
         context.execute(EXAMPLE_REPORT, T1).toCompletableFuture().get();
         Mockito.verify(_emailSender).send(
                 ALICE,
-                ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE))
+                ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE)),
+                Duration.ofSeconds(30)
         );
         Mockito.verify(_emailSender).send(
                 BOB,
-                ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE), PDF, mockRendered(EXAMPLE_REPORT, PDF, TIME_RANGE))
+                ImmutableMap.of(HTML, mockRendered(EXAMPLE_REPORT, HTML, TIME_RANGE), PDF, mockRendered(EXAMPLE_REPORT, PDF, TIME_RANGE)),
+                Duration.ofSeconds(30)
         );
     }
 
@@ -256,8 +259,8 @@ public class ReportExecutionContextTest {
         @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
         public CompletionStage<Void> send(
                 final Recipient recipient,
-                final ImmutableMap<ReportFormat, RenderedReport> formatsToSend
-        ) {
+                final ImmutableMap<ReportFormat, RenderedReport> formatsToSend,
+                final Duration timeout) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests class {@link EmailSender}.

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -68,7 +69,7 @@ public class EmailSenderTest {
         ));
 
         MockitoAnnotations.initMocks(this);
-        _sender = new EmailSender(_mailer, _config);
+        _sender = new EmailSender(_mailer, _config, new ScheduledThreadPoolExecutor(1));
     }
 
     @Test
@@ -129,7 +130,7 @@ public class EmailSenderTest {
             Thread.sleep(100000);
             return null;
         }).when(mailer).sendMail(Mockito.any());
-        final EmailSender sender = new EmailSender(mailer, _config);
+        final EmailSender sender = new EmailSender(mailer, _config, new ScheduledThreadPoolExecutor(1));
         final CompletionStage<Void> send = sender.send(
                 TestBeanFactory.createRecipient(),
                 ImmutableMap.of(new HtmlReportFormat.Builder().build(), TestBeanFactory.createRenderedReportBuilder().build()),

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -116,8 +116,9 @@ public class EmailSenderTest {
                     Duration.ofSeconds(1)
             ).toCompletableFuture().get();
         } catch (final ExecutionException e) {
-            if (e.getCause() instanceof MailException) {
-                throw (MailException) e.getCause();
+            final Throwable cause = e.getCause();
+            if (cause instanceof MailException) {
+                throw (MailException) cause;
             }
             throw e;    
         }

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/EmailSenderTest.java
@@ -124,7 +124,7 @@ public class EmailSenderTest {
         }
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testTimeout() throws Exception {
         final Mailer mailer = Mockito.mock(Mailer.class);
         Mockito.doAnswer(x -> {
@@ -140,7 +140,7 @@ public class EmailSenderTest {
 
         boolean cancelled = false;
         try {
-            send.toCompletableFuture().get(1, TimeUnit.SECONDS);
+            send.toCompletableFuture().get();
         } catch (final CancellationException exception) {
             cancelled = true;
         }

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeIT.java
@@ -20,12 +20,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import models.internal.TimeRange;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -43,6 +46,9 @@ public class BaseChromeIT {
 
     @Rule
     public WireMockRule _wireMock = new WireMockRule(wireMockConfig().dynamicPort());
+
+    public static final TimeRange DEFAULT_TIME_RANGE = new TimeRange(Instant.EPOCH, Instant.EPOCH);
+    public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(15);
 
     private static final ImmutableList<String> POSSIBLE_CHROME_PATHS = ImmutableList.of(
             "/usr/bin/chromium",

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
@@ -71,9 +71,9 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
         final CompletionStage<MockRenderedReportBuilder> stage = renderer.render(
                 source,
                 format,
-                new TimeRange(Instant.EPOCH, Instant.EPOCH),
+                DEFAULT_TIME_RANGE,
                 builder,
-                Duration.ofSeconds(15)
+                DEFAULT_TIMEOUT
         );
 
         stage.toCompletableFuture().get(20, TimeUnit.SECONDS);

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class HtmlScreenshotRendererIT extends BaseChromeIT {
 
-    @Test
+    @Test(timeout = 20000)
     public void testRendering() throws Exception {
         final MockRenderedReportBuilder builder = Mockito.mock(MockRenderedReportBuilder.class);
         final Config config = CHROME_RENDERER_CONFIG;
@@ -76,7 +76,7 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
                 DEFAULT_TIMEOUT
         );
 
-        stage.toCompletableFuture().get(20, TimeUnit.SECONDS);
+        stage.toCompletableFuture().get();
 
         final ArgumentCaptor<byte[]> bytes = ArgumentCaptor.forClass(byte[].class);
         Mockito.verify(builder).setBytes(bytes.capture());
@@ -84,7 +84,7 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
         assertTrue(response.contains("here are some bytes"));
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testTimeout() throws Exception {
         final MockRenderedReportBuilder builder = Mockito.mock(MockRenderedReportBuilder.class);
         final Config config = CHROME_RENDERER_CONFIG;
@@ -113,7 +113,7 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
 
         boolean cancelled = false;
         try {
-            stage.toCompletableFuture().get(1, TimeUnit.SECONDS);
+            stage.toCompletableFuture().get();
         } catch (final CancellationException exception) {
             cancelled = true;
         }

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
@@ -34,7 +34,6 @@ import java.time.Instant;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererIT.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -62,7 +63,7 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
         );
 
         final HtmlReportFormat format = new HtmlReportFormat.Builder().build();
-        final HtmlScreenshotRenderer renderer = new HtmlScreenshotRenderer(config);
+        final HtmlScreenshotRenderer renderer = new HtmlScreenshotRenderer(config, new ScheduledThreadPoolExecutor(1));
         final WebPageReportSource source = TestBeanFactory.createWebPageReportSourceBuilder()
                 .setUri(URI.create("http://localhost:" + _wireMock.port()))
                 .build();
@@ -97,7 +98,7 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
         );
 
         final HtmlReportFormat format = new HtmlReportFormat.Builder().build();
-        final HtmlScreenshotRenderer renderer = new HtmlScreenshotRenderer(config);
+        final HtmlScreenshotRenderer renderer = new HtmlScreenshotRenderer(config, new ScheduledThreadPoolExecutor(1));
         final WebPageReportSource source = TestBeanFactory.createWebPageReportSourceBuilder()
                 .setUri(URI.create("http://localhost:" + _wireMock.port()))
                 .build();

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
@@ -27,7 +27,6 @@ import org.mockito.Mockito;
 import java.net.URI;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -66,7 +67,9 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
                 source,
                 format,
                 new TimeRange(Instant.EPOCH, Instant.EPOCH),
-                builder);
+                builder,
+                Duration.ofSeconds(15)
+        );
 
         stage.toCompletableFuture().get(20, TimeUnit.SECONDS);
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class PdfScreenshotRendererIT extends BaseChromeIT {
 
-    @Test
+    @Test(timeout = 20000)
     public void testRendering() throws Exception {
         final MockRenderedReportBuilder builder = Mockito.mock(MockRenderedReportBuilder.class);
         final Config config = CHROME_RENDERER_CONFIG;
@@ -69,7 +69,7 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
                 DEFAULT_TIMEOUT
         );
 
-        stage.toCompletableFuture().get(20, TimeUnit.SECONDS);
+        stage.toCompletableFuture().get();
 
         final ArgumentCaptor<byte[]> bytes = ArgumentCaptor.forClass(byte[].class);
         Mockito.verify(builder).setBytes(bytes.capture());

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
@@ -18,7 +18,6 @@ package com.arpnetworking.metrics.portal.reports.impl.chrome;
 import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.arpnetworking.metrics.portal.reports.impl.testing.MockRenderedReportBuilder;
 import com.typesafe.config.Config;
-import models.internal.TimeRange;
 import models.internal.impl.PdfReportFormat;
 import models.internal.impl.WebPageReportSource;
 import org.junit.Test;
@@ -26,8 +25,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.net.URI;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -67,9 +64,9 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
         final CompletionStage<MockRenderedReportBuilder> stage = renderer.render(
                 source,
                 format,
-                new TimeRange(Instant.EPOCH, Instant.EPOCH),
+                DEFAULT_TIME_RANGE,
                 builder,
-                Duration.ofSeconds(15)
+                DEFAULT_TIMEOUT
         );
 
         stage.toCompletableFuture().get(20, TimeUnit.SECONDS);

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PdfScreenshotRendererIT.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -58,7 +59,7 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
         );
 
         final PdfReportFormat format = new PdfReportFormat.Builder().setWidthInches(8.5f).setHeightInches(11f).build();
-        final PdfScreenshotRenderer renderer = new PdfScreenshotRenderer(config);
+        final PdfScreenshotRenderer renderer = new PdfScreenshotRenderer(config, new ScheduledThreadPoolExecutor(1));
         final WebPageReportSource source = TestBeanFactory.createWebPageReportSourceBuilder()
                 .setUri(URI.create("http://localhost:" + _wireMock.port()))
                 .build();

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
@@ -21,7 +21,6 @@ import com.arpnetworking.metrics.portal.reports.impl.chrome.grafana.testing.Util
 import com.arpnetworking.metrics.portal.reports.impl.testing.MockRenderedReportBuilder;
 import com.github.tomakehurst.wiremock.common.Strings;
 import com.typesafe.config.Config;
-import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.impl.HtmlReportFormat;
 import org.junit.Test;
@@ -31,7 +30,6 @@ import org.mockito.Mockito;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -74,9 +72,9 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
         final CompletionStage<MockRenderedReportBuilder> stage = renderer.render(
                 source,
                 format,
-                new TimeRange(Instant.EPOCH, Instant.EPOCH),
+                DEFAULT_TIME_RANGE,
                 builder,
-                Duration.ofSeconds(15)
+                DEFAULT_TIMEOUT
         );
 
         stage.toCompletableFuture().get(20, TimeUnit.SECONDS);

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
@@ -77,7 +77,7 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
                 DEFAULT_TIMEOUT
         );
 
-        stage.toCompletableFuture().get(20, TimeUnit.SECONDS);
+        stage.toCompletableFuture().get();
 
         final ArgumentCaptor<byte[]> bytes = ArgumentCaptor.forClass(byte[].class);
         Mockito.verify(builder).setBytes(bytes.capture());
@@ -85,12 +85,12 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
         assertEquals(response, "content we care about");
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void testImmediateRendering() throws Exception {
         runTestWithRenderDelay(Duration.ZERO);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void testDelayedRendering() throws Exception {
         runTestWithRenderDelay(Duration.ofSeconds(2));
     }

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -62,7 +63,7 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
         );
 
         final HtmlReportFormat format = new HtmlReportFormat.Builder().build();
-        final HtmlGrafanaScreenshotRenderer renderer = new HtmlGrafanaScreenshotRenderer(config);
+        final HtmlGrafanaScreenshotRenderer renderer = new HtmlGrafanaScreenshotRenderer(config, new ScheduledThreadPoolExecutor(1));
         final GrafanaReportPanelReportSource source = new GrafanaReportPanelReportSource.Builder()
                 .setWebPageReportSource(
                         TestBeanFactory.createWebPageReportSourceBuilder()

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/HtmlScreenshotRendererIT.java
@@ -74,7 +74,9 @@ public class HtmlScreenshotRendererIT extends BaseChromeIT {
                 source,
                 format,
                 new TimeRange(Instant.EPOCH, Instant.EPOCH),
-                builder);
+                builder,
+                Duration.ofSeconds(15)
+        );
 
         stage.toCompletableFuture().get(20, TimeUnit.SECONDS);
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
@@ -20,7 +20,6 @@ import com.arpnetworking.metrics.portal.reports.impl.chrome.BaseChromeIT;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.grafana.testing.Utils;
 import com.arpnetworking.metrics.portal.reports.impl.testing.MockRenderedReportBuilder;
 import com.typesafe.config.Config;
-import models.internal.TimeRange;
 import models.internal.impl.GrafanaReportPanelReportSource;
 import models.internal.impl.PdfReportFormat;
 import org.junit.Test;
@@ -29,7 +28,6 @@ import org.mockito.Mockito;
 
 import java.net.URI;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -72,9 +70,9 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
         final CompletionStage<MockRenderedReportBuilder> stage = renderer.render(
                 source,
                 format,
-                new TimeRange(Instant.EPOCH, Instant.EPOCH),
+                DEFAULT_TIME_RANGE,
                 builder,
-                Duration.ofSeconds(15)
+                DEFAULT_TIMEOUT
         );
 
         stage.toCompletableFuture().get(20, TimeUnit.SECONDS);

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
@@ -30,7 +30,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
@@ -72,7 +72,9 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
                 source,
                 format,
                 new TimeRange(Instant.EPOCH, Instant.EPOCH),
-                builder);
+                builder,
+                Duration.ofSeconds(15)
+        );
 
         stage.toCompletableFuture().get(20, TimeUnit.SECONDS);
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class PdfScreenshotRendererIT extends BaseChromeIT {
 
-    @Test
+    @Test(timeout = 20000)
     public void testRendering() throws Exception {
         final MockRenderedReportBuilder builder = Mockito.mock(MockRenderedReportBuilder.class);
         final Config config = CHROME_RENDERER_CONFIG;
@@ -75,7 +75,7 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
                 DEFAULT_TIMEOUT
         );
 
-        stage.toCompletableFuture().get(20, TimeUnit.SECONDS);
+        stage.toCompletableFuture().get();
 
         final ArgumentCaptor<byte[]> bytes = ArgumentCaptor.forClass(byte[].class);
         Mockito.verify(builder).setBytes(bytes.capture());

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/grafana/PdfScreenshotRendererIT.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -60,7 +61,7 @@ public class PdfScreenshotRendererIT extends BaseChromeIT {
                         )
         );
         final PdfReportFormat format = new PdfReportFormat.Builder().setWidthInches(8.5f).setHeightInches(11f).build();
-        final PdfGrafanaScreenshotRenderer renderer = new PdfGrafanaScreenshotRenderer(config);
+        final PdfGrafanaScreenshotRenderer renderer = new PdfGrafanaScreenshotRenderer(config, new ScheduledThreadPoolExecutor(1));
         final GrafanaReportPanelReportSource source = new GrafanaReportPanelReportSource.Builder()
                 .setWebPageReportSource(
                         TestBeanFactory.createWebPageReportSourceBuilder()


### PR DESCRIPTION
Not too complicated, just long! Had to plumb a new field all the way from UI to database.

Changes, sorted by how far down you'll have to scroll to see them:
- Split "timeout" for reports into two: one for rendering, one for sending. Each of these operations could conceivably time out.
- Pass a `Duration timeout` into both `Renderer.render` and `Sender.send`.
- Inject a `ScheduledExecutorService` into Renderer/Sender implementations, in order to respect the passed timeout.

Tested:
- added automated tests to ensure timeouts are respected
- manually created and edited reports in the UI
- created a Grafana report pointed at a normal web page (which will never fire the appropriate event, and therefore time out); used PGAdmin to confirm that the report execution aborted+failed after the specified timeout