### PR TITLE
Revert "add args to gpg to hopefully fix the Maven signing issue (#298)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,29 +287,6 @@
         </configuration>
       </plugin>
 
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>${maven.gpg.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <configuration>
-              <gpgArguments combine.children="append">
-                <!-- This is closely tied to the fact that Travis is configured to use Ubuntu 18.04:
-                  by default, Travis uses Ubuntu 16.04, which has GPG 1; but 18.04 has GPG 2,
-                  which does... something fancy to try to read the passphrase, resulting in an error
-                  "inappropriate ioctl for device". Googling suggested that `- -pinentry-mode loopback`
-                  would fix it. We'll see. -->
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- Project Specific Plugins -->
       <plugin>
         <groupId>com.google.code.play2-maven-plugin</groupId>


### PR DESCRIPTION
This reverts commit ccb58248f34a30e9d0ba396c27abce6ad1a416eb.

The `sign` goal is executed during the `verify` phase, and since #298 was merged, when I `mvn verify` locally it fails with
```
gpg: skipped "arpnet": No secret key
gpg: signing failed: No secret key
```