### PR TITLE
Use an independent actor for holding rollups to be performed.

### DIFF
--- a/app/com/arpnetworking/rollups/NoMoreRollups.java
+++ b/app/com/arpnetworking/rollups/NoMoreRollups.java
@@ -15,31 +15,26 @@
  */
 package com.arpnetworking.rollups;
 
-import scala.concurrent.duration.Deadline;
-
 import java.io.Serializable;
 
 /**
- * Message class used to signify that no more metric names are available.
+ * Message class used to signify that no more rollups are available.
  *
  * @author Gilligan Markham (gmarkham at dropbox dot com)
  */
 public final class NoMoreRollups implements Serializable {
 
-    /**
-     * Creates a NoMoreMetrics instance with a specified deadline when more data is expected.
-     *
-     * @param nextRefresh point in time when the next refresh is schedule to occur.
-     */
-    public NoMoreRollups(final Deadline nextRefresh) {
-        // Protected against negative times.
-        _nextRefreshMillis = Math.max(nextRefresh.timeLeft().toMillis(), 0);
-    }
-
-    public long getNextRefreshMillis() {
-        return _nextRefreshMillis;
-    }
-
-    private final long _nextRefreshMillis;
     private static final long serialVersionUID = -3503619526731721351L;
+    private static final NoMoreRollups THE_INSTANCE = new NoMoreRollups();
+
+    /**
+     * Creates a NoMoreRollups instance.
+     */
+    private NoMoreRollups() {
+        // Protected against negative times.
+    }
+
+    public static NoMoreRollups getInstance() {
+        return THE_INSTANCE;
+    }
 }

--- a/app/com/arpnetworking/rollups/NoMoreRollups.java
+++ b/app/com/arpnetworking/rollups/NoMoreRollups.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import scala.concurrent.duration.Deadline;
+
+import java.io.Serializable;
+
+/**
+ * Message class used to signify that no more metric names are available.
+ *
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public final class NoMoreRollups implements Serializable {
+
+    /**
+     * Creates a NoMoreMetrics instance with a specified deadline when more data is expected.
+     *
+     * @param nextRefresh point in time when the next refresh is schedule to occur.
+     */
+    public NoMoreRollups(final Deadline nextRefresh) {
+        // Protected against negative times.
+        _nextRefreshMillis = Math.max(nextRefresh.timeLeft().toMillis(), 0);
+    }
+
+    public long getNextRefreshMillis() {
+        return _nextRefreshMillis;
+    }
+
+    private final long _nextRefreshMillis;
+    private static final long serialVersionUID = -3503619526731721351L;
+}

--- a/app/com/arpnetworking/rollups/RollupDefinition.java
+++ b/app/com/arpnetworking/rollups/RollupDefinition.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Data class that holds the information necessary to rollup a metric for a single period.
+ *
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public final class RollupDefinition implements Serializable {
+    private static final long serialVersionUID = -1098548879115718541L;
+    private final String _sourceMetricName;
+    private final String _destinationMetricName;
+    private final RollupPeriod _period;
+    private final Instant _startTime;
+    private final Instant _endTime;
+    private final ImmutableSet<String> _groupByTags;
+
+    private RollupDefinition(final Builder builder) {
+        _sourceMetricName = builder._sourceMetricName;
+        _destinationMetricName = builder._destinationMetricName;
+        _period = builder._period;
+        _startTime = builder._startTime;
+        _endTime = builder._endTime;
+        _groupByTags = builder._groupByTags;
+    }
+
+    public String getSourceMetricName() {
+        return _sourceMetricName;
+    }
+
+    public String getDestinationMetricName() {
+        return _destinationMetricName;
+    }
+
+    public RollupPeriod getPeriod() {
+        return _period;
+    }
+
+    public Instant getStartTime() {
+        return _startTime;
+    }
+
+    public Instant getEndTime() {
+        return _endTime;
+    }
+
+    public ImmutableSet<String> getGroupByTags() {
+        return _groupByTags;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final RollupDefinition that = (RollupDefinition) o;
+        return _sourceMetricName.equals(that._sourceMetricName)
+                && _destinationMetricName.equals(that._destinationMetricName)
+                && _period == that._period
+                && _startTime.equals(that._startTime)
+                && _endTime.equals(that._endTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_sourceMetricName, _destinationMetricName, _period, _startTime, _endTime, _groupByTags);
+    }
+
+    /**
+     * {@code RollupDefinition} builder static inner class.
+     */
+    public static final class Builder extends OvalBuilder<RollupDefinition> {
+        private String _sourceMetricName;
+        private String _destinationMetricName;
+        private RollupPeriod _period;
+        private Instant _startTime;
+        private Instant _endTime;
+        private ImmutableSet<String> _groupByTags;
+
+        /**
+         * Creates a builder for a RollupDefinition.
+         */
+        protected Builder() {
+            super(RollupDefinition::new);
+        }
+
+        /**
+         * Sets the {@code _sourceMetricName} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _sourceMetricName} to set
+         * @return a reference to this Builder
+         */
+        public Builder setSourceMetricName(final String value) {
+            _sourceMetricName = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@code _destinationMetricName} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _destinationMetricName} to set
+         * @return a reference to this Builder
+         */
+        public Builder setDestinationMetricName(final String value) {
+            _destinationMetricName = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@code _period} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _period} to set
+         * @return a reference to this Builder
+         */
+        public Builder setPeriod(final RollupPeriod value) {
+            _period = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@code _startTime} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _startTime} to set
+         * @return a reference to this Builder
+         */
+        public Builder setStartTime(final Instant value) {
+            _startTime = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@code _endTime} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _endTime} to set
+         * @return a reference to this Builder
+         */
+        public Builder setEndTime(final Instant value) {
+            _endTime = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@code _groupByTags} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _groupByTags} to set
+         * @return a reference to this Builder
+         */
+        public Builder setGroupByTags(final ImmutableSet<String> value) {
+            _groupByTags = value;
+            return this;
+        }
+    }
+}

--- a/app/com/arpnetworking/rollups/RollupDefinition.java
+++ b/app/com/arpnetworking/rollups/RollupDefinition.java
@@ -17,6 +17,8 @@ package com.arpnetworking.rollups;
 
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.google.common.collect.ImmutableSet;
+import net.sf.oval.constraint.NotEmpty;
+import net.sf.oval.constraint.NotNull;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -94,11 +96,19 @@ public final class RollupDefinition implements Serializable {
      * {@code RollupDefinition} builder static inner class.
      */
     public static final class Builder extends OvalBuilder<RollupDefinition> {
+        @NotNull
+        @NotEmpty
         private String _sourceMetricName;
+        @NotNull
+        @NotEmpty
         private String _destinationMetricName;
+        @NotNull
         private RollupPeriod _period;
+        @NotNull
         private Instant _startTime;
+        @NotNull
         private Instant _endTime;
+        @NotNull
         private ImmutableSet<String> _groupByTags;
 
         /**

--- a/app/com/arpnetworking/rollups/RollupExecutor.java
+++ b/app/com/arpnetworking/rollups/RollupExecutor.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import akka.actor.AbstractActorWithTimers;
+import akka.actor.ActorRef;
+import akka.pattern.PatternsCS;
+import com.arpnetworking.kairos.client.KairosDbClient;
+import com.arpnetworking.kairos.client.models.Aggregator;
+import com.arpnetworking.kairos.client.models.Metric;
+import com.arpnetworking.kairos.client.models.MetricsQuery;
+import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
+import com.arpnetworking.kairos.client.models.Sampling;
+import com.arpnetworking.metrics.Units;
+import com.arpnetworking.metrics.incubator.PeriodicMetrics;
+import com.arpnetworking.play.configuration.ConfigurationHelper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import net.sf.oval.constraint.NotNull;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Actor that fetches RollupDefinitions from a RollupManager and performs the specified
+ * Rollup.
+ *
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public class RollupExecutor extends AbstractActorWithTimers {
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .match(RollupDefinition.class, this::executeRollup)
+                .matchEquals(FETCH_ROLLUP, work -> this.fetchRollup())
+                .match(NoMoreRollups.class, work -> this.scheduleFetch())
+                .match(FinishRollupMessage.class, work -> this.fetchRollup())
+                .build();
+    }
+
+    @Override
+    public void preStart() {
+        getSelf().tell(FETCH_ROLLUP, ActorRef.noSender());
+    }
+
+    private void executeRollup(final RollupDefinition rollupDefinition) {
+        final long startTime = System.nanoTime();
+        PatternsCS.pipe(
+                performRollup(rollupDefinition)
+                        .handle((response, failure) -> {
+                            final String baseMetricName = "rollup/generator/perform_rollup_"
+                                    + rollupDefinition.getPeriod().name().toLowerCase(Locale.getDefault());
+                            _metrics.recordCounter(baseMetricName + "/success", failure == null ? 1 : 0);
+                            _metrics.recordTimer(
+                                    baseMetricName + "/latency",
+                                    System.nanoTime() - startTime,
+                                    Optional.of(Units.NANOSECOND));
+                            return new FinishRollupMessage.Builder()
+                                    .setRollupDefinition(rollupDefinition)
+                                    .setFailure(failure)
+                                    .build();
+                        }), getContext().dispatcher())
+                .to(getSelf());
+    }
+
+
+    private CompletionStage<MetricsQueryResponse> performRollup(final RollupDefinition rollupDefinition) {
+        final MetricsQuery.Builder queryBuilder = new MetricsQuery.Builder();
+        final Metric.Builder metricBuilder = new Metric.Builder();
+        final String rollupMetricName = rollupDefinition.getDestinationMetricName();
+        final RollupPeriod period = rollupDefinition.getPeriod();
+
+        queryBuilder.setStartTime(rollupDefinition.getStartTime());
+        queryBuilder.setEndTime(rollupDefinition.getEndTime());
+
+        metricBuilder.setName(rollupDefinition.getSourceMetricName());
+
+        if (!rollupDefinition.getGroupByTags().isEmpty()) {
+            metricBuilder.setGroupBy(ImmutableList.of(
+                    new MetricsQuery.GroupBy.Builder()
+                            .setName("tag")
+                            .addOtherArg("tags", rollupDefinition.getGroupByTags())
+                            .build()
+            ));
+        }
+        metricBuilder.setAggregators(ImmutableList.of(
+                new Aggregator.Builder()
+                        .setName("merge")
+                        .setSampling(new Sampling.Builder()
+                                .setValue(1)
+                                .setUnit(period.getSamplingUnit())
+                                .build())
+                        .setAlignSampling(true)
+                        .setAlignStartTime(true)
+                        .build(),
+                new Aggregator.Builder()
+                        .setName("save_as")
+                        .setOtherArgs(ImmutableMap.of("metric_name", rollupMetricName))
+                        .build(),
+                new Aggregator.Builder()
+                        .setName("count")
+                        .build()
+        ));
+
+        queryBuilder.setMetrics(ImmutableList.of(metricBuilder.build()));
+
+        return _kairosDbClient.queryMetrics(queryBuilder.build());
+    }
+
+    private void fetchRollup() {
+        _rollupManager.tell(RollupFetch.getInstance(), getSelf());
+    }
+
+
+    private void scheduleFetch() {
+        getTimers().startSingleTimer(FETCH_TIMER, FETCH_ROLLUP, _pollInterval);
+    }
+
+    /**
+     * RollupGenerator actor constructor.
+     *
+     * @param configuration play configuration
+     * @param rollupManager actor ref to RollupManager actor
+     * @param kairosDbClient kairosdb client
+     * @param metrics periodic metrics instance
+     */
+    @Inject
+    public RollupExecutor(
+            final Config configuration,
+            @Named("RollupManager") final ActorRef rollupManager,
+            final KairosDbClient kairosDbClient,
+            final PeriodicMetrics metrics) {
+        _rollupManager = rollupManager;
+        _kairosDbClient = kairosDbClient;
+        _metrics = metrics;
+        _pollInterval = ConfigurationHelper.getFiniteDuration(configuration, "rollup.worker.pollInterval");
+    }
+
+    private final KairosDbClient _kairosDbClient;
+    private final PeriodicMetrics _metrics;
+    private final ActorRef _rollupManager;
+    private final FiniteDuration _pollInterval;
+    private static final String FETCH_TIMER = "rollupFetchTimer";
+    static final Object FETCH_ROLLUP = new Object();
+
+    static final class FinishRollupMessage extends FailableMessage {
+        private static final long serialVersionUID = -5696789105734902279L;
+        private final RollupDefinition _rollupDefinition;
+
+        FinishRollupMessage(final Builder builder) {
+            super(builder);
+            this._rollupDefinition = builder._rollupDefinition;
+        }
+
+        public RollupDefinition getRollupDefinition() {
+            return _rollupDefinition;
+        }
+
+        /**
+         * {@link com.arpnetworking.rollups.FinishRollupMessage} builder static inner class.
+         */
+        public static final class Builder extends FailableMessage.Builder<Builder, FinishRollupMessage> {
+
+            /**
+             * Creates a builder for a FinishRollupMessage.
+             */
+            Builder() {
+                super(FinishRollupMessage::new);
+            }
+
+            /**
+             * Sets the {@code _metricName} and returns a reference to this Builder so that the methods can be chained together.
+             *
+             * @param value the {@code _metricName} to set
+             * @return a reference to this Builder
+             */
+            public Builder setRollupDefinition(final RollupDefinition value) {
+                _rollupDefinition = value;
+                return this;
+            }
+
+
+            @Override
+            protected void reset() {
+                super.reset();
+                _rollupDefinition = null;
+            }
+
+            @Override
+            protected Builder self() {
+                return this;
+            }
+
+            @NotNull
+            private RollupDefinition _rollupDefinition;
+        }
+    }
+}

--- a/app/com/arpnetworking/rollups/RollupFetch.java
+++ b/app/com/arpnetworking/rollups/RollupFetch.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import java.io.Serializable;
+
+/**
+ * Message class used to cause the RollupManager actor to respond with a rollup task to
+ * execute.
+ *
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public final class RollupFetch implements Serializable {
+
+    public static RollupFetch getInstance() {
+        return THE_INSTANCE;
+    }
+
+    private RollupFetch() {
+    }
+
+    private static final RollupFetch THE_INSTANCE = new RollupFetch();
+    private static final long serialVersionUID = -5228306672149052183L;
+}

--- a/app/com/arpnetworking/rollups/RollupManager.java
+++ b/app/com/arpnetworking/rollups/RollupManager.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import akka.actor.AbstractActorWithTimers;
+import com.arpnetworking.metrics.incubator.PeriodicMetrics;
+import com.arpnetworking.play.configuration.ConfigurationHelper;
+import com.typesafe.config.Config;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+
+/**
+ * Actor for holding and dispatching rollup definitions.  This allows for different mechanisms, e.g. automated
+ * rollups and manual backfills, to be ordered, staged and de-duplicated before being acted upon.
+ *
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public class RollupManager extends AbstractActorWithTimers {
+    private final PeriodicMetrics _periodicMetrics;
+    private TreeSet<RollupDefinition> _rollupDefinitions;
+    private FiniteDuration _refreshInterval;
+
+    private static final Object RECORD_METRICS_MSG = new Object();
+    private static final String METRICS_TIMER = "metrics_timer";
+    private static final FiniteDuration METRICS_INTERVAL = FiniteDuration.apply(1, TimeUnit.SECONDS);
+
+    /**
+     * Metrics discovery constructor.
+     *
+     * @param configuration play configuration object
+     * @param periodicMetrics periodic metrics client
+     */
+    @Inject
+    public RollupManager(final Config configuration, final PeriodicMetrics periodicMetrics) {
+        _refreshInterval = ConfigurationHelper.getFiniteDuration(configuration, "rollup.fetch.interval");
+        _periodicMetrics = periodicMetrics;
+        _rollupDefinitions = new TreeSet<>(new RollupComparator());
+        getTimers().startPeriodicTimer(METRICS_TIMER, RECORD_METRICS_MSG, METRICS_INTERVAL);
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .matchEquals(
+                        RECORD_METRICS_MSG,
+                        work -> _periodicMetrics.recordGauge("rollup/manager/queue_size", _rollupDefinitions.size()))
+                .match(
+                        RollupDefinition.class,
+                        work -> _rollupDefinitions.add(work))
+                .match(
+                        RollupFetch.class,
+                        work -> {
+                            final Optional<RollupDefinition> rollupDefinition = getNextRollup();
+                            if (rollupDefinition.isPresent()) {
+                                getSender().tell(rollupDefinition.get(), getSelf());
+                            } else {
+                                getSender().tell(new NoMoreRollups(_refreshInterval.fromNow()), getSelf());
+                            }
+
+                        })
+                .build();
+    }
+
+    private Optional<RollupDefinition> getNextRollup() {
+        return Optional.ofNullable(_rollupDefinitions.pollFirst());
+    }
+
+    private static class RollupComparator implements Comparator<RollupDefinition>, Serializable {
+
+        private static final long serialVersionUID = -3992696463296110397L;
+
+        @Override
+        public int compare(final RollupDefinition def1, final RollupDefinition def2) {
+            // It's assumed that if the source, destination and period are the same then they represent
+            // the same period for a different (or the same) time range.  We don't check endTime, groupByTags,
+            // etc, because if they were different then the resulting rollup would be broken anyway.
+            if (Objects.hash(def1.getSourceMetricName(), def1.getDestinationMetricName(), def1.getPeriod())
+                    == Objects.hash(def2.getSourceMetricName(), def2.getDestinationMetricName(), def2.getPeriod())) {
+                return def1.getStartTime().compareTo(def2.getStartTime());
+            } else {
+                return 1;
+            }
+        }
+    }
+}

--- a/app/com/arpnetworking/rollups/RollupManager.java
+++ b/app/com/arpnetworking/rollups/RollupManager.java
@@ -74,7 +74,7 @@ public class RollupManager extends AbstractActorWithTimers {
                             if (rollupDefinition.isPresent()) {
                                 getSender().tell(rollupDefinition.get(), getSelf());
                             } else {
-                                getSender().tell(new NoMoreRollups(_refreshInterval.fromNow()), getSelf());
+                                getSender().tell(NoMoreRollups.getInstance(), getSelf());
                             }
 
                         })

--- a/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
@@ -122,6 +122,7 @@ public class RollupExecutorTest {
                                 .setPeriod(RollupPeriod.HOURLY)
                                 .setStartTime(Instant.EPOCH)
                                 .setEndTime(Instant.EPOCH.plusMillis(1))
+                                .setGroupByTags(ImmutableSet.of())
                                 .build()
                         )
                         .build(),

--- a/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
@@ -42,7 +42,6 @@ import org.mockito.MockitoAnnotations;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -71,8 +70,6 @@ public class RollupExecutorTest {
     private TestKit _probe;
 
     private ActorSystem _system;
-
-    private static final AtomicLong SYSTEM_NAME_NONCE = new AtomicLong(0);
 
     @Before
     public void setUp() {

--- a/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.javadsl.TestKit;
+import com.arpnetworking.commons.akka.GuiceActorCreator;
+import com.arpnetworking.kairos.client.KairosDbClient;
+import com.arpnetworking.kairos.client.models.Metric;
+import com.arpnetworking.kairos.client.models.MetricsQuery;
+import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
+import com.arpnetworking.kairos.client.models.SamplingUnit;
+import com.arpnetworking.metrics.incubator.PeriodicMetrics;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import com.typesafe.config.Config;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+/**
+ * Test cases for the RollupGenerator actor.
+ *
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public class RollupExecutorTest {
+    private Injector _injector;
+    @Mock
+    private KairosDbClient _kairosDbClient;
+    @Mock
+    private Config _config;
+    @Mock
+    private PeriodicMetrics _periodicMetrics;
+    private TestKit _probe;
+
+    private ActorSystem _system;
+
+    private static final AtomicLong SYSTEM_NAME_NONCE = new AtomicLong(0);
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(_config.getString(eq("rollup.worker.pollInterval"))).thenReturn("3sec");
+
+        _system = ActorSystem.create();
+
+        _probe = new TestKit(_system);
+
+        _injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(KairosDbClient.class).toInstance(_kairosDbClient);
+                bind(Config.class).toInstance(_config);
+                bind(ActorRef.class)
+                        .annotatedWith(Names.named("RollupManager"))
+                        .toInstance(_probe.getRef());
+                bind(PeriodicMetrics.class).toInstance(_periodicMetrics);
+            }
+        });
+    }
+
+    @After
+    public void tearDown() {
+        TestKit.shutdownActorSystem(_system);
+        _system = null;
+    }
+
+    private ActorRef createActor() {
+        return _system.actorOf(GuiceActorCreator.props(_injector, TestRollupExecutor.class));
+    }
+
+    @Test
+    public void testSendsFetchOnStartup() {
+        final ActorRef actor = createActor();
+        _probe.expectMsg(RollupExecutor.FETCH_ROLLUP);
+        actor.tell(RollupExecutor.FETCH_ROLLUP, ActorRef.noSender());
+        _probe.expectMsg(RollupFetch.getInstance());
+    }
+
+    @Test
+    public void testFetchesNextRollup() {
+        final ActorRef actor = createActor();
+        _probe.expectMsg(RollupExecutor.FETCH_ROLLUP);
+        actor.tell(new RollupExecutor.FinishRollupMessage.Builder()
+                        .setRollupDefinition(new RollupDefinition.Builder()
+                                .setSourceMetricName("metric")
+                                .setDestinationMetricName("metric_1h")
+                                .setPeriod(RollupPeriod.HOURLY)
+                                .setStartTime(Instant.EPOCH)
+                                .setEndTime(Instant.EPOCH.plusMillis(1))
+                                .build()
+                        )
+                        .build(),
+                ActorRef.noSender()
+        );
+        _probe.expectMsg(RollupFetch.getInstance());
+    }
+
+    @Test
+    public void testPerformsRollup() {
+        when(_kairosDbClient.queryMetrics(any())).thenAnswer(invocation -> {
+            final CompletableFuture<MetricsQueryResponse> future = new CompletableFuture<>();
+            final Object arg0 = invocation.getArguments()[0];
+            if (arg0 instanceof MetricsQuery) {
+                final MetricsQuery query = (MetricsQuery) arg0;
+                final String metricName = query.getMetrics().get(0).getName();
+                final MetricsQueryResponse.QueryResult.Builder builder = new MetricsQueryResponse.QueryResult.Builder();
+                builder.setName(metricName);
+
+                builder.setValues(ImmutableList.of(new MetricsQueryResponse.DataPoint.Builder()
+                        .setTime(Instant.EPOCH)
+                        .setValue(0.0)
+                        .build()
+                ));
+                future.complete(new MetricsQueryResponse.Builder()
+                        .setQueries(ImmutableList.of(new MetricsQueryResponse.Query.Builder()
+                                .setResults(ImmutableList.of(builder.build()))
+                                .build()))
+                        .build()
+                );
+            }
+
+            return future;
+        });
+
+        final ArgumentCaptor<MetricsQuery> captor = ArgumentCaptor.forClass(MetricsQuery.class);
+        final ActorRef actor = createActor();
+        _probe.expectMsg(RollupExecutor.FETCH_ROLLUP);
+
+        actor.tell(
+                new RollupDefinition.Builder()
+                        .setSourceMetricName("metric")
+                        .setDestinationMetricName("metric_1h")
+                        .setPeriod(RollupPeriod.HOURLY)
+                        .setGroupByTags(ImmutableSet.of("tag1", "tag2"))
+                        .setStartTime(Instant.EPOCH)
+                        .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS))
+                        .build(),
+                ActorRef.noSender());
+
+        final RollupExecutor.FinishRollupMessage finishRollupMessage =
+                _probe.expectMsgClass(RollupExecutor.FinishRollupMessage.class);
+        assertFalse(finishRollupMessage.isFailure());
+        assertEquals("metric", finishRollupMessage.getRollupDefinition().getSourceMetricName());
+        assertEquals(RollupPeriod.HOURLY, finishRollupMessage.getRollupDefinition().getPeriod());
+
+        verify(_kairosDbClient, times(1)).queryMetrics(captor.capture());
+        final MetricsQuery rollupQuery = captor.getValue();
+        assertEquals("metric", rollupQuery.getMetrics().get(0).getName());
+        assertEquals(Instant.EPOCH, rollupQuery.getStartTime());
+        assertTrue(rollupQuery.getEndTime().isPresent());
+        assertEquals(Instant.EPOCH.plus(1, ChronoUnit.HOURS), rollupQuery.getEndTime().get());
+        assertEquals(1, rollupQuery.getMetrics().size());
+        final Metric metric = rollupQuery.getMetrics().get(0);
+        assertEquals(1, metric.getGroupBy().size());
+        assertEquals("tag", metric.getGroupBy().get(0).getName());
+        assertEquals(ImmutableSet.of("tag1", "tag2"), metric.getGroupBy().get(0).getOtherArgs().get("tags"));
+        assertEquals(3, metric.getAggregators().size());
+        assertEquals("merge", metric.getAggregators().get(0).getName());
+        assertTrue(metric.getAggregators().get(0).getAlignSampling().isPresent());
+        assertTrue(metric.getAggregators().get(0).getAlignSampling().get());
+        assertTrue(metric.getAggregators().get(0).getAlignStartTime().isPresent());
+        assertTrue(metric.getAggregators().get(0).getAlignStartTime().get());
+        assertFalse(metric.getAggregators().get(0).getAlignEndTime().isPresent());
+        assertTrue(metric.getAggregators().get(0).getSampling().isPresent());
+        assertEquals(1L, metric.getAggregators().get(0).getSampling().get().getValue());
+        assertEquals(SamplingUnit.HOURS, metric.getAggregators().get(0).getSampling().get().getUnit());
+        assertEquals("save_as", metric.getAggregators().get(1).getName());
+        assertEquals("metric_1h", metric.getAggregators().get(1).getOtherArgs().get("metric_name"));
+        assertFalse(metric.getAggregators().get(1).getSampling().isPresent());
+        assertEquals("count", metric.getAggregators().get(2).getName());
+        assertFalse(metric.getAggregators().get(2).getSampling().isPresent());
+
+        _probe.expectNoMessage();
+    }
+
+    /**
+     * Test actor class that overrides {@code getSelf()} so that messages passed back to the actor
+     * can be intercepted.
+     */
+    public static final class TestRollupExecutor extends RollupExecutor {
+        @Inject
+        public TestRollupExecutor(
+                final Config configuration,
+                @Named("RollupManager") final ActorRef testActor,
+                final KairosDbClient kairosDbClient,
+                final PeriodicMetrics metrics) {
+            super(configuration, testActor, kairosDbClient, metrics);
+            _self = testActor;
+        }
+
+        @Override
+        public ActorRef getSelf() {
+            return _self;
+        }
+
+        private final ActorRef _self;
+    }
+}

--- a/test/java/com/arpnetworking/rollups/RollupManagerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupManagerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.TestActorRef;
+import akka.testkit.javadsl.TestKit;
+import com.arpnetworking.commons.akka.GuiceActorCreator;
+import com.arpnetworking.metrics.incubator.PeriodicMetrics;
+import com.arpnetworking.metrics.portal.AkkaClusteringConfigFactory;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link MetricsDiscovery}.
+ *
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public final class RollupManagerTest {
+    private Injector _injector;
+    @Mock
+    private Config _config;
+    @Mock
+    private PeriodicMetrics _periodicMetrics;
+    private ActorSystem _system;
+
+    private static final AtomicLong SYSTEM_NAME_NONCE = new AtomicLong(0);
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(_config.getString(eq("rollup.fetch.interval"))).thenReturn("1h");
+
+        _injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Config.class).toInstance(_config);
+                bind(PeriodicMetrics.class).toInstance(_periodicMetrics);
+            }
+        });
+
+        _system = ActorSystem.create(
+                "test-" + SYSTEM_NAME_NONCE.getAndIncrement(),
+                ConfigFactory.parseMap(AkkaClusteringConfigFactory.generateConfiguration()));
+
+    }
+
+    @After
+    public void tearDown() {
+        TestKit.shutdownActorSystem(_system);
+        _system = null;
+    }
+
+    private TestActorRef<MetricsDiscovery> createActor() {
+        return TestActorRef.create(_system, GuiceActorCreator.props(_injector, RollupManager.class));
+    }
+
+    @Test
+    public void testStoreRollupDefinition() {
+        final TestKit testKit = new TestKit(_system);
+        final ActorRef actor = createActor();
+        final ActorRef testActor = testKit.getTestActor();
+        final RollupDefinition.Builder rollupDefBuilder = new RollupDefinition.Builder()
+                .setSourceMetricName("foo")
+                .setDestinationMetricName("foo_1h")
+                .setPeriod(RollupPeriod.HOURLY)
+                .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
+                .setStartTime(Instant.EPOCH)
+                .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS));
+        final RollupDefinition rollupDef = rollupDefBuilder.build();
+        final RollupDefinition rollupDef2 = rollupDefBuilder
+                .setDestinationMetricName("foo_1d")
+                .setPeriod(RollupPeriod.DAILY).build();
+
+        actor.tell(rollupDef, testActor);
+        actor.tell(rollupDef2, testActor);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsg(rollupDef);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsg(rollupDef2);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsgClass(NoMoreRollups.class);
+    }
+
+    @Test
+    public void testDeDupsRollups() {
+        final TestKit testKit = new TestKit(_system);
+        final ActorRef actor = createActor();
+        final ActorRef testActor = testKit.getTestActor();
+        final RollupDefinition.Builder rollupDefBuilder = new RollupDefinition.Builder()
+                .setSourceMetricName("foo")
+                .setDestinationMetricName("foo_1h")
+                .setPeriod(RollupPeriod.HOURLY)
+                .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
+                .setStartTime(Instant.EPOCH)
+                .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS));
+        final RollupDefinition rollupDef = rollupDefBuilder.build();
+        final RollupDefinition rollupDef2 = rollupDefBuilder.build();
+        actor.tell(rollupDef, testActor);
+        actor.tell(rollupDef2, testActor);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsg(rollupDef);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsgClass(NoMoreRollups.class);
+    }
+
+    @Test
+    public void testReturnsRollupsInChronologicalOrder() {
+        final TestKit testKit = new TestKit(_system);
+        final ActorRef actor = createActor();
+        final ActorRef testActor = testKit.getTestActor();
+        final RollupDefinition.Builder rollupDefBuilder = new RollupDefinition.Builder()
+                .setSourceMetricName("foo")
+                .setDestinationMetricName("foo_1h")
+                .setPeriod(RollupPeriod.HOURLY)
+                .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
+                .setStartTime(Instant.EPOCH)
+                .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS));
+        final RollupDefinition rollupDef = rollupDefBuilder.build();
+        final RollupDefinition rollupDef2 = rollupDefBuilder.setStartTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS)).build();
+        actor.tell(rollupDef2, testActor);
+        actor.tell(rollupDef, testActor);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsg(rollupDef);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsg(rollupDef2);
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsgClass(NoMoreRollups.class);
+    }
+
+
+
+}


### PR DESCRIPTION
Adds a cluster sharded actor that holds rollups to be performed, with an actor for actually executing those rollups.

Currently the actors are not all fully configured, this will also be followed with a PR to remove the rollup execution code out of the RollupGenerator actor.  That actor will instead send RollupDefinitions to the new RollupManager actor.