### PR TITLE
remove concept of "triggering event" from web-based reports

### DIFF
--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -212,7 +212,6 @@ class EditSourceViewModel extends BaseSourceViewModel {
                     uri: this.url(),
                     title: this.title(),
                     ignoreCertificateErrors: this.ignoreCertificateErrors(),
-                    triggeringEventName: this.eventName(),
                 };
             case SourceType.GRAFANA:
                 return {
@@ -223,7 +222,6 @@ class EditSourceViewModel extends BaseSourceViewModel {
                         uri: this.url(),
                         title: this.title(),
                         ignoreCertificateErrors: this.ignoreCertificateErrors(),
-                        triggeringEventName: this.eventName(),
                     },
                 };
             default:

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -44,7 +44,6 @@ export class BaseSourceViewModel {
     type = ko.observable<SourceType>(SourceType.WEB_PAGE);
     title = ko.observable<string>("");
     url = ko.observable<string>("");
-    eventName = ko.observable<string>("");
     ignoreCertificateErrors = ko.observable<boolean>(false);
 
     public load(raw): this {
@@ -60,13 +59,11 @@ export class BaseSourceViewModel {
             case SourceType.WEB_PAGE:
                 this.url(raw.uri);
                 this.title(raw.title);
-                this.eventName(raw.triggeringEventName);
                 this.ignoreCertificateErrors(raw.ignoreCertificateErrors);
                 break;
             case SourceType.GRAFANA:
                 this.url(raw.webPageReportSource.uri);
                 this.title(raw.webPageReportSource.title);
-                this.eventName(raw.webPageReportSource.triggeringEventName);
                 this.ignoreCertificateErrors(raw.webPageReportSource.ignoreCertificateErrors);
                 break;
         }

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -528,7 +528,6 @@ public final class DatabaseReportRepository implements ReportRepository {
             ebeanSource.setUuid(source.getId());
             ebeanSource.setIgnoreCertificateErrors(source.ignoresCertificateErrors());
             ebeanSource.setUri(source.getUri());
-            ebeanSource.setTriggeringEventName(source.getTriggeringEventName());
             ebeanSource.setTitle(source.getTitle());
             return ebeanSource;
         }
@@ -539,7 +538,6 @@ public final class DatabaseReportRepository implements ReportRepository {
             ebeanSource.setUuid(source.getWebPageReportSource().getId());
             ebeanSource.setIgnoreCertificateErrors(source.getWebPageReportSource().ignoresCertificateErrors());
             ebeanSource.setUri(source.getWebPageReportSource().getUri());
-            ebeanSource.setTriggeringEventName(source.getWebPageReportSource().getTriggeringEventName());
             ebeanSource.setTitle(source.getWebPageReportSource().getTitle());
             return ebeanSource;
         }

--- a/app/models/ebean/GrafanaReportPanelReportSource.java
+++ b/app/models/ebean/GrafanaReportPanelReportSource.java
@@ -43,9 +43,6 @@ public class GrafanaReportPanelReportSource extends ReportSource {
     @Column(name = "ignore_certificate_errors")
     private boolean ignoreCertificateErrors;
 
-    @Column(name = "triggering_event_name")
-    private String triggeringEventName;
-
     public URI getUri() {
         return uri;
     }
@@ -70,14 +67,6 @@ public class GrafanaReportPanelReportSource extends ReportSource {
         ignoreCertificateErrors = value;
     }
 
-    public String getTriggeringEventName() {
-        return triggeringEventName;
-    }
-
-    public void setTriggeringEventName(final String value) {
-        triggeringEventName = value;
-    }
-
     @Override
     public models.internal.impl.GrafanaReportPanelReportSource toInternal() {
         return new models.internal.impl.GrafanaReportPanelReportSource.Builder()
@@ -87,7 +76,6 @@ public class GrafanaReportPanelReportSource extends ReportSource {
                                 .setUri(uri)
                                 .setTitle(title)
                                 .setIgnoreCertificateErrors(ignoreCertificateErrors)
-                                .setTriggeringEventName(triggeringEventName)
                                 .build())
                 .build();
     }

--- a/app/models/ebean/WebPageReportSource.java
+++ b/app/models/ebean/WebPageReportSource.java
@@ -46,9 +46,6 @@ public class WebPageReportSource extends ReportSource {
     @Column(name = "ignore_certificate_errors")
     private boolean ignoreCertificateErrors;
 
-    @Column(name = "triggering_event_name")
-    private String triggeringEventName;
-
     public URI getUri() {
         return uri;
     }
@@ -73,14 +70,6 @@ public class WebPageReportSource extends ReportSource {
         ignoreCertificateErrors = value;
     }
 
-    public String getTriggeringEventName() {
-        return triggeringEventName;
-    }
-
-    public void setTriggeringEventName(final String value) {
-        triggeringEventName = value;
-    }
-
     @Override
     public models.internal.reports.ReportSource toInternal() {
         return new models.internal.impl.WebPageReportSource.Builder()
@@ -88,7 +77,6 @@ public class WebPageReportSource extends ReportSource {
                 .setUri(uri)
                 .setTitle(title)
                 .setIgnoreCertificateErrors(ignoreCertificateErrors)
-                .setTriggeringEventName(triggeringEventName)
                 .build();
     }
 }

--- a/app/models/internal/impl/WebPageReportSource.java
+++ b/app/models/internal/impl/WebPageReportSource.java
@@ -41,14 +41,12 @@ public final class WebPageReportSource implements ReportSource {
     private final URI _uri;
     private final String _title;
     private final boolean _ignoreCertificateErrors;
-    private final String _triggeringEventName;
 
     private WebPageReportSource(final Builder builder) {
         _id = builder._id;
         _uri = builder._uri;
         _title = builder._title;
         _ignoreCertificateErrors = builder._ignoreCertificateErrors;
-        _triggeringEventName = builder._triggeringEventName;
     }
 
     @Override
@@ -58,7 +56,6 @@ public final class WebPageReportSource implements ReportSource {
                 .add("url", _uri)
                 .add("title", _title)
                 .add("ignoreCertificateErrors", _ignoreCertificateErrors)
-                .add("triggeringEventName", _triggeringEventName)
                 .toString();
     }
 
@@ -94,18 +91,6 @@ public final class WebPageReportSource implements ReportSource {
         return _ignoreCertificateErrors;
     }
 
-    /**
-     * Get the browser event name used to trigger this report source.
-     *
-     * The report will be considered generated once an event with this name is registered
-     * with the browser.
-     *
-     * @return the name of the triggering event.
-     */
-    public String getTriggeringEventName() {
-        return _triggeringEventName;
-    }
-
     @Override
     public SourceType getType() {
         return SourceType.WEB_PAGE;
@@ -128,13 +113,12 @@ public final class WebPageReportSource implements ReportSource {
         return _ignoreCertificateErrors == that._ignoreCertificateErrors
                 && Objects.equals(_id, that._id)
                 && Objects.equals(_uri, that._uri)
-                && Objects.equals(_title, that._title)
-                && Objects.equals(_triggeringEventName, that._triggeringEventName);
+                && Objects.equals(_title, that._title);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_id, _uri, _title, _ignoreCertificateErrors, _triggeringEventName);
+        return Objects.hash(_id, _uri, _title, _ignoreCertificateErrors);
     }
 
     /**
@@ -182,17 +166,6 @@ public final class WebPageReportSource implements ReportSource {
         }
 
         /**
-         * The triggering event name for the source. Required. Cannot be null or empty.
-         *
-         * @param triggeringEventName The event name.
-         * @return This instance of {@code Builder}
-         */
-        public Builder setTriggeringEventName(final String triggeringEventName) {
-            _triggeringEventName = triggeringEventName;
-            return this;
-        }
-
-        /**
          * Determine if the source should ignore certificate errors. Cannot be null. Defaults to false.
          *
          * @param ignoreCertificateErrors Whether this source should ignore certificate errors.
@@ -211,9 +184,6 @@ public final class WebPageReportSource implements ReportSource {
         @NotNull
         @NotEmpty
         private String _title;
-        @NotNull
-        @NotEmpty
-        private String _triggeringEventName;
         @NotNull
         private Boolean _ignoreCertificateErrors = false;
 

--- a/app/models/view/impl/WebPageReportSource.java
+++ b/app/models/view/impl/WebPageReportSource.java
@@ -67,14 +67,6 @@ public final class WebPageReportSource implements ReportSource {
         _ignoreCertificateErrors = value;
     }
 
-    public String getTriggeringEventName() {
-        return _triggeringEventName;
-    }
-
-    public void setTriggeringEventName(final String value) {
-        _triggeringEventName = value;
-    }
-
     @Override
     public models.internal.impl.WebPageReportSource toInternal() {
         return new models.internal.impl.WebPageReportSource.Builder()
@@ -82,7 +74,6 @@ public final class WebPageReportSource implements ReportSource {
                 .setUri(_uri)
                 .setTitle(_title)
                 .setIgnoreCertificateErrors(_ignoreCertificateErrors)
-                .setTriggeringEventName(_triggeringEventName)
                 .build();
     }
 
@@ -97,7 +88,6 @@ public final class WebPageReportSource implements ReportSource {
         viewSource.setId(source.getId());
         viewSource.setUri(source.getUri());
         viewSource.setTitle(source.getTitle());
-        viewSource.setTriggeringEventName(source.getTriggeringEventName());
         viewSource.setIgnoreCertificateErrors(source.ignoresCertificateErrors());
         return viewSource;
     }
@@ -109,7 +99,6 @@ public final class WebPageReportSource implements ReportSource {
                 .add("url", _uri)
                 .add("title", _title)
                 .add("ignoreCertificateErrors", _ignoreCertificateErrors)
-                .add("triggeringEventName", _triggeringEventName)
                 .toString();
     }
 
@@ -125,13 +114,12 @@ public final class WebPageReportSource implements ReportSource {
         return _ignoreCertificateErrors == otherWebPageReportSource._ignoreCertificateErrors
                 && Objects.equals(_id, otherWebPageReportSource._id)
                 && Objects.equals(_uri, otherWebPageReportSource._uri)
-                && Objects.equals(_title, otherWebPageReportSource._title)
-                && Objects.equals(_triggeringEventName, otherWebPageReportSource._triggeringEventName);
+                && Objects.equals(_title, otherWebPageReportSource._title);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_id, _uri, _title, _ignoreCertificateErrors, _triggeringEventName);
+        return Objects.hash(_id, _uri, _title, _ignoreCertificateErrors);
     }
 
 
@@ -143,6 +131,4 @@ public final class WebPageReportSource implements ReportSource {
     private String _title;
     @JsonProperty("ignoreCertificateErrors")
     private boolean _ignoreCertificateErrors;
-    @JsonProperty("triggeringEventName")
-    private String _triggeringEventName;
 }

--- a/conf/db/migration/metrics_portal_ddl/V19__drop_web_page_triggering_event.sql
+++ b/conf/db/migration/metrics_portal_ddl/V19__drop_web_page_triggering_event.sql
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2019 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE portal.report_sources DROP COLUMN triggering_event_name;

--- a/public/html/reports/EditSourceViewModel.html
+++ b/public/html/reports/EditSourceViewModel.html
@@ -42,15 +42,6 @@
            placeholder="Source URL"
            data-bind="value: url">
 </div>
-<div class="form-group">
-    <label for="sourceEventName">Browser event name</label>
-    <span class="glyphicon glyphicon-question-sign"
-          data-bind="popover: helpMessages['eventName']"
-          data-trigger="hover"></span>
-    <input class="form-control"
-           type="text" id="sourceEventName" placeholder="Event name"
-           data-bind="value: eventName">
-</div>
 <div class="checkbox">
     <label for="sourceIgnoreCertificateErrors">
         <input id="sourceIgnoreCertificateErrors"

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -69,7 +69,6 @@ public final class TestBeanFactory {
     private static final String TEST_NAME = "test-name";
     private static final String TEST_ETAG = "test-etag";
     private static final String TEST_TITLE = "test-title";
-    private static final String TEST_EVENT = "onload-";
     private static final List<Operator> OPERATORS = Arrays.asList(
             Operator.EQUAL_TO,
             Operator.GREATER_THAN,
@@ -183,7 +182,6 @@ public final class TestBeanFactory {
         return new WebPageReportSource.Builder()
                 .setTitle(TEST_TITLE + UUID.randomUUID().toString())
                 .setId(UUID.randomUUID())
-                .setTriggeringEventName(TEST_EVENT + UUID.randomUUID().toString())
                 .setUri(URI.create("http://" + UUID.randomUUID().toString().replace("-", "") + ".example.com"))
                 .setIgnoreCertificateErrors(false);
     }

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
@@ -237,7 +237,6 @@ public class DatabaseReportRepositoryIT {
                 new WebPageReportSource.Builder()
                         .setId(UUID.randomUUID())
                         .setTitle("Test title")
-                        .setTriggeringEventName("onload")
                         .setUri(URI.create("https://foo.test.com"));
 
         // Initial report

--- a/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/reports/ReportExecutionContextTest.java
@@ -90,7 +90,6 @@ public class ReportExecutionContextTest {
             .setReportSource(new WebPageReportSource.Builder()
                     .setId(UUID.randomUUID())
                     .setTitle("My Report Title")
-                    .setTriggeringEventName("myTriggeringEventName")
                     .setUri(URI.create("https://example.com"))
                     .setIgnoreCertificateErrors(true)
                     .build()

--- a/test/java/models/view/ReportSerializationTest.java
+++ b/test/java/models/view/ReportSerializationTest.java
@@ -72,7 +72,6 @@ public final class ReportSerializationTest {
                         .setUri(URI.create("https://example.com"))
                         .setTitle("My Report Title")
                         .setIgnoreCertificateErrors(false)
-                        .setTriggeringEventName("myTriggeringEventName")
                         .build())
                 .setSchedule(new com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule.Builder()
                         .setRunAtAndAfter(Instant.parse("2019-01-01T00:00:00Z"))

--- a/test/resources/models/view/ReportSerializationTest.testValidReport.json
+++ b/test/resources/models/view/ReportSerializationTest.testValidReport.json
@@ -7,8 +7,7 @@
     "id": "22222222-2222-2222-2222-222222222222",
     "uri": "https://example.com",
     "title": "My Report Title",
-    "ignoreCertificateErrors": false,
-    "triggeringEventName": "myTriggeringEventName"
+    "ignoreCertificateErrors": false
   },
   "schedule": {
     "type": "ONE_OFF",


### PR DESCRIPTION
It's never even used in the code currently; and the current behavior of "simple web pages get screenshotted on `load`, Grafana pages get screenshotted on `reportrendered`" seems perfectly adequate for all foreseeable use cases.