### PR TITLE
add OriginConfig class

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
@@ -17,8 +17,6 @@
 package com.arpnetworking.metrics.portal.reports.impl.chrome;
 
 import com.arpnetworking.commons.builder.OvalBuilder;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -32,7 +30,6 @@ import java.util.regex.Pattern;
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
-@JsonDeserialize(builder = OriginConfig.Builder.class)
 public final class OriginConfig {
 
     private OriginConfig(final Builder builder) {
@@ -111,7 +108,6 @@ public final class OriginConfig {
     /**
      * Builder implementation that constructs {@code OriginConfig}.
      */
-    @JsonPOJOBuilder(withPrefix = "set")
     public static final class Builder extends OvalBuilder<OriginConfig> {
         /**
          * Public Constructor.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
@@ -52,6 +52,8 @@ public final class OriginConfig {
      * @return Whether a browser should be allowed to navigate to that path.
      */
     public boolean isNavigationAllowed(final String path) {
+        // We _could_ precompile all the patterns so they don't need to be re-compiled each time,
+        //   but this is in the context of making HTTP requests: compiling a regex is not our bottleneck here.
         return _allowedNavigationPaths.stream().anyMatch(pattern -> Pattern.compile(pattern).matcher(path).matches());
     }
 

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
@@ -78,11 +78,6 @@ public final class OriginConfig {
         return _additionalHeaders;
     }
 
-//    public static OriginConfig fromConfig(final Config config) {
-//        return new Builder()
-//                .setAdditionalHeaders(config.)
-//    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfig.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Describes special actions that should be done for some origin (i.e. scheme+host+port).
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
+@JsonDeserialize(builder = OriginConfig.Builder.class)
+public final class OriginConfig {
+
+    private OriginConfig(final Builder builder) {
+        _allowedNavigationPaths = ImmutableSet.copyOf(builder._allowedNavigationPaths);
+        _allowedRequestPaths = ImmutableSet.copyOf(builder._allowedRequestPaths);
+        _additionalHeaders = ImmutableMap.copyOf(builder._additionalHeaders);
+    }
+
+    private final ImmutableSet<String> _allowedNavigationPaths;
+    private final ImmutableSet<String> _allowedRequestPaths;
+    private final ImmutableMap<String, String> _additionalHeaders;
+
+    /**
+     * Tests whether a browser should be allowed to navigate to a path.
+     *
+     * @param path The path to be navigated to.
+     * @return Whether a browser should be allowed to navigate to that path.
+     */
+    public boolean isNavigationAllowed(final String path) {
+        return _allowedNavigationPaths.stream().anyMatch(pattern -> Pattern.compile(pattern).matcher(path).matches());
+    }
+
+    /**
+     * Tests whether a browser should be allowed to make a request to a path.
+     *
+     * @param path The path to be requested.
+     * @return Whether requests should be allowed to that path.
+     */
+    public boolean isRequestAllowed(final String path) {
+        return isNavigationAllowed(path)
+                || _allowedRequestPaths.stream().anyMatch(pattern -> Pattern.compile(pattern).matcher(path).matches());
+    }
+
+    public ImmutableSet<String> getAllowedNavigationPaths() {
+        return _allowedNavigationPaths;
+    }
+
+    public ImmutableSet<String> getAllowedRequestPaths() {
+        return _allowedRequestPaths;
+    }
+
+    public ImmutableMap<String, String> getAdditionalHeaders() {
+        return _additionalHeaders;
+    }
+
+//    public static OriginConfig fromConfig(final Config config) {
+//        return new Builder()
+//                .setAdditionalHeaders(config.)
+//    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final OriginConfig that = (OriginConfig) o;
+        return _allowedNavigationPaths.equals(that._allowedNavigationPaths)
+                && _allowedRequestPaths.equals(that._allowedRequestPaths)
+                && _additionalHeaders.equals(that._additionalHeaders);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_allowedNavigationPaths, _allowedRequestPaths, _additionalHeaders);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("allowedNavigationPaths", _allowedNavigationPaths)
+                .add("allowedRequestPaths", _allowedRequestPaths)
+                .add("additionalHeaders", _additionalHeaders)
+                .toString();
+    }
+
+    /**
+     * Builder implementation that constructs {@code OriginConfig}.
+     */
+    @JsonPOJOBuilder(withPrefix = "set")
+    public static final class Builder extends OvalBuilder<OriginConfig> {
+        /**
+         * Public Constructor.
+         */
+        public Builder() {
+            super(OriginConfig::new);
+        }
+
+        /**
+         * Set the patterns of paths to which navigation should be allowed. Optional. Defaults to empty set.
+         *
+         * @param allowedNavigationPaths The path patterns.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setAllowedNavigationPaths(final ImmutableSet<String> allowedNavigationPaths) {
+            _allowedNavigationPaths = allowedNavigationPaths;
+            return this;
+        }
+
+        /**
+         * Add a pattern to the set of paths that requests should be allowed to. Optional. Defaults to empty set.
+         *
+         * @param allowedRequestPaths The path pattern.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setAllowedRequestPaths(final ImmutableSet<String> allowedRequestPaths) {
+            _allowedRequestPaths = allowedRequestPaths;
+            return this;
+        }
+
+        /**
+         * Add a header that should be added to all requests to this origin. Optional. Defaults to empty map.
+         *
+         * @param additionalHeaders The header name.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setAdditionalHeaders(final ImmutableMap<String, String> additionalHeaders) {
+            _additionalHeaders = additionalHeaders;
+            return this;
+        }
+
+        private Set<String> _allowedNavigationPaths = ImmutableSet.of();
+        private Set<String> _allowedRequestPaths = ImmutableSet.of();
+        private ImmutableMap<String, String> _additionalHeaders = ImmutableMap.of();
+    }
+}

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
@@ -1,0 +1,76 @@
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OriginConfigTest {
+    @Test
+    public void testDeserialization() throws IOException {
+        assertEquals(
+                new OriginConfig.Builder()
+                        .setAdditionalHeaders(ImmutableMap.of())
+                        .setAllowedNavigationPaths(ImmutableSet.of())
+                        .setAllowedRequestPaths(ImmutableSet.of())
+                        .build(),
+                MAPPER.readValue(
+                        "{}",
+                        OriginConfig.class
+                )
+        );
+
+        assertEquals(
+                new OriginConfig.Builder()
+                        .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-.*"))
+                        .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-.*"))
+                        .setAdditionalHeaders(ImmutableMap.of("X-Extra-Header", "extra header value"))
+                        .build(),
+                MAPPER.readValue(
+                        "{\n" +
+                                "  \"allowedRequestPaths\": [\"/allowed-req-.*\"],\n" +
+                                "  \"allowedNavigationPaths\": [\"/allowed-nav-.*\"],\n" +
+                                "  \"additionalHeaders\": {\"X-Extra-Header\": \"extra header value\"}\n" +
+                                "}",
+                        OriginConfig.class
+                )
+        );
+    }
+
+    @Test
+    public void testIsRequestAllowed() {
+        final OriginConfig config = new OriginConfig.Builder()
+                .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-.*"))
+                .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-.*"))
+                .build();
+
+        assertFalse(config.isRequestAllowed(""));
+        assertFalse(config.isRequestAllowed("/disallowed"));
+        assertTrue(config.isRequestAllowed("/allowed-req-1"));
+        assertTrue(config.isRequestAllowed("/allowed-nav-1"));
+    }
+
+    @Test
+    public void testIsNavigationAllowed() {
+        final OriginConfig config = new OriginConfig.Builder()
+                .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-.*"))
+                .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-.*"))
+                .build();
+
+        assertFalse(config.isNavigationAllowed(""));
+        assertFalse(config.isNavigationAllowed("/disallowed"));
+        assertFalse(config.isNavigationAllowed("/allowed-req-1"));
+        assertTrue(config.isNavigationAllowed("/allowed-nav-1"));
+    }
+
+
+    private static final ObjectMapper MAPPER = ObjectMapperFactory.createInstance();
+}

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.arpnetworking.metrics.portal.reports.impl.chrome;
 
 import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
@@ -12,6 +28,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests for {@link OriginConfig}.
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
 public class OriginConfigTest {
     @Test
     public void testDeserialization() throws IOException {

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
@@ -50,14 +50,14 @@ public class OriginConfigTest {
 
         assertEquals(
                 new OriginConfig.Builder()
-                        .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-.*"))
-                        .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-.*"))
+                        .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-\\d+"))
+                        .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-\\d+"))
                         .setAdditionalHeaders(ImmutableMap.of("X-Extra-Header", "extra header value"))
                         .build(),
                 MAPPER.readValue(
                         "{\n"
-                                + "  \"allowedRequestPaths\": [\"/allowed-req-.*\"],\n"
-                                + "  \"allowedNavigationPaths\": [\"/allowed-nav-.*\"],\n"
+                                + "  \"allowedRequestPaths\": [\"/allowed-req-\\\\d+\"],\n"
+                                + "  \"allowedNavigationPaths\": [\"/allowed-nav-\\\\d+\"],\n"
                                 + "  \"additionalHeaders\": {\"X-Extra-Header\": \"extra header value\"}\n"
                                 + "}",
                         OriginConfig.class
@@ -68,27 +68,33 @@ public class OriginConfigTest {
     @Test
     public void testIsRequestAllowed() {
         final OriginConfig config = new OriginConfig.Builder()
-                .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-.*"))
-                .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-.*"))
+                .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-\\d+"))
+                .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-\\d+"))
                 .build();
 
         assertFalse(config.isRequestAllowed(""));
         assertFalse(config.isRequestAllowed("/disallowed"));
         assertTrue(config.isRequestAllowed("/allowed-req-1"));
         assertTrue(config.isRequestAllowed("/allowed-nav-1"));
+
+        assertFalse(config.isRequestAllowed("/sneaky-prefix/allowed-req-1"));
+        assertFalse(config.isRequestAllowed("/allowed-req-1/sneaky-suffix"));
     }
 
     @Test
     public void testIsNavigationAllowed() {
         final OriginConfig config = new OriginConfig.Builder()
-                .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-.*"))
-                .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-.*"))
+                .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-\\d+"))
+                .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-\\d+"))
                 .build();
 
         assertFalse(config.isNavigationAllowed(""));
         assertFalse(config.isNavigationAllowed("/disallowed"));
         assertFalse(config.isNavigationAllowed("/allowed-req-1"));
         assertTrue(config.isNavigationAllowed("/allowed-nav-1"));
+
+        assertFalse(config.isRequestAllowed("/sneaky-prefix/allowed-nav-1"));
+        assertFalse(config.isRequestAllowed("/allowed-nav-1/sneaky-suffix"));
     }
 
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/OriginConfigTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -35,11 +34,11 @@ public class OriginConfigTest {
                         .setAdditionalHeaders(ImmutableMap.of("X-Extra-Header", "extra header value"))
                         .build(),
                 MAPPER.readValue(
-                        "{\n" +
-                                "  \"allowedRequestPaths\": [\"/allowed-req-.*\"],\n" +
-                                "  \"allowedNavigationPaths\": [\"/allowed-nav-.*\"],\n" +
-                                "  \"additionalHeaders\": {\"X-Extra-Header\": \"extra header value\"}\n" +
-                                "}",
+                        "{\n"
+                                + "  \"allowedRequestPaths\": [\"/allowed-req-.*\"],\n"
+                                + "  \"allowedNavigationPaths\": [\"/allowed-nav-.*\"],\n"
+                                + "  \"additionalHeaders\": {\"X-Extra-Header\": \"extra header value\"}\n"
+                                + "}",
                         OriginConfig.class
                 )
         );


### PR DESCRIPTION
An instance of this class defines policies to be implemented for a particular origin, e.g. what paths should be requestable/navigable-to or what headers should be added to requests to that origin.

Potentially controversial: I've added Jackson annotations to this class so that it's deserializable from JSON. I'm hoping to use Jackson to deserialize the `Map<String, OriginConfig>` in the application.conf file, because manually validating fields' presence/types is a pain. I'd be willing-but-not-thrilled to budge on this.