### PR TITLE
add args to gpg to hopefully fix the Maven signing issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,29 @@
         </configuration>
       </plugin>
 
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>${maven.gpg.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <configuration>
+              <gpgArguments combine.children="append">
+                <!-- This is closely tied to the fact that Travis is configured to use Ubuntu 18.04:
+                  by default, Travis uses Ubuntu 16.04, which has GPG 1; but 18.04 has GPG 2,
+                  which does... something fancy to try to read the passphrase, resulting in an error
+                  "inappropriate ioctl for device". Googling suggested that `- -pinentry-mode loopback`
+                  would fix it. We'll see. -->
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Project Specific Plugins -->
       <plugin>
         <groupId>com.google.code.play2-maven-plugin</groupId>


### PR DESCRIPTION
This results in the following block getting added to the effective pom (as displayed by `mvn help:effective-pom`), in the `plugins` section:
```xml
       <plugin>
        <artifactId>maven-gpg-plugin</artifactId>
        <version>1.6</version>
        <executions>
          <execution>
            <id>sign-artifacts</id>
            <phase>verify</phase>
            <goals>
              <goal>sign</goal>
            </goals>
            <configuration>
              <gpgArguments combine.children="append">
                <arg>--pinentry-mode</arg>
                <arg>loopback</arg>
              </gpgArguments>
              <keyname>arpnet</keyname>
              <passphraseServerId>arpnet</passphraseServerId>
            </configuration>
          </execution>
        </executions>
      </plugin>
```

That looks like a properly-merged version of the parent and child plugin-configs.