### PR TITLE
refactor DevToolsFactory creation, and improve Chrome-rendering tests

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/CachingChromeServiceFactory.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/CachingChromeServiceFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.github.kklisura.cdt.launch.ChromeArguments;
+import com.github.kklisura.cdt.launch.ChromeLauncher;
+import com.github.kklisura.cdt.launch.config.ChromeLauncherConfiguration;
+import com.github.kklisura.cdt.launch.support.impl.ProcessLauncherImpl;
+import com.github.kklisura.cdt.services.ChromeService;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Factory that creates Chrome instances, caching them to avoid creating redundant processes. Thread-safe.
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
+public final class CachingChromeServiceFactory {
+    /**
+     * Get a Chrome instance with the given parameters, creating it if it doesn't already exist.
+     *
+     * @param path Path to the Chrome executable.
+     * @param args Command-line options to pass to that Chrome instance.
+     * @return The (possibly freshly-created, possibly pre-existing) Chrome instance.
+     */
+    public ChromeService getOrCreate(final String path, final ImmutableMap<String, Object> args) {
+        return _cache.computeIfAbsent(new ChromeServiceKey(path, args), this::create);
+    }
+
+    private ChromeService create(final ChromeServiceKey key) {
+        // The config should be able to override the CHROME_PATH environment variable that ChromeLauncher uses.
+        // This requires in our own custom "environment" (since it defaults to using System::getEnv).
+        final ImmutableMap<String, String> env = ImmutableMap.of(
+                ChromeLauncher.ENV_CHROME_PATH, key._path
+        );
+        // ^^^ In order to pass this environment in, we need to use a many-argument constructor,
+        //   which doesn't have obvious default values. So I stole the arguments from the fewer-argument constructor:
+        // CHECKSTYLE.OFF: LineLength
+        //   https://github.com/kklisura/chrome-devtools-java-client/blob/master/cdt-java-client/src/main/java/com/github/kklisura/cdt/launch/ChromeLauncher.java#L105
+        // CHECKSTYLE.ON: LineLength
+        final ChromeLauncher launcher = new ChromeLauncher(
+                new ProcessLauncherImpl(),
+                env::get,
+                new ChromeLauncher.RuntimeShutdownHookRegistry(),
+                new ChromeLauncherConfiguration()
+        );
+        return launcher.launch(ChromeArguments.defaults(true)
+                .additionalArguments(key._args)
+                .build());
+    }
+
+    private final Map<ChromeServiceKey, ChromeService> _cache = Maps.newConcurrentMap();
+
+    private static final class ChromeServiceKey {
+        private final String _path;
+        private final ImmutableMap<String, Object> _args;
+        private ChromeServiceKey(final String path, final ImmutableMap<String, Object> args) {
+            _path = path;
+            _args = args;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final ChromeServiceKey that = (ChromeServiceKey) o;
+            return _path.equals(that._path)
+                    && _args.equals(that._args);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(_path, _args);
+        }
+    }
+}

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -209,7 +209,10 @@ public class MainModule extends AbstractModule {
     @Singleton
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Invoked reflectively by Guice")
     private DevToolsFactory provideChromeDevToolsFactory(final Config config, final ObjectMapper mapper) {
-        return new DefaultDevToolsFactory(config.getConfig("chrome"), mapper);
+        return new DefaultDevToolsFactory.Builder()
+                .setConfig(config.getConfig("chrome"))
+                .setObjectMapper(mapper)
+                .build();
     }
 
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -52,7 +52,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -52,6 +52,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
@@ -72,11 +72,11 @@ public abstract class BaseChromeTestSuite {
             .findFirst();
 
 
-    protected DevToolsFactory getDevToolsFactory() {
+    /* package private */ DevToolsFactory getDevToolsFactory() {
         return getDevToolsFactory(".*");
     }
 
-    protected DevToolsFactory getDevToolsFactory(final String allowedPathsPattern) {
+    /* package private */ DevToolsFactory getDevToolsFactory(final String allowedPathsPattern) {
         return new DefaultDevToolsFactory(ConfigFactory.parseMap(ImmutableMap.of(
                 "path", CHROME_PATH.get(),
                 "args", ImmutableMap.of(

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
@@ -64,6 +64,8 @@ public abstract class BaseChromeTestSuite {
             "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
     );
 
+    private static final CachingChromeServiceFactory SERVICE_FACTORY = new CachingChromeServiceFactory();
+
     /**
      * Path to the Chrome binary to use for Chrome-renderer tests.
      */
@@ -72,34 +74,45 @@ public abstract class BaseChromeTestSuite {
             .findFirst();
 
 
-    /* package private */ DevToolsFactory getDevToolsFactory() {
+    protected DevToolsFactory getDevToolsFactory() {
         return getDevToolsFactory(".*");
     }
 
-    /* package private */ DevToolsFactory getDevToolsFactory(final String allowedPathsPattern) {
-        return new DefaultDevToolsFactory(ConfigFactory.parseMap(ImmutableMap.of(
-                "path", CHROME_PATH.get(),
-                "args", ImmutableMap.of(
-                        "no-sandbox", true,
-                        "headless", true,
-                        "remote-debugging-port", 48928
-                ),
-                "executor", ImmutableMap.of(
-                        "corePoolSize", 8,
-                        "maximumPoolSize", 8,
-                        "keepAlive", "PT1S",
-                        "queueSize", 1024
-                ),
-                "originConfigs", ImmutableMap.of(
-                        "byOrigin", ImmutableMap.of(
-                                ConfigUtil.quoteString("http://localhost:" + _wireMock.port()), ImmutableMap.of(
-                                        "allowedNavigationPaths", ImmutableList.of(allowedPathsPattern),
-                                        "allowedRequestPaths", ImmutableList.of(allowedPathsPattern),
-                                        "additionalHeaders", ImmutableMap.of("X-Extra-Header", "extra header value")
+    /**
+     * Create a new {@link DevToolsFactory}.
+     *
+     * @param allowedPathsPattern Regex matching the localhost paths that Chrome should be allowed to access. Default {@code .*}.
+     * @return A new {@link DevToolsFactory}.
+     */
+    protected DevToolsFactory getDevToolsFactory(final String allowedPathsPattern) {
+        return new DefaultDevToolsFactory.Builder()
+                .setConfig(
+                        ConfigFactory.parseMap(ImmutableMap.of(
+                                "path", CHROME_PATH.get(),
+                                "args", ImmutableMap.of(
+                                        "no-sandbox", true,
+                                        "headless", true,
+                                        "remote-debugging-port", 48928
+                                ),
+                                "executor", ImmutableMap.of(
+                                        "corePoolSize", 8,
+                                        "maximumPoolSize", 8,
+                                        "keepAlive", "PT1S",
+                                        "queueSize", 1024
+                                ),
+                                "originConfigs", ImmutableMap.of(
+                                        "byOrigin", ImmutableMap.of(
+                                                ConfigUtil.quoteString("http://localhost:" + _wireMock.port()), ImmutableMap.of(
+                                                        "allowedNavigationPaths", ImmutableList.of(allowedPathsPattern),
+                                                        "allowedRequestPaths", ImmutableList.of(allowedPathsPattern),
+                                                        "additionalHeaders", ImmutableMap.of("X-Extra-Header", "extra header value")
+                                                )
+                                        )
                                 )
-                        )
+                        ))
                 )
-        )));
+                .setServiceFactory(SERVICE_FACTORY)
+                .build();
     }
 
     /**

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/BaseChromeTestSuite.java
@@ -73,11 +73,16 @@ public abstract class BaseChromeTestSuite {
 
 
     protected DevToolsFactory getDevToolsFactory() {
+        return getDevToolsFactory(".*");
+    }
+
+    protected DevToolsFactory getDevToolsFactory(final String allowedPathsPattern) {
         return new DefaultDevToolsFactory(ConfigFactory.parseMap(ImmutableMap.of(
                 "path", CHROME_PATH.get(),
                 "args", ImmutableMap.of(
                         "no-sandbox", true,
-                        "headless", true
+                        "headless", true,
+                        "remote-debugging-port", 48928
                 ),
                 "executor", ImmutableMap.of(
                         "corePoolSize", 8,
@@ -88,8 +93,9 @@ public abstract class BaseChromeTestSuite {
                 "originConfigs", ImmutableMap.of(
                         "byOrigin", ImmutableMap.of(
                                 ConfigUtil.quoteString("http://localhost:" + _wireMock.port()), ImmutableMap.of(
-                                        "allowedNavigationPaths", ImmutableList.of(".*"),
-                                        "allowedRequestPaths", ImmutableList.of(".*")
+                                        "allowedNavigationPaths", ImmutableList.of(allowedPathsPattern),
+                                        "allowedRequestPaths", ImmutableList.of(allowedPathsPattern),
+                                        "additionalHeaders", ImmutableMap.of("X-Extra-Header", "extra header value")
                                 )
                         )
                 )

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactoryTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactoryTest.java
@@ -58,7 +58,7 @@ public class DefaultDevToolsFactoryTest {
 
     @Test
     public void testValidConstruction() {
-        new DefaultDevToolsFactory(VALID_CONFIG);
+        new DefaultDevToolsFactory.Builder().setConfig(VALID_CONFIG).build();
     }
 
     @Test(timeout = 2000)
@@ -77,7 +77,7 @@ public class DefaultDevToolsFactoryTest {
                 "executor.keepAlive",
                 "executor.queueSize"
         );
-        optionalFields.forEach(field -> new DefaultDevToolsFactory(VALID_CONFIG.withoutPath(field)));
+        optionalFields.forEach(field -> new DefaultDevToolsFactory.Builder().setConfig(VALID_CONFIG.withoutPath(field)).build());
 
         final ImmutableSet<ImmutableList<Object>> invalidations = ImmutableSet.of(
                 ImmutableList.of("path", ImmutableMap.of(), ConfigException.WrongType.class),
@@ -127,7 +127,7 @@ public class DefaultDevToolsFactoryTest {
 
     private void assertMissingRaises(final String field) {
         try {
-            new DefaultDevToolsFactory(VALID_CONFIG.withoutPath(field));
+            new DefaultDevToolsFactory.Builder().setConfig(VALID_CONFIG.withoutPath(field)).build();
             fail("missing field '" + field + "' should have made constructor fail");
         } catch (final ConfigException.Missing e) {
         }
@@ -135,7 +135,7 @@ public class DefaultDevToolsFactoryTest {
 
     private <E extends Exception> void assertInvalidates(final String field, @Nullable final Object badValue, final Class<E> clazz) {
         try {
-            new DefaultDevToolsFactory(VALID_CONFIG.withValue(field, ConfigValueFactory.fromAnyRef(badValue)));
+            new DefaultDevToolsFactory.Builder().setConfig(VALID_CONFIG.withValue(field, ConfigValueFactory.fromAnyRef(badValue))).build();
             fail("setting " + field + "=" + badValue + " should have made constructor throw " + clazz.getName());
             // CHECKSTYLE.OFF: IllegalCatch
         } catch (final Exception e) {

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapperTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsServiceWrapperTest.java
@@ -137,6 +137,7 @@ public class DevToolsServiceWrapperTest {
             _dts.navigate("https://whitelisted.com/disallowed-path");
             Assert.fail("navigate() to illegal path should have raised an exception");
         } catch (final IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("navigation is not allowed"));
         }
     }
 

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/HtmlScreenshotRendererTest.java
@@ -27,14 +27,12 @@ import org.mockito.Mockito;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 


### PR DESCRIPTION
Functionally, this is a no-op:
- refactor DevToolsFactory creation to make it possible for multiple instances to share the same Chrome instances (this solves some test nondeterminism I was running into)
- add some new tests for Chrome-related stuff