### PR TITLE
Nullability Fix for Gaps Aggregator

### DIFF
--- a/app/com/arpnetworking/kairos/client/models/DataPoint.java
+++ b/app/com/arpnetworking/kairos/client/models/DataPoint.java
@@ -21,13 +21,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import models.internal.TimeSeriesResult;
-import models.internal.impl.DefaultTimeSeriesResult;
 import net.sf.oval.constraint.NotNull;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Model class for a data point in a kairosdb metrics query.
@@ -39,20 +38,8 @@ public final class DataPoint {
         return _time;
     }
 
-    public Object getValue() {
+    public Optional<Object> getValue() {
         return _value;
-    }
-
-    /**
-     * Converts this to an internal model.
-     *
-     * @return a new internal model
-     */
-    public TimeSeriesResult.DataPoint toInternal() {
-        return new DefaultTimeSeriesResult.DataPoint.Builder()
-                .setTime(_time)
-                .setValue(_value)
-                .build();
     }
 
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD") // Invoked reflectively by Jackson
@@ -89,11 +76,11 @@ public final class DataPoint {
 
     private DataPoint(final Builder builder) {
         _time = builder._time;
-        _value = builder._value;
+        _value = Optional.ofNullable(builder._value);
     }
 
     private final Instant _time;
-    private final Object _value;
+    private final Optional<Object> _value;
 
     /**
      * Implementation of the builder pattern for a {@link DataPoint}.
@@ -128,7 +115,7 @@ public final class DataPoint {
         }
 
         /**
-         * Sets the value. Required. Cannot be null.
+         * Sets the value. Optional. Defaults to null.
          *
          * @param value the value
          * @return this {@link Builder}
@@ -146,7 +133,6 @@ public final class DataPoint {
 
         @NotNull
         private Instant _time;
-        @NotNull
         private Object _value;
     }
 }

--- a/app/com/arpnetworking/kairos/client/models/MetricsQueryResponse.java
+++ b/app/com/arpnetworking/kairos/client/models/MetricsQueryResponse.java
@@ -53,18 +53,6 @@ public final class MetricsQueryResponse {
         return _otherArgs;
     }
 
-    /**
-     * Converts this KairosDB model to an internal TimeSeriesResult model.
-     *
-     * @return a new {@link TimeSeriesResult} model
-     */
-    public TimeSeriesResult toTimeSeriesResult() {
-        return new DefaultTimeSeriesResult.Builder()
-                .setQueries(_queries.stream().map(Query::toInternal).collect(ImmutableList.toImmutableList()))
-                .setOtherArgs(_otherArgs)
-                .build();
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -178,19 +166,6 @@ public final class MetricsQueryResponse {
 
         public ImmutableList<QueryResult> getResults() {
             return _results;
-        }
-
-        /**
-         * Converts this model to an internal model.
-         *
-         * @return a new internal model
-         */
-        public TimeSeriesResult.Query toInternal() {
-            return new DefaultTimeSeriesResult.Query.Builder()
-                    .setSampleSize(_sampleSize)
-                    .setOtherArgs(_otherArgs)
-                    .setResults(_results.stream().map(QueryResult::toInternal).collect(ImmutableList.toImmutableList()))
-                    .build();
         }
 
         @Override
@@ -335,22 +310,6 @@ public final class MetricsQueryResponse {
         @JsonAnyGetter
         public ImmutableMap<String, Object> getOtherArgs() {
             return _otherArgs;
-        }
-
-        /**
-         * Converts this model to an internal model.
-         *
-         * @return a new internal model
-         */
-        public TimeSeriesResult.Result toInternal() {
-            return new DefaultTimeSeriesResult.Result.Builder()
-                    .setAlerts(ImmutableList.of())
-                    .setGroupBy(_groupBy.stream().map(QueryGroupBy::toInternal).collect(ImmutableList.toImmutableList()))
-                    .setName(_name)
-                    .setValues(_values.stream().map(DataPoint::toInternal).collect(ImmutableList.toImmutableList()))
-                    .setTags(_tags)
-                    .setOtherArgs(_otherArgs)
-                    .build();
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <aspectj.maven.plugin.version>1.8</aspectj.maven.plugin.version>
     <build.helper.maven.plugin.version>1.10</build.helper.maven.plugin.version>
     <commons.io.version>2.5</commons.io.version>
-    <docker.maven.plugin.version>0.30.0</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.27.2</docker.maven.plugin.version>
     <javassist.maven.plugin.version>0.1.2</javassist.maven.plugin.version>
     <maven.assembly.plugin.version>2.6</maven.assembly.plugin.version>
     <rpm.maven.plugin.version>2.1.5</rpm.maven.plugin.version>
@@ -565,6 +565,9 @@
             <goals>
               <goal>push</goal>
             </goals>
+            <configuration>
+              <filter>arpnetworking/metrics-portal:${project.version}</filter>
+            </configuration>
           </execution>
         </executions>
         <configuration>

--- a/test/java/com/arpnetworking/metrics/portal/integration/controllers/KairosDbProxyControllerIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/controllers/KairosDbProxyControllerIT.java
@@ -232,7 +232,7 @@ public final class KairosDbProxyControllerIT {
         assertEquals(ImmutableList.of("host.example.com"), result.getTags().get("host"));
         assertEquals(ImmutableList.of("foo"), result.getTags().get("ignored"));
         assertEquals(1, result.getValues().size());
-        assertEquals(1, result.getValues().get(0).getValue());
+        assertEquals(1, result.getValues().get(0).getValue().get());
     }
 
     @Test
@@ -287,7 +287,7 @@ public final class KairosDbProxyControllerIT {
         assertEquals(1, result.getTags().size());
         assertEquals(ImmutableList.of("host.example.com"), result.getTags().get("host"));
         assertEquals(1, result.getValues().size());
-        assertEquals(1, result.getValues().get(0).getValue());
+        assertEquals(1, result.getValues().get(0).getValue().get());
     }
 
     private void assertMetricsQuery(final String aggregator, final Number expectedValue, final int minutes) {
@@ -302,7 +302,7 @@ public final class KairosDbProxyControllerIT {
         assertEquals(createError("Unexpected tags"), 1, result.getTags().size());
         assertEquals(createError("Unexpected tag"), ImmutableList.of("host.example.com"), result.getTags().get("host"));
         assertEquals(createError("Unexpected values for " + aggregator), 1, result.getValues().size());
-        assertEquals(createError("Wrong value for " + aggregator), expectedValue, result.getValues().get(0).getValue());
+        assertEquals(createError("Wrong value for " + aggregator), expectedValue, result.getValues().get(0).getValue().get());
     }
 
     private MetricsQueryResponse queryMetrics(final MetricsQuery query) {


### PR DESCRIPTION
Make data point optional to support gaps aggregator. Remove internal model conversion instead of propagating change down deprecated path.