### PR TITLE
Tag Namer Filtering Part 1

### DIFF
--- a/app/com/arpnetworking/kairos/client/KairosDbClient.java
+++ b/app/com/arpnetworking/kairos/client/KairosDbClient.java
@@ -20,6 +20,7 @@ import com.arpnetworking.kairos.client.models.MetricsQuery;
 import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
 import com.arpnetworking.kairos.client.models.RollupResponse;
 import com.arpnetworking.kairos.client.models.RollupTask;
+import com.arpnetworking.kairos.client.models.TagNamesResponse;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -86,4 +87,11 @@ public interface KairosDbClient {
      * @return the response
      */
     CompletionStage<Void> deleteRollup(String id);
+
+    /**
+     * Query tag names in KairosDb.
+     *
+     * @return the response
+     */
+    CompletionStage<TagNamesResponse> listTagNames();
 }

--- a/app/com/arpnetworking/kairos/client/KairosDbClientImpl.java
+++ b/app/com/arpnetworking/kairos/client/KairosDbClientImpl.java
@@ -33,6 +33,7 @@ import com.arpnetworking.kairos.client.models.MetricsQuery;
 import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
 import com.arpnetworking.kairos.client.models.RollupResponse;
 import com.arpnetworking.kairos.client.models.RollupTask;
+import com.arpnetworking.kairos.client.models.TagNamesResponse;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -103,6 +104,12 @@ public final class KairosDbClientImpl implements KairosDbClient {
     public CompletionStage<Void> deleteRollup(final String id) {
         final HttpRequest request = HttpRequest.DELETE(createUri(ROLLUPS_PATH).toString() + "/" + id);
         return fireRequest(request, Void.class);
+    }
+
+    @Override
+    public CompletionStage<TagNamesResponse> listTagNames() {
+        final HttpRequest request = HttpRequest.GET(createUri(LIST_TAG_NAMES_PATH).toString());
+        return fireRequest(request, TagNamesResponse.class);
     }
 
     private CompletionStage<MetricsQueryResponse> performMetricsQuery(final URI uri, final MetricsQuery query) {
@@ -182,6 +189,7 @@ public final class KairosDbClientImpl implements KairosDbClient {
     static final URI METRICS_NAMES_PATH = URI.create("/api/v1/metricnames");
     static final URI METRICS_TAGS_PATH = URI.create("/api/v1/datapoints/query/tags");
     static final URI ROLLUPS_PATH = URI.create("/api/v1/rollups");
+    static final URI LIST_TAG_NAMES_PATH = URI.create("/api/v1/tagnames");
     private static final TypeReference<List<RollupTask>> ROLLUP_LIST_TYPEREF = new TypeReference<List<RollupTask>>() { };
 
     /**

--- a/app/com/arpnetworking/kairos/client/models/TagNamesResponse.java
+++ b/app/com/arpnetworking/kairos/client/models/TagNamesResponse.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.kairos.client.models;
+
+import com.arpnetworking.commons.builder.ThreadLocalBuilder;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import net.sf.oval.constraint.NotNull;
+
+/**
+ * Defines the response to a tag query.
+ *
+ * https://kairosdb.github.io/docs/build/html/restapi/ListTagNames.html
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class TagNamesResponse {
+
+    @JsonAnyGetter
+    public ImmutableMap<String, Object> getOtherArgs() {
+        return _otherArgs;
+    }
+
+    public ImmutableSet<String> getResults() {
+        return _results;
+    }
+
+    private TagNamesResponse(final Builder builder) {
+        _otherArgs = builder._otherArgs;
+        _results = builder._results;
+    }
+
+    private final ImmutableMap<String, Object> _otherArgs;
+    private final ImmutableSet<String> _results;
+
+    /**
+     * Implementation of the builder pattern for {@link TagNamesResponse}.
+     */
+    public static final class Builder extends ThreadLocalBuilder<TagNamesResponse> {
+        /**
+         * Public constructor.
+         */
+        public Builder() {
+            super(TagNamesResponse::new);
+        }
+
+        /**
+         * Adds an "unknown" parameter. Optional.
+         *
+         * @param key key for the entry
+         * @param value value for the entry
+         * @return this {@link MetricsQueryResponse.Builder}
+         */
+        @JsonAnySetter
+        public Builder addOtherArg(final String key, final Object value) {
+            _otherArgs = new ImmutableMap.Builder<String, Object>().putAll(_otherArgs).put(key, value).build();
+            return this;
+        }
+
+        /**
+         * Sets the tag names result of the response. Required. Cannot be null.
+         *
+         * @param value the resulting tag name list
+         * @return this {@link Builder}
+         */
+        public Builder setResults(final ImmutableSet<String> value) {
+            _results = value;
+            return this;
+        }
+
+        @Override
+        protected void reset() {
+            _otherArgs = ImmutableMap.of();
+            _results = null;
+        }
+
+        @NotNull
+        private ImmutableMap<String, Object> _otherArgs = ImmutableMap.of();
+        @NotNull
+        private ImmutableSet<String> _results;
+    }
+}

--- a/app/com/arpnetworking/kairos/service/KairosDbService.java
+++ b/app/com/arpnetworking/kairos/service/KairosDbService.java
@@ -21,6 +21,7 @@ import com.arpnetworking.kairos.client.models.MetricsQuery;
 import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
 import com.arpnetworking.kairos.client.models.RollupResponse;
 import com.arpnetworking.kairos.client.models.RollupTask;
+import com.arpnetworking.kairos.client.models.TagNamesResponse;
 
 import java.util.List;
 import java.util.Optional;
@@ -98,4 +99,11 @@ public interface KairosDbService {
      * @return the response
      */
     CompletionStage<Void> deleteRollup(String id);
+
+    /**
+     * Query tag names in KairosDb.
+     *
+     * @return the response
+     */
+    CompletionStage<TagNamesResponse> listTagNames();
 }

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -143,6 +143,10 @@ kairosdb {
   uri = "http://"${kairosdb.host}":"${kairosdb.port}
   timeout = "1 hour"
 }
+kairosdb.proxy {
+  filterRollups = true
+  excludedTagNames = []
+}
 
 # Reporting
 # ~~~~~
@@ -210,12 +214,6 @@ query {
       type = "com.arpnetworking.metrics.portal.query.impl.NoQueryExecutor"
     }
   }
-}
-
-# Proxy
-# ~~~~~
-proxy {
-  filterRollups = true
 }
 
 # Akka

--- a/test/java/com/arpnetworking/kairos/client/KairosDbClientImplTest.java
+++ b/test/java/com/arpnetworking/kairos/client/KairosDbClientImplTest.java
@@ -29,6 +29,7 @@ import com.arpnetworking.kairos.client.models.RollupResponse;
 import com.arpnetworking.kairos.client.models.RollupTask;
 import com.arpnetworking.kairos.client.models.Sampling;
 import com.arpnetworking.kairos.client.models.SamplingUnit;
+import com.arpnetworking.kairos.client.models.TagNamesResponse;
 import com.arpnetworking.testing.SerializationTestUtils;
 import com.arpnetworking.utility.test.ResourceHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -343,4 +344,21 @@ public class KairosDbClientImplTest {
         assertNull(response);
     }
 
+    @Test
+    public void testListTagNames() throws Exception {
+        _wireMock.givenThat(
+                get(urlEqualTo(KairosDbClientImpl.LIST_TAG_NAMES_PATH.toString()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(ResourceHelper.loadResource(getClass(), "testListTagNames.response"))
+                                .withStatus(200))
+        );
+
+        final TagNamesResponse response = _kairosDbClient.listTagNames().toCompletableFuture().get();
+
+        SerializationTestUtils.assertJsonEquals(
+                ResourceHelper.loadResource(getClass(), "testListTagNames.response"),
+                OBJECT_MAPPER.writeValueAsString(response)
+        );
+    }
 }

--- a/test/java/com/arpnetworking/kairos/client/models/TagNamesResponseTest.java
+++ b/test/java/com/arpnetworking/kairos/client/models/TagNamesResponseTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Dropbox, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.kairos.client.models;
+
+import com.arpnetworking.testing.SerializationTestUtils;
+import com.arpnetworking.utility.test.ResourceHelper;
+import org.junit.Test;
+
+/**
+ * Tests for {@link TagNamesResponse}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class TagNamesResponseTest {
+
+    @Test
+    public void testTranslationLosesNothing() throws Exception {
+        SerializationTestUtils.assertTranslationLosesNothing(
+                ResourceHelper.loadResource(getClass(), "testTranslationLosesNothing"),
+                TagNamesResponse.class
+        );
+    }
+}

--- a/test/resources/com/arpnetworking/kairos/client/KairosDbClientImplTest.testListTagNames.response.json
+++ b/test/resources/com/arpnetworking/kairos/client/KairosDbClientImplTest.testListTagNames.response.json
@@ -1,0 +1,8 @@
+{
+  "results": [
+    "os_name",
+    "os_version",
+    "app_version",
+    "country"
+  ]
+}

--- a/test/resources/com/arpnetworking/kairos/client/models/TagNamesResponseTest.testTranslationLosesNothing.json
+++ b/test/resources/com/arpnetworking/kairos/client/models/TagNamesResponseTest.testTranslationLosesNothing.json
@@ -1,0 +1,9 @@
+{
+  "results": [
+    "os_name",
+    "os_version",
+    "app_version",
+    "country"
+  ],
+  "arn48894": ["4949g", 3, {"foo":  "bar"}]
+}

--- a/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testFilterTagNamesOnListTagNames.backend_response.json
+++ b/test/resources/com/arpnetworking/kairos/service/KairosDbServiceImplTest.testFilterTagNamesOnListTagNames.backend_response.json
@@ -1,0 +1,9 @@
+{
+  "results": [
+    "os_name",
+    "os_version",
+    "app_version",
+    "country",
+    "host"
+  ]
+}


### PR DESCRIPTION
Add support for excluding tags (by name). Implement first part of this filtering for the list tag names endpoint (http://[host]:[port]/api/v1/tagnames).