### PR TITLE
add configuration for what source types are available in the UI

### DIFF
--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -22,6 +22,7 @@ import moment = require('moment-timezone/moment-timezone');
 import csrf from '../Csrf';
 
 import {
+    availableSourceTypes,
     BaseRecipientViewModel,
     BaseScheduleViewModel,
     BaseSourceViewModel,
@@ -232,10 +233,13 @@ class EditSourceViewModel extends BaseSourceViewModel {
     }
 
     // Used by KO data-bind.
-    readonly availableSourceTypes = [
-        {value: SourceType.WEB_PAGE,  text: "Web page"},
-        {value: SourceType.GRAFANA,  text: "Grafana"},
-    ];
+    private static readonly sourceTypeDisplayNames = {
+        [SourceType.WEB_PAGE]: "Web page",
+        [SourceType.GRAFANA]: "Grafana",
+    };
+    readonly availableSourceTypes: {value: SourceType, text: string}[] = availableSourceTypes.map(
+        type => ({value: type, text: EditSourceViewModel.sourceTypeDisplayNames[type]})
+    );
 
     readonly helpMessages = {
         type: "The source type determines how a report is generated.<br>" +

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -41,7 +41,7 @@ export class ZoneInfo {
 
 export class BaseSourceViewModel {
     id = ko.observable(uuid.v4());
-    type = ko.observable<SourceType>(SourceType.WEB_PAGE);
+    type = ko.observable<SourceType>(SourceType.GRAFANA);
     title = ko.observable<string>("");
     url = ko.observable<string>("");
     eventName = ko.observable<string>("");

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -2,6 +2,7 @@ import uuid = require('../Uuid');
 import ko = require('knockout');
 // @ts-ignore: import is valid
 import moment = require('moment-timezone/moment-timezone');
+import features = require('configure');
 
 export enum RecipientType {
     EMAIL,
@@ -25,6 +26,8 @@ export enum ScheduleRepetition {
     MONTHLY,
 }
 
+export const availableSourceTypes: SourceType[] = features.sourceTypes.map((s: keyof typeof SourceType) => SourceType[s]);
+
 export class ZoneInfo {
     value: string;
     display: string;
@@ -41,7 +44,7 @@ export class ZoneInfo {
 
 export class BaseSourceViewModel {
     id = ko.observable(uuid.v4());
-    type = ko.observable<SourceType>(SourceType.GRAFANA);
+    type = ko.observable<SourceType>(availableSourceTypes[0]);
     title = ko.observable<string>("");
     url = ko.observable<string>("");
     eventName = ko.observable<string>("");

--- a/app/models/internal/Features.java
+++ b/app/models/internal/Features.java
@@ -15,6 +15,7 @@
  */
 package models.internal;
 
+import com.arpnetworking.metrics.portal.reports.SourceType;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -79,4 +80,11 @@ public interface Features {
      * @return list of ports for metrics aggregator daemon (or its proxies).
      */
     ImmutableList<Integer> getMetricsAggregatorDaemonPorts();
+
+    /**
+     * Names of {@link SourceType}s to display in the UI.
+     *
+     * @return list of names of {@link SourceType} enum values.
+     */
+    ImmutableList<String> getSourceTypes();
 }

--- a/app/models/internal/impl/DefaultFeatures.java
+++ b/app/models/internal/impl/DefaultFeatures.java
@@ -16,6 +16,7 @@
 package models.internal.impl;
 
 import com.arpnetworking.logback.annotations.Loggable;
+import com.arpnetworking.metrics.portal.reports.SourceType;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import models.internal.Features;
@@ -68,6 +69,11 @@ public final class DefaultFeatures implements Features {
     }
 
     @Override
+    public ImmutableList<String> getSourceTypes() {
+        return _sourceTypes.stream().map(SourceType::name).collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
     public String toString() {
         return new StringBuilder()
                 .append("{telemetryEnabled=").append(_telemetryEnabled)
@@ -97,6 +103,10 @@ public final class DefaultFeatures implements Features {
         _reportsEnabled = configuration.getBoolean("portal.features.reports.enabled");
         _metricsAggregatorDaemonPorts = ImmutableList.copyOf(
                 configuration.getIntList("portal.features.metricsAggregatorDaemonPorts"));
+        _sourceTypes = configuration.getStringList("portal.features.reports.sourceTypes")
+                .stream()
+                .map(SourceType::valueOf)
+                .collect(ImmutableList.toImmutableList());
     }
 
     private final boolean _telemetryEnabled;
@@ -107,4 +117,5 @@ public final class DefaultFeatures implements Features {
     private final boolean _rollupsEnabled;
     private final boolean _reportsEnabled;
     private final ImmutableList<Integer> _metricsAggregatorDaemonPorts;
+    private final ImmutableList<SourceType> _sourceTypes;
 }

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -77,6 +77,7 @@ portal.features {
 
   # Reports
   reports.enabled = false
+  reports.sourceTypes = [WEB_PAGE, GRAFANA]
 
   # Metrics aggregator ports
   metricsAggregatorDaemonPorts = [7090]


### PR DESCRIPTION
Verified manually that if I changed the configured `reports.sourceTypes = [GRAFANA]`, then only that option appeared in the dropdown.