### PR TITLE
allow configuration of what report format types are displayed in the UI.

### DIFF
--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -22,6 +22,7 @@ import moment = require('moment-timezone/moment-timezone');
 import csrf from '../Csrf';
 
 import {
+    availableReportFormatTypes,
     availableSourceTypes,
     BaseRecipientViewModel,
     BaseScheduleViewModel,
@@ -189,10 +190,16 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
         }
     }
 
-    readonly availableFormats = [
-        {value: ReportFormat.PDF,  text: "PDF"},
-        {value: ReportFormat.HTML,  text: "HTML"},
-    ];
+    private static readonly formatDisplayNames = {
+        [ReportFormat.PDF]: "PDF",
+        [ReportFormat.HTML]: "HTML",
+    };
+    readonly availableFormats: {value: ReportFormat, text: string}[] = availableReportFormatTypes.map(
+        reportFormatType => ({
+            value: reportFormatType,
+            text: EditRecipientViewModel.formatDisplayNames[reportFormatType],
+        })
+    );
 
     readonly helpMessages = {
         format: "The format that will be delivered to this recipient. For example, a PDF attached to an email or " +

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -26,7 +26,18 @@ export enum ScheduleRepetition {
     MONTHLY,
 }
 
+function mimeTypeToReportFormat(mimeType: string): ReportFormat | undefined {
+    if (/^application\/pdf\b/.test(mimeType)) {
+        return ReportFormat.HTML;
+    } else if (/^text\/html\b/.test(mimeType)) {
+        return ReportFormat.HTML;
+    }
+    return undefined;
+}
 export const availableSourceTypes: SourceType[] = features.sourceTypes.map((s: keyof typeof SourceType) => SourceType[s]);
+export const availableReportFormatTypes: ReportFormat[] = features.reportFormatTypes
+    .map((s: string) => mimeTypeToReportFormat(s))
+    .filter(fmt => (fmt !== undefined));
 
 export class ZoneInfo {
     value: string;

--- a/app/models/internal/Features.java
+++ b/app/models/internal/Features.java
@@ -17,6 +17,8 @@ package models.internal;
 
 import com.arpnetworking.metrics.portal.reports.SourceType;
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.MediaType;
+import models.internal.reports.ReportFormat;
 
 /**
  * Internal model interface for metrics portal feature state.
@@ -87,4 +89,11 @@ public interface Features {
      * @return list of names of {@link SourceType} enum values.
      */
     ImmutableList<String> getSourceTypes();
+
+    /**
+     * {@link MediaType}s of {@link ReportFormat}s to display in the UI.
+     *
+     * @return list of names of {@link MediaType}s.
+     */
+    ImmutableList<String> getReportFormatTypes();
 }

--- a/app/models/internal/impl/DefaultFeatures.java
+++ b/app/models/internal/impl/DefaultFeatures.java
@@ -18,6 +18,7 @@ package models.internal.impl;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.arpnetworking.metrics.portal.reports.SourceType;
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.MediaType;
 import com.typesafe.config.Config;
 import models.internal.Features;
 
@@ -74,6 +75,11 @@ public final class DefaultFeatures implements Features {
     }
 
     @Override
+    public ImmutableList<String> getReportFormatTypes() {
+        return _reportFormatTypes.stream().map(MediaType::toString).collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
     public String toString() {
         return new StringBuilder()
                 .append("{telemetryEnabled=").append(_telemetryEnabled)
@@ -84,6 +90,8 @@ public final class DefaultFeatures implements Features {
                 .append(", rollupsEnabled=").append(_rollupsEnabled)
                 .append(", reportsEnabled=").append(_reportsEnabled)
                 .append(", metricsAggregatorDaemonPorts=").append(_metricsAggregatorDaemonPorts)
+                .append(", sourceTypes=").append(_sourceTypes)
+                .append(", reportFormatTypes=").append(_reportFormatTypes)
                 .append("}")
                 .toString();
     }
@@ -107,6 +115,10 @@ public final class DefaultFeatures implements Features {
                 .stream()
                 .map(SourceType::valueOf)
                 .collect(ImmutableList.toImmutableList());
+        _reportFormatTypes = configuration.getStringList("portal.features.reports.formatTypes")
+                .stream()
+                .map(MediaType::parse)
+                .collect(ImmutableList.toImmutableList());
     }
 
     private final boolean _telemetryEnabled;
@@ -118,4 +130,5 @@ public final class DefaultFeatures implements Features {
     private final boolean _reportsEnabled;
     private final ImmutableList<Integer> _metricsAggregatorDaemonPorts;
     private final ImmutableList<SourceType> _sourceTypes;
+    private final ImmutableList<MediaType> _reportFormatTypes;
 }

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -78,6 +78,10 @@ portal.features {
   # Reports
   reports.enabled = false
   reports.sourceTypes = [WEB_PAGE, GRAFANA]
+  reports.formatTypes = [
+    "text/html; charset=utf-8",
+    "application/pdf",
+  ]
 
   # Metrics aggregator ports
   metricsAggregatorDaemonPorts = [7090]


### PR DESCRIPTION
Follows the same pattern as source-type configuration.