### PR TITLE
add class to coordinate between many origins' configs

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactory.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactory.java
@@ -17,7 +17,6 @@ package com.arpnetworking.metrics.portal.reports.impl.chrome;
 
 import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
 import com.arpnetworking.play.configuration.ConfigurationHelper;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.kklisura.cdt.launch.ChromeArguments;
 import com.github.kklisura.cdt.launch.ChromeLauncher;
@@ -81,7 +80,7 @@ public final class DefaultDevToolsFactory implements DevToolsFactory {
      *       <li>{@code queueSize} is how large the executor's queue should be before task-submissions start blocking.</li>
      *     </ul>
      *   </li>
-     *   <li>{@code origins} is a mapping from web origins (i.e. {@code scheme://authority}) to {@link OriginConfig}s,
+     *   <li>{@code originConfigs} is a {@link PerOriginConfigs} object,
      *     describing each allowed origin's permissions/configuration.</li>
      *   </ul>
      * @param objectMapper is an {@link ObjectMapper} used to deserialize parts of the config.
@@ -97,8 +96,8 @@ public final class DefaultDevToolsFactory implements DevToolsFactory {
         _service = Suppliers.memoize(this::createService);
         try {
             _originConfigs = objectMapper.readValue(
-                    ConfigurationHelper.toJson(config, "origins"),
-                    ORIGIN_CONFIG_MAP_TYPE
+                    ConfigurationHelper.toJson(config, "originConfigs"),
+                    PerOriginConfigs.class
             );
         } catch (final IOException e) {
             throw new IllegalArgumentException(e);
@@ -149,8 +148,5 @@ public final class DefaultDevToolsFactory implements DevToolsFactory {
     private final ImmutableMap<String, Object> _chromeArgs;
     private final ExecutorService _executor;
     private final Supplier<ChromeService> _service;
-    private final ImmutableMap<String, OriginConfig> _originConfigs;
-
-    private static final TypeReference<ImmutableMap<String, OriginConfig>> ORIGIN_CONFIG_MAP_TYPE =
-            new TypeReference<ImmutableMap<String, OriginConfig>>() {};
+    private final PerOriginConfigs _originConfigs;
 }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapper.java
@@ -20,7 +20,6 @@ import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.Base64;
 import java.util.UUID;
@@ -37,7 +36,7 @@ import java.util.function.Supplier;
  */
 public class DevToolsServiceWrapper implements DevToolsService {
     private final com.github.kklisura.cdt.services.ChromeService _chromeService;
-    private final ImmutableMap<String, OriginConfig> _originConfigs;
+    private final PerOriginConfigs _originConfigs;
     private final com.github.kklisura.cdt.services.types.ChromeTab _tab;
     private final com.github.kklisura.cdt.services.ChromeDevToolsService _dts;
     private final ExecutorService _executor;
@@ -52,7 +51,7 @@ public class DevToolsServiceWrapper implements DevToolsService {
      */
     /* package private */ DevToolsServiceWrapper(
             final com.github.kklisura.cdt.services.ChromeService chromeService,
-            final ImmutableMap<String, OriginConfig> originConfigs,
+            final PerOriginConfigs originConfigs,
             final com.github.kklisura.cdt.services.types.ChromeTab tab,
             final com.github.kklisura.cdt.services.ChromeDevToolsService dts,
             final ExecutorService executor

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PerOriginConfigs.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/PerOriginConfigs.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import net.sf.oval.constraint.NotNull;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Describes special actions that should be done for each of several origins (i.e. scheme+host+port).
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
+public final class PerOriginConfigs {
+
+    private PerOriginConfigs(final Builder builder) {
+        _byOrigin = builder._byOrigin;
+    }
+
+    private final ImmutableMap<String, OriginConfig> _byOrigin;
+
+    /**
+     * Tests whether a browser should be allowed to navigate to a URI.
+     *
+     * @param uri The URI to be navigated to.
+     * @return Whether a browser should be allowed to navigate to that URI.
+     */
+    public boolean isNavigationAllowed(final URI uri) {
+        return getOrDefault(uri, oconf -> oconf.isNavigationAllowed(uri.getPath()), false);
+    }
+
+    /**
+     * Tests whether a browser should be allowed to make a request to a URI.
+     *
+     * @param uri The URI to be requested.
+     * @return Whether a browser should be allowed to make a request to that URI.
+     */
+    public boolean isRequestAllowed(final URI uri) {
+        return getOrDefault(uri, oconf -> oconf.isRequestAllowed(uri.getPath()), false);
+    }
+
+    /**
+     * Gets any additional headers that should be added to requests to a particular URI.
+     *
+     * @param uri The URI to be requested.
+     * @return Any additional headers to add to that request.
+     */
+    public ImmutableMap<String, String> getAdditionalHeaders(final URI uri) {
+        return getOrDefault(uri, OriginConfig::getAdditionalHeaders, ImmutableMap.of());
+    }
+
+    /**
+     * Overload of {@link #isNavigationAllowed(URI)}.
+     *
+     * @param uri The URI to be navigated to.
+     * @return Whether a browser should be allowed to navigate to that URI.
+     */
+    public boolean isNavigationAllowed(final String uri) {
+        return isNavigationAllowed(URI.create(uri));
+    }
+
+    /**
+     * Overload of {@link #isRequestAllowed(URI)}.
+     *
+     * @param uri The URI to be requested.
+     * @return Whether a browser should be allowed to make a request to that URI.
+     */
+    public boolean isRequestAllowed(final String uri) {
+        return isRequestAllowed(URI.create(uri));
+    }
+
+    /**
+     * Overload of {@link #getAdditionalHeaders(URI)}.
+     *
+     * @param uri The URI to be requested.
+     * @return Any additional headers to add to that request.
+     */
+    public ImmutableMap<String, String> getAdditionalHeaders(final String uri) {
+        return getAdditionalHeaders(URI.create(uri));
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("_byOrigin", _byOrigin)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final PerOriginConfigs that = (PerOriginConfigs) o;
+        return _byOrigin.equals(that._byOrigin);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_byOrigin);
+    }
+
+    private String getOrigin(final URI uri) {
+        return uri.getScheme() + "://" + uri.getAuthority();
+    }
+
+    private <T> T getOrDefault(final URI uri, final Function<OriginConfig, T> f, final T defaultValue) {
+        final OriginConfig config = _byOrigin.get(getOrigin(uri));
+        if (config == null) {
+            return defaultValue;
+        }
+        return f.apply(config);
+    }
+
+
+    /**
+     * Builder implementation that constructs {@code OriginConfig}.
+     */
+    public static final class Builder extends OvalBuilder<PerOriginConfigs> {
+        /**
+         * Public Constructor.
+         */
+        public Builder() {
+            super(PerOriginConfigs::new);
+        }
+
+        /**
+         * Set the configurations for all origins. Required. Cannot be null.
+         *
+         * @param byOrigin The configs for all origins.
+         * @return This instance of {@code Builder}.
+         */
+        public Builder setByOrigin(final ImmutableMap<String, OriginConfig> byOrigin) {
+            _byOrigin = byOrigin;
+            return this;
+        }
+
+        @NotNull
+        private ImmutableMap<String, OriginConfig> _byOrigin = null;
+    }
+}

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -187,11 +187,13 @@ chrome {
     "remote-debugging-port": 48928
     "remote-debugging-address": "0.0.0.0"
   }
-  origins = {
-    "https://example.com" {
-      allowedNavigationPaths: [".*"]
-      allowedRequestPaths: [".*"]
-      # additionalHeaders: {"X-Extra-Header": "extra header value"}
+  originConfigs = {
+    byOrigin = {
+      "https://example.com" {
+        allowedNavigationPaths: [".*"]
+        allowedRequestPaths: [".*"]
+        # additionalHeaders: {"X-Extra-Header": "extra header value"}
+      }
     }
   }
 }

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
@@ -85,10 +85,12 @@ public abstract class BaseChromeTestSuite {
                         "keepAlive", "PT1S",
                         "queueSize", 1024
                 ),
-                "origins", ImmutableMap.of(
-                        ConfigUtil.quoteString("http://localhost:" + _wireMock.port()), ImmutableMap.of(
-                                "allowedNavigationPaths", ImmutableList.of(".*"),
-                                "allowedRequestPaths", ImmutableList.of(".*")
+                "originConfigs", ImmutableMap.of(
+                        "byOrigin", ImmutableMap.of(
+                                ConfigUtil.quoteString("http://localhost:" + _wireMock.port()), ImmutableMap.of(
+                                        "allowedNavigationPaths", ImmutableList.of(".*"),
+                                        "allowedRequestPaths", ImmutableList.of(".*")
+                                )
                         )
                 )
         )));

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactoryTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactoryTest.java
@@ -49,8 +49,10 @@ public class DefaultDevToolsFactoryTest {
                     "keepAlive", "PT1S",
                     "queueSize", 1024
             ),
-            "origins", ImmutableMap.of(
-                    ConfigUtil.quoteString("https://whitelisted.com"), ImmutableMap.of()
+            "originConfigs", ImmutableMap.of(
+                    "byOrigin", ImmutableMap.of(
+                            ConfigUtil.quoteString("https://whitelisted.com"), ImmutableMap.of()
+                    )
             )
     ));
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapperTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapperTest.java
@@ -47,7 +47,13 @@ public class DevToolsServiceWrapperTest {
         MockitoAnnotations.initMocks(this);
         Mockito.doReturn(_page).when(_wrapped).getPage();
         _tab = new com.github.kklisura.cdt.services.types.ChromeTab();
-        _dts = new DevToolsServiceWrapper(_service, ImmutableMap.of(), _tab, _wrapped, new ScheduledThreadPoolExecutor(1));
+        _dts = new DevToolsServiceWrapper(
+                _service,
+                new PerOriginConfigs.Builder().setByOrigin(ImmutableMap.of()).build(),
+                _tab,
+                _wrapped,
+                new ScheduledThreadPoolExecutor(1)
+        );
     }
 
     @Test

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PerOriginConfigsTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/PerOriginConfigsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link OriginConfig}.
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
+public class PerOriginConfigsTest {
+    @Test
+    public void testDeserialization() throws IOException {
+        assertEquals(
+                new PerOriginConfigs.Builder()
+                        .setByOrigin(ImmutableMap.of(
+                                "http://example.com", new OriginConfig.Builder()
+                                        .setAllowedNavigationPaths(ImmutableSet.of("/"))
+                                        .build()
+                        ))
+                        .build(),
+                MAPPER.readValue(
+                        "{\"byOrigin\": {\"http://example.com\": {\"allowedNavigationPaths\": [\"/\"]}}}",
+                        PerOriginConfigs.class
+                )
+        );
+    }
+
+    @Test
+    public void testDefaults() {
+        final PerOriginConfigs emptyConfig = makeSimpleConfig(ImmutableMap.of());
+        assertFalse(emptyConfig.isNavigationAllowed("http://example.com"));
+        assertFalse(emptyConfig.isRequestAllowed("http://example.com"));
+        assertEquals(ImmutableMap.of(), emptyConfig.getAdditionalHeaders("http://example.com"));
+    }
+
+    @Test
+    public void testDispatch() {
+        final PerOriginConfigs config = makeSimpleConfig(ImmutableMap.of(
+                "https://example.com", "/",
+                "https://google.com", "/search"
+        ));
+        assertTrue(config.isNavigationAllowed("https://example.com/"));
+        assertFalse(config.isNavigationAllowed("http://example.com/"));
+        assertFalse(config.isNavigationAllowed("https://example.com"));
+        assertFalse(config.isNavigationAllowed("https://example.com/search"));
+
+        assertTrue(config.isNavigationAllowed("https://google.com/search"));
+        assertFalse(config.isNavigationAllowed("https://google.com"));
+        assertFalse(config.isNavigationAllowed("https://google.com/"));
+
+        assertFalse(config.isNavigationAllowed("https://other.com/"));
+    }
+
+    @Test
+    public void testIsNavigationAllowed() {
+        final OriginConfig config = new OriginConfig.Builder()
+                .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-\\d+"))
+                .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-\\d+"))
+                .build();
+
+        assertFalse(config.isNavigationAllowed(""));
+        assertFalse(config.isNavigationAllowed("/disallowed"));
+        assertFalse(config.isNavigationAllowed("/allowed-req-1"));
+        assertTrue(config.isNavigationAllowed("/allowed-nav-1"));
+
+        assertFalse(config.isRequestAllowed("/sneaky-prefix/allowed-nav-1"));
+        assertFalse(config.isRequestAllowed("/allowed-nav-1/sneaky-suffix"));
+    }
+
+    private PerOriginConfigs makeSimpleConfig(ImmutableMap<String, String> allowedPathByOrigin) {
+        return new PerOriginConfigs.Builder()
+                .setByOrigin(
+                        allowedPathByOrigin.entrySet().stream().collect(ImmutableMap.toImmutableMap(
+                                Map.Entry::getKey,
+                                entry -> new OriginConfig.Builder().setAllowedNavigationPaths(ImmutableSet.of(entry.getValue())).build()
+                        ))
+                )
+                .build();
+    }
+
+    private static final ObjectMapper MAPPER = ObjectMapperFactory.createInstance();
+}


### PR DESCRIPTION
There were a lot of `ImmutableMap<String, OriginConfig>`s floating around, and there were starting to be a few `uri.getScheme() + "://" + uri.getAuthority()` computations to figure out how to dispatch. I wrote a class to encapsulate that complexity.