### PR TITLE
When Chrome devtools are closed, close the entire tab

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsFactory.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsFactory.java
@@ -48,7 +48,7 @@ public final class DevToolsFactory {
         if (ignoreCertificateErrors) {
             result.getSecurity().setIgnoreCertificateErrors(true);
         }
-        return new DevToolsServiceWrapper(result);
+        return new DevToolsServiceWrapper(service, tab, result);
     }
 
     /**

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
@@ -33,14 +33,24 @@ import java.util.function.Supplier;
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
 public class DevToolsServiceWrapper implements DevToolsService {
+    private final com.github.kklisura.cdt.services.ChromeService _chromeService;
+    private final com.github.kklisura.cdt.services.types.ChromeTab _tab;
     private final com.github.kklisura.cdt.services.ChromeDevToolsService _dts;
 
     /**
-     * Public constructor.
+     * Constructor.
      *
+     * @param chromeService The {@link com.github.kklisura.cdt.services.ChromeService} that owns the devtools.
+     * @param tab The {@link com.github.kklisura.cdt.services.types.ChromeTab} associated with the devtools.
      * @param dts The {@link com.github.kklisura.cdt.services.ChromeDevToolsService} instance to wrap.
      */
-    public DevToolsServiceWrapper(final com.github.kklisura.cdt.services.ChromeDevToolsService dts) {
+    /* package private */ DevToolsServiceWrapper(
+            final com.github.kklisura.cdt.services.ChromeService chromeService,
+            final com.github.kklisura.cdt.services.types.ChromeTab tab,
+            final com.github.kklisura.cdt.services.ChromeDevToolsService dts
+    ) {
+        _chromeService = chromeService;
+        _tab = tab;
         _dts = dts;
     }
 
@@ -121,6 +131,7 @@ public class DevToolsServiceWrapper implements DevToolsService {
 
     @Override
     public void close() {
+        _chromeService.closeTab(_tab);
         _dts.close();
     }
 


### PR DESCRIPTION
Currently, the tab lingers, which could very easily become a serious memory leak. Oops.

- Before the fix, running `ps` after 0, 1, 20, and 40 Chrome-based reports have completely finished:

    ```
    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 0
    PID   RSS  COMMAND          COMMAND
        1 233m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
       84    4 ps               ps -ef -o pid,rss,comm,args

    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 1
    PID   RSS  COMMAND          COMMAND
        1 233m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
      102  33m chrome           /usr/lib/chromium/chrome --no-first-run --remote-de
      106  15m chrome           /usr/lib/chromium/chrome --type=zygote --no-sandbox
      124  42m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      159  47m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      173    4 ps               ps -ef -o pid,rss,comm,args

    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 20
    PID   RSS  COMMAND          COMMAND
        1 244m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
      102  75m chrome           /usr/lib/chromium/chrome --no-first-run --remote-de
      106  14m chrome           /usr/lib/chromium/chrome --type=zygote --no-sandbox
      124  40m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      159  60m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      478    4 ps               ps -ef -o pid,rss,comm,args

    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 40
    PID   RSS  COMMAND          COMMAND
        1 250m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
      102 119m chrome           /usr/lib/chromium/chrome --no-first-run --remote-de
      106  14m chrome           /usr/lib/chromium/chrome --type=zygote --no-sandbox
      124  40m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      159  74m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      796    4 ps               ps -ef -o pid,rss,comm,args
    ```
    
- The same, after the fix:

    ```
    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 0
    PID   RSS  COMMAND          COMMAND
        1 234m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
       83    4 ps               ps -ef -o pid,rss,comm,args

    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 1
    PID   RSS  COMMAND          COMMAND
        1 232m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
      101  31m chrome           /usr/lib/chromium/chrome --no-first-run --remote-de
      105  15m chrome           /usr/lib/chromium/chrome --type=zygote --no-sandbox
      123  39m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      172    4 ps               ps -ef -o pid,rss,comm,args

    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 20
    PID   RSS  COMMAND          COMMAND
        1 251m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
      101  39m chrome           /usr/lib/chromium/chrome --no-first-run --remote-de
      105  14m chrome           /usr/lib/chromium/chrome --type=zygote --no-sandbox
      123  39m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      489    4 ps               ps -ef -o pid,rss,comm,args

    ~ $ docker exec -it metrics-portal-1 ps -ef -o pid,rss,comm,args   # 40
    PID   RSS  COMMAND          COMMAND
        1 251m java             /usr/lib/jvm/java-1.8-openjdk/jre/bin/java -XX:+Hea
      101  38m chrome           /usr/lib/chromium/chrome --no-first-run --remote-de
      105  14m chrome           /usr/lib/chromium/chrome --type=zygote --no-sandbox
      123  39m chrome           /usr/lib/chromium/chrome --type=renderer --no-sandb
      823    4 ps               ps -ef -o pid,rss,comm,args
    ```


Lifted this method of closing the tab from [the example in the library's docs](https://github.com/kklisura/chrome-devtools-java-client/#usage).