### PR TITLE
Added RollupForwarder to use as an indirection level for between the cluster pool and RollupManager

### DIFF
--- a/app/com/arpnetworking/rollups/RollupForwarder.java
+++ b/app/com/arpnetworking/rollups/RollupForwarder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.rollups;
+
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * @author Gilligan Markham (gmarkham at dropbox dot com)
+ */
+public class RollupForwarder extends AbstractActor {
+    private final ActorRef _rollupManager;
+
+    /**
+     * RollupForwarder actor constructor.
+     *
+     * @param rollupManager actor ref to RollupManager actor
+     */
+    @Inject
+    public RollupForwarder(
+            @Named("RollupManager") final ActorRef rollupManager) {
+        _rollupManager = rollupManager;
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .matchAny(
+                        msg -> _rollupManager.forward(msg, context())
+
+                )
+                .build();
+    }
+}

--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -74,7 +74,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
      *
      * @param configuration play configuration
      * @param metricsDiscovery actor ref to metrics discovery actor
-     * @param rollupManager actor ref for rollup manager actor
+     * @param rollupManagerPool actor ref for rollup manager pool actor
      * @param kairosDbClient kairosdb client
      * @param clock clock to use for time calculations
      * @param metrics periodic metrics instance
@@ -83,12 +83,12 @@ public class RollupGenerator extends AbstractActorWithTimers {
     public RollupGenerator(
             final Config configuration,
             @Named("RollupMetricsDiscovery") final ActorRef metricsDiscovery,
-            @Named("RollupManager") final ActorRef rollupManager,
+            @Named("RollupManagerPool") final ActorRef rollupManagerPool,
             final KairosDbClient kairosDbClient,
             final Clock clock,
             final PeriodicMetrics metrics) {
         _metricsDiscovery = metricsDiscovery;
-        _rollupManager = rollupManager;
+        _rollupManagerPool = rollupManagerPool;
         _kairosDbClient = kairosDbClient;
         _clock = clock;
         _metrics = metrics;
@@ -240,7 +240,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
 
                     rollupBuilder.setStartTime(startTime)
                             .setEndTime(startTime.plus(period.periodCountToDuration(1)).minusMillis(1));
-                    _rollupManager.tell(rollupBuilder.build(), self());
+                    _rollupManagerPool.tell(rollupBuilder.build(), self());
                 }
             }
 
@@ -313,7 +313,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
     }
 
     private final ActorRef _metricsDiscovery;
-    private final ActorRef _rollupManager;
+    private final ActorRef _rollupManagerPool;
     private final KairosDbClient _kairosDbClient;
     private final int _maxBackFillPeriods;
     private final FiniteDuration _fetchBackoff;


### PR DESCRIPTION
This addresses a problem with the individual RollupExecutor actors not being able to get work from their local RollupManager due to it being behind a ConsistentHashPool.  Instead of the pool instantiating the RollupManager it now instantiates a RollupForwarder which in turn references the local RollupManager.  This allows the RollupManager to be created as an eager singleton and passed to the RollupExecutors so they can talk to the local instance.