### PR TITLE
add report anti-entropy role to cluster

### DIFF
--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -249,7 +249,12 @@ akka {
   cluster {
     seed-nodes=["akka.tcp://mportal@127.0.0.1:2558"]
     auto-down-unreachable-after = 300s
-    roles = ["host_indexer", "rollup_metrics_discovery", "rollup_manager"]
+    roles = [
+        "host_indexer",
+        "rollup_metrics_discovery",
+        "rollup_manager",
+        "report_repository_anti_entropy",
+    ]
     sharding {
       guardian-name="sharding"
       role=""


### PR DESCRIPTION
It currently isn't declared in the configfile, so no node has that role, so anti-entropy isn't getting run.