### PR TITLE
explicitly disable add_saved_from in RollupExecutor

### DIFF
--- a/app/com/arpnetworking/rollups/RollupExecutor.java
+++ b/app/com/arpnetworking/rollups/RollupExecutor.java
@@ -122,7 +122,10 @@ public class RollupExecutor extends AbstractActorWithTimers {
                         .build(),
                 new Aggregator.Builder()
                         .setName("save_as")
-                        .setOtherArgs(ImmutableMap.of("metric_name", rollupMetricName))
+                        .setOtherArgs(ImmutableMap.of(
+                                "metric_name", rollupMetricName,
+                                "add_saved_from", false
+                        ))
                         .build(),
                 new Aggregator.Builder()
                         .setName("count")


### PR DESCRIPTION
The KairosDB SaveAsAggregator bakes in the assumption that you're not saving a previous save-as, otherwise the `saved_from` tag thats added to the output series by default will conflict with the existing tag.

Now that we're rolling up roll-ups, this conflict occurs in RollupExecutor. I figured the actual fix would be to update SaveAs (see https://github.com/ddimensia/kairosdb/pull/3) but since Metrics Portal will likely be run against other instances of KairosDB they'll still have this conflict outside of that fork and I think the appropriate action is just to turn this off entirely.