### PR TITLE
add configuration option to use deprecated DevTools request-interception protocol

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactory.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactory.java
@@ -49,7 +49,7 @@ public final class DefaultDevToolsFactory implements DevToolsFactory {
         if (ignoreCertificateErrors) {
             result.getSecurity().setIgnoreCertificateErrors(true);
         }
-        return new DevToolsServiceWrapper(service, _originConfigs, tab, result, _executor);
+        return new DevToolsServiceWrapper(service, _originConfigs, tab, result, _executor, _networkConfigurationProtocol);
     }
 
     private DefaultDevToolsFactory(final Builder builder) {
@@ -67,6 +67,9 @@ public final class DefaultDevToolsFactory implements DevToolsFactory {
         } catch (final IOException e) {
             throw new IllegalArgumentException(e);
         }
+        _networkConfigurationProtocol = builder._config.hasPath("networkConfigurationProtocol")
+                ? DevToolsNetworkConfigurationProtocol.valueOf(builder._config.getString("networkConfigurationProtocol"))
+                : DevToolsNetworkConfigurationProtocol.FETCH;
     }
 
     @Override
@@ -96,6 +99,7 @@ public final class DefaultDevToolsFactory implements DevToolsFactory {
     private final ExecutorService _executor;
     private final Supplier<ChromeService> _service;
     private final PerOriginConfigs _originConfigs;
+    private final DevToolsNetworkConfigurationProtocol _networkConfigurationProtocol;
 
     /**
      * Implementation of builder pattern for {@link DefaultDevToolsFactory}.

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsNetworkConfigurationProtocol.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsNetworkConfigurationProtocol.java
@@ -26,11 +26,13 @@ import com.github.kklisura.cdt.protocol.types.network.RequestPattern;
 import com.github.kklisura.cdt.services.ChromeDevToolsService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+@SuppressFBWarnings("SE_BAD_FIELD") // False positive: https://github.com/spotbugs/spotbugs/issues/740
 /* package private */ enum DevToolsNetworkConfigurationProtocol {
 
     @Deprecated

--- a/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsNetworkConfigurationProtocol.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsNetworkConfigurationProtocol.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.arpnetworking.steno.Logger;
+import com.arpnetworking.steno.LoggerFactory;
+import com.github.kklisura.cdt.protocol.commands.Fetch;
+import com.github.kklisura.cdt.protocol.commands.Network;
+import com.github.kklisura.cdt.protocol.types.fetch.HeaderEntry;
+import com.github.kklisura.cdt.protocol.types.network.ErrorReason;
+import com.github.kklisura.cdt.protocol.types.network.Request;
+import com.github.kklisura.cdt.protocol.types.network.RequestPattern;
+import com.github.kklisura.cdt.services.ChromeDevToolsService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/* package private */ enum DevToolsNetworkConfigurationProtocol {
+
+    @Deprecated
+    NETWORK(DevToolsNetworkConfigurationProtocol::configureWithNetwork),
+    FETCH(DevToolsNetworkConfigurationProtocol::configureWithFetch);
+
+    DevToolsNetworkConfigurationProtocol(final BiConsumer<ChromeDevToolsService, PerOriginConfigs> configure) {
+        _configure = configure;
+    }
+
+    public void configure(final ChromeDevToolsService dts, final PerOriginConfigs originConfigs) {
+        _configure.accept(dts, originConfigs);
+    }
+
+    private final BiConsumer<ChromeDevToolsService, PerOriginConfigs> _configure;
+
+    @SuppressWarnings("deprecation")
+    private static void configureWithNetwork(final ChromeDevToolsService dts, final PerOriginConfigs originConfigs) {
+
+        final Network network = dts.getNetwork();
+        network.setRequestInterception(ImmutableList.of(new RequestPattern()));
+        network.onRequestIntercepted(event -> {
+            final String url = event.getRequest().getUrl();
+            if (!originConfigs.isRequestAllowed(url)) {
+                LOGGER.warn()
+                        .setMessage("rejecting request")
+                        .addData("url", url)
+                        .log();
+                network.continueInterceptedRequest(
+                        event.getInterceptionId(), ErrorReason.ABORTED, null, null, null, null, null, null
+                );
+                return;
+            }
+            final ImmutableMap<String, Object> headers = ImmutableMap.<String, Object>builder()
+                    .putAll(event.getRequest().getHeaders())
+                    .putAll(originConfigs.getAdditionalHeaders(url))
+                    .build();
+            network.continueInterceptedRequest(
+                    event.getInterceptionId(),
+                    null,
+                    null,
+                    url,
+                    event.getRequest().getMethod(),
+                    event.getRequest().getPostData(),
+                    headers,
+                    null
+            );
+        });
+    }
+
+    private static void configureWithFetch(final ChromeDevToolsService dts, final PerOriginConfigs originConfigs) {
+        final Fetch fetch = dts.getFetch();
+        fetch.enable();
+        fetch.onRequestPaused(event -> {
+            final String url = event.getRequest().getUrl();
+            if (!originConfigs.isRequestAllowed(url)) {
+                LOGGER.warn()
+                        .setMessage("rejecting request")
+                        .addData("url", url)
+                        .log();
+                fetch.failRequest(event.getRequestId(), ErrorReason.ABORTED);
+                return;
+            }
+            final ImmutableMap<String, String> headers = ImmutableMap.<String, String>builder()
+                    .putAll(getRequestHeaders(event.getRequest()))
+                    .putAll(originConfigs.getAdditionalHeaders(url))
+                    .build();
+            fetch.continueRequest(
+                    event.getRequestId(),
+                    url,
+                    event.getRequest().getMethod(),
+                    event.getRequest().getPostData(),
+                    headerMapToList(headers)
+            );
+        });
+    }
+
+    private static ImmutableMap<String, String> getRequestHeaders(final Request request) {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (final Map.Entry<String, Object> entry : request.getHeaders().entrySet()) {
+            if (entry.getValue() instanceof String) {
+                builder = builder.put(entry.getKey(), (String) entry.getValue());
+            }
+        }
+        return builder.build();
+    }
+
+    /* package private */ static ImmutableList<HeaderEntry> headerMapToList(final ImmutableMap<String, String> headers) {
+        return headers.entrySet().stream()
+                .map(entry -> {
+                    final HeaderEntry headerEntry = new HeaderEntry();
+                    headerEntry.setName(entry.getKey());
+                    headerEntry.setValue(entry.getValue());
+                    return headerEntry;
+                })
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    /* package private */ static ImmutableMap<String, String> headerListToMap(final Collection<HeaderEntry> headers) {
+        return headers.stream().collect(ImmutableMap.toImmutableMap(HeaderEntry::getName, HeaderEntry::getValue));
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DevToolsNetworkConfigurationProtocol.class);
+
+}

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -204,6 +204,9 @@ chrome {
       }
     }
   }
+  # networkConfigurationProtocol = NETWORK
+  # ^ Uncomment if your Chromium version is so new it doesn't support the old Network DevTools API.
+  #   I can't find for sure when that happened -- v73, I think.
 }
 
 # Queries

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactoryTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DefaultDevToolsFactoryTest.java
@@ -70,6 +70,8 @@ public class DefaultDevToolsFactoryTest {
         requiredFields.forEach(this::assertMissingRaises);
         requiredFields.forEach(field -> assertInvalidates(field, null, ConfigException.Missing.class));
 
+        assertStillValid("networkConfigurationProtocol", "NETWORK");
+
         final ImmutableSet<String> optionalFields = ImmutableSet.of(
                 "executor",
                 "executor.corePoolSize",
@@ -83,6 +85,7 @@ public class DefaultDevToolsFactoryTest {
                 ImmutableList.of("path", ImmutableMap.of(), ConfigException.WrongType.class),
                 ImmutableList.of("args", 1, ConfigException.WrongType.class),
                 ImmutableList.of("executor", 1, ConfigException.WrongType.class),
+                ImmutableList.of("networkConfigurationProtocol", "SOME_RANDOM_NON_ENUM_NAME", IllegalArgumentException.class),
 
                 ImmutableList.of("executor.corePoolSize", "", ConfigException.WrongType.class),
                 ImmutableList.of("executor.corePoolSize", -1, IllegalArgumentException.class),
@@ -131,6 +134,10 @@ public class DefaultDevToolsFactoryTest {
             fail("missing field '" + field + "' should have made constructor fail");
         } catch (final ConfigException.Missing e) {
         }
+    }
+
+    private <E extends Exception> void assertStillValid(final String field, @Nullable final Object value) {
+        new DefaultDevToolsFactory.Builder().setConfig(VALID_CONFIG.withValue(field, ConfigValueFactory.fromAnyRef(value))).build();
     }
 
     private <E extends Exception> void assertInvalidates(final String field, @Nullable final Object badValue, final Class<E> clazz) {

--- a/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsNetworkConfigurationProtocolTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/impl/chrome/DevToolsNetworkConfigurationProtocolTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2019 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.reports.impl.chrome;
+
+import com.github.kklisura.cdt.protocol.events.fetch.RequestPaused;
+import com.github.kklisura.cdt.protocol.support.types.EventHandler;
+import com.github.kklisura.cdt.protocol.types.network.ErrorReason;
+import com.github.kklisura.cdt.protocol.types.network.Request;
+import com.github.kklisura.cdt.services.ChromeDevToolsService;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+/**
+ * Tests for {@link DevToolsNetworkConfigurationProtocol}.
+ *
+ * @author Spencer Pearson (spencerpearson at dropbox dot com)
+ */
+@SuppressWarnings("deprecation")
+public class DevToolsNetworkConfigurationProtocolTest {
+
+    @Mock
+    private ChromeDevToolsService _dts;
+    @Mock
+    private com.github.kklisura.cdt.protocol.commands.Network _network;
+    @Mock
+    private com.github.kklisura.cdt.protocol.commands.Fetch _fetch;
+    @Captor
+    private ArgumentCaptor<EventHandler<com.github.kklisura.cdt.protocol.events.network.RequestIntercepted>> _requestInterceptorCaptor;
+    @Captor
+    private ArgumentCaptor<EventHandler<RequestPaused>> _requestPausedCaptor;
+    private PerOriginConfigs _originConfigs = new PerOriginConfigs.Builder().setByOrigin(ImmutableMap.of(
+            "https://whitelisted.com", new OriginConfig.Builder()
+                    .setAllowedNavigationPaths(ImmutableSet.of("/allowed-nav-.*"))
+                    .setAllowedRequestPaths(ImmutableSet.of("/allowed-req-.*"))
+                    .setAdditionalHeaders(ImmutableMap.of("X-Extra-Header", "extra header value"))
+                    .build()
+    )).build();
+
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        Mockito.doReturn(_network).when(_dts).getNetwork();
+        Mockito.doReturn(_fetch).when(_dts).getFetch();
+    }
+
+    @Test
+    public void testNetworkFiltersRequests() {
+        DevToolsNetworkConfigurationProtocol.NETWORK.configure(_dts, _originConfigs);
+        Mockito.verify(_network).onRequestIntercepted(_requestInterceptorCaptor.capture());
+        final EventHandler<com.github.kklisura.cdt.protocol.events.network.RequestIntercepted> callback =
+                _requestInterceptorCaptor.getValue();
+
+        final Request request = new Request();
+        request.setMethod("POST");
+        request.setUrl("https://whitelisted.com/allowed-req-1");
+        request.setPostData("data");
+        request.setHeaders(ImmutableMap.of());
+        final com.github.kklisura.cdt.protocol.events.network.RequestIntercepted event =
+                new com.github.kklisura.cdt.protocol.events.network.RequestIntercepted();
+        event.setInterceptionId(UUID.randomUUID().toString());
+        event.setRequest(request);
+
+        callback.onEvent(event);
+        Mockito.verify(_network).continueInterceptedRequest(
+                Mockito.eq(event.getInterceptionId()),
+                Mockito.isNull(),
+                Mockito.isNull(),
+                Mockito.eq("https://whitelisted.com/allowed-req-1"),
+                Mockito.eq("POST"),
+                Mockito.eq("data"),
+                Mockito.any(),
+                Mockito.isNull()
+        );
+
+        request.setUrl("https://whitelisted.com/disallowed-path");
+        Mockito.reset(_network);
+        callback.onEvent(event);
+        Mockito.verify(_network).continueInterceptedRequest(
+                event.getInterceptionId(),
+                ErrorReason.ABORTED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        request.setUrl("https://not-whitelisted.com/allowed-req-1");
+        Mockito.reset(_network);
+        callback.onEvent(event);
+        Mockito.verify(_network).continueInterceptedRequest(
+                event.getInterceptionId(),
+                ErrorReason.ABORTED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Test
+    public void testNetworkAddsHeaders() {
+        DevToolsNetworkConfigurationProtocol.NETWORK.configure(_dts, _originConfigs);
+        Mockito.verify(_network).onRequestIntercepted(_requestInterceptorCaptor.capture());
+        final EventHandler<com.github.kklisura.cdt.protocol.events.network.RequestIntercepted> callback =
+                _requestInterceptorCaptor.getValue();
+
+        final Request request = new Request();
+        request.setMethod("POST");
+        request.setUrl("https://whitelisted.com/allowed-req-1");
+        request.setPostData("data");
+        request.setHeaders(ImmutableMap.of("Original-Header", "original header value"));
+        final com.github.kklisura.cdt.protocol.events.network.RequestIntercepted event =
+                new com.github.kklisura.cdt.protocol.events.network.RequestIntercepted();
+        event.setRequest(request);
+        event.setInterceptionId(UUID.randomUUID().toString());
+
+        callback.onEvent(event);
+        Mockito.verify(_network).continueInterceptedRequest(
+                event.getInterceptionId(),
+                null,
+                null,
+                "https://whitelisted.com/allowed-req-1",
+                "POST",
+                "data",
+                ImmutableMap.of(
+                        "Original-Header", "original header value",
+                        "X-Extra-Header", "extra header value"
+                ),
+                null
+        );
+    }
+
+    @Test
+    public void testFetchFiltersRequests() {
+        DevToolsNetworkConfigurationProtocol.FETCH.configure(_dts, _originConfigs);
+        Mockito.verify(_fetch).onRequestPaused(_requestPausedCaptor.capture());
+        final EventHandler<RequestPaused> callback = _requestPausedCaptor.getValue();
+
+        final Request request = new Request();
+        request.setMethod("POST");
+        request.setUrl("https://whitelisted.com/allowed-req-1");
+        request.setPostData("data");
+        request.setHeaders(ImmutableMap.of());
+        final RequestPaused event = new RequestPaused();
+        event.setRequestId(UUID.randomUUID().toString());
+        event.setRequest(request);
+
+        callback.onEvent(event);
+        Mockito.verify(_fetch).continueRequest(
+                Mockito.eq(event.getRequestId()),
+                Mockito.eq("https://whitelisted.com/allowed-req-1"),
+                Mockito.eq("POST"),
+                Mockito.eq("data"),
+                Mockito.any()
+        );
+
+        request.setUrl("https://whitelisted.com/disallowed-path");
+        Mockito.reset(_fetch);
+        callback.onEvent(event);
+        Mockito.verify(_fetch).failRequest(
+                event.getRequestId(),
+                ErrorReason.ABORTED
+        );
+
+        request.setUrl("https://not-whitelisted.com/allowed-req-1");
+        Mockito.reset(_fetch);
+        callback.onEvent(event);
+        Mockito.verify(_fetch).failRequest(
+                event.getRequestId(),
+                ErrorReason.ABORTED
+        );
+    }
+
+    @Test
+    public void testFetchAddsHeaders() {
+        DevToolsNetworkConfigurationProtocol.FETCH.configure(_dts, _originConfigs);
+        Mockito.verify(_fetch).onRequestPaused(_requestPausedCaptor.capture());
+        final EventHandler<RequestPaused> callback = _requestPausedCaptor.getValue();
+
+        final Request request = new Request();
+        request.setMethod("POST");
+        request.setUrl("https://whitelisted.com/allowed-req-1");
+        request.setPostData("data");
+        request.setHeaders(ImmutableMap.of("Original-Header", "original header value"));
+        final RequestPaused event = new RequestPaused();
+        event.setRequest(request);
+        event.setRequestId(UUID.randomUUID().toString());
+
+        callback.onEvent(event);
+        Mockito.verify(_fetch).continueRequest(
+                Mockito.eq(event.getRequestId()),
+                Mockito.eq("https://whitelisted.com/allowed-req-1"),
+                Mockito.eq("POST"),
+                Mockito.eq("data"),
+                Mockito.argThat(headers -> DevToolsNetworkConfigurationProtocol.headerListToMap(headers).equals(ImmutableMap.of(
+                        "Original-Header", "original header value",
+                        "X-Extra-Header", "extra header value"
+                        ))
+                )
+        );
+    }
+
+}


### PR DESCRIPTION
- add enum for whether to use old or new DevTools protocol
- refactor request-interception code into that enum (copying old code from 8c0fe5cd25ac3f28d1b337af5ce2155893f70b95)
- add configuration option from app-config to control which strategy to use
