### PR TITLE
Wired in RollupExecutor and made RollupGenerator delegate to RollupManager.

### DIFF
--- a/app/com/arpnetworking/rollups/RollupManager.java
+++ b/app/com/arpnetworking/rollups/RollupManager.java
@@ -17,8 +17,6 @@ package com.arpnetworking.rollups;
 
 import akka.actor.AbstractActorWithTimers;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
-import com.arpnetworking.play.configuration.ConfigurationHelper;
-import com.typesafe.config.Config;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.Serializable;
@@ -38,7 +36,6 @@ import javax.inject.Inject;
 public class RollupManager extends AbstractActorWithTimers {
     private final PeriodicMetrics _periodicMetrics;
     private TreeSet<RollupDefinition> _rollupDefinitions;
-    private FiniteDuration _refreshInterval;
 
     private static final Object RECORD_METRICS_MSG = new Object();
     private static final String METRICS_TIMER = "metrics_timer";
@@ -47,12 +44,10 @@ public class RollupManager extends AbstractActorWithTimers {
     /**
      * Metrics discovery constructor.
      *
-     * @param configuration play configuration object
      * @param periodicMetrics periodic metrics client
      */
     @Inject
-    public RollupManager(final Config configuration, final PeriodicMetrics periodicMetrics) {
-        _refreshInterval = ConfigurationHelper.getFiniteDuration(configuration, "rollup.fetch.interval");
+    public RollupManager(final PeriodicMetrics periodicMetrics) {
         _periodicMetrics = periodicMetrics;
         _rollupDefinitions = new TreeSet<>(new RollupComparator());
         getTimers().startPeriodicTimer(METRICS_TIMER, RECORD_METRICS_MSG, METRICS_INTERVAL);

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -124,7 +124,8 @@ hostProvider {
 # Rollups
 # ~~~~~
 rollup {
-  worker.count = 5
+  generator.count = 5
+  executor.count = 5
   fetch.interval = "1h"
   fetch.backoff = "5min"
   maxBackFill.periods = 2160

--- a/test/java/com/arpnetworking/rollups/RollupManagerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupManagerTest.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -38,9 +37,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
-
 /**
  * Test cases for {@link MetricsDiscovery}.
  *
@@ -48,8 +44,6 @@ import static org.mockito.Mockito.when;
  */
 public final class RollupManagerTest {
     private Injector _injector;
-    @Mock
-    private Config _config;
     @Mock
     private PeriodicMetrics _periodicMetrics;
     private ActorSystem _system;
@@ -59,12 +53,10 @@ public final class RollupManagerTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        when(_config.getString(eq("rollup.fetch.interval"))).thenReturn("1h");
 
         _injector = Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
-                bind(Config.class).toInstance(_config);
                 bind(PeriodicMetrics.class).toInstance(_periodicMetrics);
             }
         });
@@ -157,7 +149,4 @@ public final class RollupManagerTest {
         actor.tell(RollupFetch.getInstance(), testActor);
         testKit.expectMsgClass(NoMoreRollups.class);
     }
-
-
-
 }


### PR DESCRIPTION

This wires up the RollupExecutor actor in the MainModule and changes RollupGenerator to send RollupDefinitions to RollupManager rather than execute the rollup queries itself.