### PR TITLE
fix exception when a report has multiple executions; and subtly change semantics for scheduling

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -30,7 +30,6 @@ import com.typesafe.config.Config;
 import io.ebean.EbeanServer;
 import io.ebean.PagedList;
 import io.ebean.Transaction;
-import io.jsonwebtoken.lang.Collections;
 import models.ebean.NeverReportSchedule;
 import models.ebean.OneOffReportSchedule;
 import models.ebean.PeriodicReportSchedule;
@@ -54,14 +53,12 @@ import play.Environment;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -150,7 +147,10 @@ public final class DatabaseReportRepository implements ReportRepository {
     }
 
     @Override
-    public Optional<Instant> getJobLastExecutionScheduled(final UUID reportId, final Organization organization) throws NoSuchElementException {
+    public Optional<Instant> getJobLastExecutionScheduled(
+            final UUID reportId,
+            final Organization organization
+    ) throws NoSuchElementException {
         assertIsOpen();
         return _ebeanServer.find(ReportExecution.class)
                 .orderBy()

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -147,7 +147,7 @@ public final class DatabaseReportRepository implements ReportRepository {
     }
 
     @Override
-    public Optional<Instant> getJobLastExecutionScheduled(
+    public Optional<Instant> getLastScheduledTimeWhereExecutionCompleted(
             final UUID reportId,
             final Organization organization
     ) throws NoSuchElementException {

--- a/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
@@ -102,7 +102,8 @@ public final class NoReportRepository implements ReportRepository {
     }
 
     @Override
-    public Optional<Instant> getJobLastExecutionScheduled(final UUID id, final Organization organization) throws NoSuchElementException {
+    public Optional<Instant> getLastScheduledTimeWhereExecutionCompleted(final UUID id, final Organization organization)
+            throws NoSuchElementException {
         assertIsOpen();
         return Optional.empty();
     }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
@@ -102,7 +102,7 @@ public final class NoReportRepository implements ReportRepository {
     }
 
     @Override
-    public Optional<Instant> getJobLastRun(final UUID id, final Organization organization) throws NoSuchElementException {
+    public Optional<Instant> getJobLastExecutionScheduled(final UUID id, final Organization organization) throws NoSuchElementException {
         assertIsOpen();
         return Optional.empty();
     }

--- a/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
@@ -102,7 +102,7 @@ public final class CachedJob<T> implements Job<T> {
         }
         _periodicMetrics.recordCounter("cached_job_reload_success", 1);
         _cached = loaded.get();
-        _lastRun = _ref.getRepository(injector).getJobLastRun(_ref.getJobId(), _ref.getOrganization());
+        _lastRun = _ref.getRepository(injector).getJobLastExecutionScheduled(_ref.getJobId(), _ref.getOrganization());
     }
 
     /**

--- a/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
@@ -102,7 +102,7 @@ public final class CachedJob<T> implements Job<T> {
         }
         _periodicMetrics.recordCounter("cached_job_reload_success", 1);
         _cached = loaded.get();
-        _lastRun = _ref.getRepository(injector).getJobLastExecutionScheduled(_ref.getJobId(), _ref.getOrganization());
+        _lastRun = _ref.getRepository(injector).getLastScheduledTimeWhereExecutionCompleted(_ref.getJobId(), _ref.getOrganization());
     }
 
     /**

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
@@ -53,14 +53,14 @@ public interface JobRepository<T> {
     Optional<Job<T>> getJob(UUID id, Organization organization);
 
     /**
-     * Get the last time that a job with a given UUID was run.
+     * Get the last time an execution for a job was scheduled to run.
      *
      * @param id The id assigned to the Job by a previous call to {@code add}.
      * @param organization The organization owning the job.
-     * @return The last time that that job was executed.
+     * @return The last time that an execution for that job was scheduled to run.
      * @throws NoSuchElementException if no job has the given UUID.
      */
-    Optional<Instant> getJobLastRun(UUID id, Organization organization) throws NoSuchElementException;
+    Optional<Instant> getJobLastExecutionScheduled(UUID id, Organization organization) throws NoSuchElementException;
 
     /**
      * Notify the repository that a job has started executing.

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
@@ -53,11 +53,13 @@ public interface JobRepository<T> {
     Optional<Job<T>> getJob(UUID id, Organization organization);
 
     /**
-     * Get the last time an execution for a job was scheduled to run.
+     * Get the last time that any completed execution for a given job was scheduled for.
+     *
+     * More precisely, in pseudocode, {@code job.executions().filter(hasCompleted).map(scheduledFor).max()}.
      *
      * @param id The id assigned to the Job by a previous call to {@code add}.
      * @param organization The organization owning the job.
-     * @return The last time that an execution for that job was scheduled to run.
+     * @return The last time that any completed execution for the job was scheduled for.
      * @throws NoSuchElementException if no job has the given UUID.
      */
     Optional<Instant> getJobLastExecutionScheduled(UUID id, Organization organization) throws NoSuchElementException;

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
@@ -62,7 +62,7 @@ public interface JobRepository<T> {
      * @return The last time that any completed execution for the job was scheduled for.
      * @throws NoSuchElementException if no job has the given UUID.
      */
-    Optional<Instant> getJobLastExecutionScheduled(UUID id, Organization organization) throws NoSuchElementException;
+    Optional<Instant> getLastScheduledTimeWhereExecutionCompleted(UUID id, Organization organization) throws NoSuchElementException;
 
     /**
      * Notify the repository that a job has started executing.

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
@@ -288,7 +288,7 @@ public class DatabaseReportRepositoryIT {
         assertThat(execution.getError(), nullValue());
         assertThat(execution.getScheduled(), equalTo(scheduled));
 
-        final Optional<Instant> lastRun = _repository.getJobLastExecutionScheduled(report.getId(), _organization);
+        final Optional<Instant> lastRun = _repository.getLastScheduledTimeWhereExecutionCompleted(report.getId(), _organization);
         assertThat(lastRun, equalTo(Optional.of(execution.getScheduled())));
     }
 
@@ -319,7 +319,7 @@ public class DatabaseReportRepositoryIT {
         assertThat(retrievedError, notNullValue());
         assertThat(retrievedError, containsString(throwable.getMessage()));
         assertThat(retrievedError, containsString(throwable.getCause().getMessage()));
-        final Optional<Instant> lastRun = _repository.getJobLastExecutionScheduled(report.getId(), _organization);
+        final Optional<Instant> lastRun = _repository.getLastScheduledTimeWhereExecutionCompleted(report.getId(), _organization);
         assertThat(lastRun, equalTo(Optional.of(execution.getScheduled())));
     }
 
@@ -336,7 +336,10 @@ public class DatabaseReportRepositoryIT {
         _repository.jobSucceeded(report.getId(), _organization, t0.plus(dt.multipliedBy(2)), new DefaultReportResult());
         _repository.jobSucceeded(report.getId(), _organization, t0.plus(dt.multipliedBy(3)), new DefaultReportResult());
 
-        assertEquals(t0.plus(dt.multipliedBy(3)), _repository.getJobLastExecutionScheduled(report.getId(), _organization).get());
+        assertEquals(
+                t0.plus(dt.multipliedBy(3)),
+                _repository.getLastScheduledTimeWhereExecutionCompleted(report.getId(), _organization).get()
+        );
     }
 
     @Test
@@ -363,7 +366,7 @@ public class DatabaseReportRepositoryIT {
         assertThat(execution.getReport().getUuid(), equalTo(report.getId()));
         assertThat(execution.getScheduled(), equalTo(scheduled));
 
-        final Optional<Instant> lastRun = _repository.getJobLastExecutionScheduled(report.getId(), _organization);
+        final Optional<Instant> lastRun = _repository.getLastScheduledTimeWhereExecutionCompleted(report.getId(), _organization);
         assertThat(lastRun, equalTo(Optional.empty()));
     }
 

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
@@ -87,7 +87,7 @@ public class MapJobRepository<T> implements JobRepository<T> {
     }
 
     @Override
-    public Optional<Instant> getJobLastRun(final UUID id, final Organization organization) throws NoSuchElementException {
+    public Optional<Instant> getJobLastExecutionScheduled(final UUID id, final Organization organization) throws NoSuchElementException {
         assertIsOpen();
         return Optional.ofNullable(_lastRuns.getOrDefault(organization, Maps.newHashMap()).get(id));
     }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
@@ -87,7 +87,8 @@ public class MapJobRepository<T> implements JobRepository<T> {
     }
 
     @Override
-    public Optional<Instant> getJobLastExecutionScheduled(final UUID id, final Organization organization) throws NoSuchElementException {
+    public Optional<Instant> getLastScheduledTimeWhereExecutionCompleted(final UUID id, final Organization organization)
+            throws NoSuchElementException {
         assertIsOpen();
         return Optional.ofNullable(_lastRuns.getOrDefault(organization, Maps.newHashMap()).get(id));
     }


### PR DESCRIPTION
Currently, `DatabaseReportRepository.getJobLastRun()` will throw if a job has multiple completed executions. This fixes that.

Along the way, I decided that the semantics for that method were wrong, and it should return
`job.executions().filter(hasCompleted).map(scheduledFor).max()`
rather than
`job.executions().filter(hasCompleted).map(completedAt).max()`
, in order to catch up in weird edge cases where one run doesn't complete until after it is next scheduled to start.