### PR TITLE
Allow control of various aspects of report configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ To debug on port 9002 with the server on port 8080 via Play; you need to configu
 
 To launch dependencies only via Docker:
 
-    metrics-portal> ./jdk-wrapper.sh ./mvnw docker:start -PdependenciesOnly -Dpostgres.port=6432
+    metrics-portal> ./jdk-wrapper.sh ./mvnw docker:start -PdependenciesOnly
 
 To execute unit performance tests:
 

--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -264,8 +264,7 @@ class EditSourceViewModel extends BaseSourceViewModel {
                 "the browser and the page content is taken as the rendered report. This <i>only</i> supports static " +
                 "content.</li>",
         [SourceType.GRAFANA]: "<li class='list-group-item'><b>Grafana</b> - Specialization of the Web Page source " +
-                "for capturing page content from Grafana based reports which may contain dynamic content. Additionally, " +
-                "these sources pass the scheduled date as the </li>",
+                "for capturing page content from a Grafana based report which may contain dynamic content.</li>",
     };
     readonly availableSourceTypes: {value: SourceType, text: string}[] = availableSourceTypes.map(
         sourceType => ({value: sourceType, text: EditSourceViewModel.sourceTypeDisplayNames[sourceType]})

--- a/app/assets/javascripts/classes/reports/EditReportViewModel.ts
+++ b/app/assets/javascripts/classes/reports/EditReportViewModel.ts
@@ -23,6 +23,9 @@ import csrf from '../Csrf';
 
 import {
     availableSourceTypes,
+    availableReportFormats,
+    availableRecipientTypes,
+    availableReportIntervals,
     BaseRecipientViewModel,
     BaseScheduleViewModel,
     BaseSourceViewModel,
@@ -140,14 +143,6 @@ class EditReportViewModel {
         }
     }
 
-    readonly availableRecipientTypes = [
-        {value: RecipientType.EMAIL,  text: "Email"},
-    ];
-
-    readonly helpMessages = {
-        timeout: "Time that can be spent rendering/sending the report before forcibly halting execution. HH:MM:SS or ISO-8601.",
-    }
-
     private static parseProblems(responseJson: string): string[] {
         try {
             return JSON.parse(responseJson).errors;
@@ -155,6 +150,18 @@ class EditReportViewModel {
             return [EditReportViewModel.UNKNOWN_ERROR_MESSAGE];
         }
     }
+
+    private static readonly recipientTypeDisplayNames = {
+        [RecipientType.EMAIL]: "Email",
+    };
+
+    readonly availableRecipientTypes: {value: RecipientType, text: string}[] = availableRecipientTypes.map(
+        recipientType => ({value: recipientType, text: EditReportViewModel.recipientTypeDisplayNames[recipientType]})
+    );
+
+    readonly helpMessages = {
+        timeout: "Time that can be spent rendering/sending the report before forcibly halting execution. HH:MM:SS or ISO-8601.",
+    };
 }
 
 class EditRecipientViewModel extends BaseRecipientViewModel {
@@ -189,14 +196,31 @@ class EditRecipientViewModel extends BaseRecipientViewModel {
         }
     }
 
-    readonly availableFormats = [
-        {value: ReportFormat.PDF,  text: "PDF"},
-        {value: ReportFormat.HTML,  text: "HTML"},
-    ];
+    private static readonly reportFormatDisplayNames = {
+        [ReportFormat.HTML]: "HTML",
+        [ReportFormat.PDF]: "PDF",
+    };
+
+    private static readonly reportFormatHelp = {
+        [ReportFormat.HTML]: "<li class='list-group-item'><b>HTML</b> - Hyper Text Markup Language (HTML) tells a " +
+                "web browser how to display text, images and other forms of multimedia. Graphical content within " +
+                "reports is currently <b>not</b> supported when rendered as HTML.</li>",
+        [ReportFormat.PDF]: "<li class='list-group-item'><b>PDF</b> - Portable Document Format (PDF) is a file format " +
+                "that has captured all the elements of a document as an electronic image. Graphical content within " +
+                "reports is currently supported when rendered as PDF.</li>",
+    };
+
+    readonly availableFormats: {value: ReportFormat, text: string}[] = availableReportFormats.map(
+        reportFormat => ({value: reportFormat, text: EditRecipientViewModel.reportFormatDisplayNames[reportFormat]})
+    );
 
     readonly helpMessages = {
-        format: "The format that will be delivered to this recipient. For example, a PDF attached to an email or " +
-            "some HTML rendered inline.",
+        format: "The format that the report will be delivered in to the recipient.<br>" +
+              "<ul class='list-group'>"+
+              availableReportFormats.map(
+                      reportFormat => EditRecipientViewModel.reportFormatHelp[reportFormat]
+                  )+
+              "</ul>",
     };
 }
 
@@ -232,14 +256,16 @@ class EditSourceViewModel extends BaseSourceViewModel {
 
     // Used by KO data-bind.
     private static readonly sourceTypeDisplayNames = {
-        [SourceType.WEB_PAGE]: "Web page",
+        [SourceType.WEB_PAGE]: "Web Page",
         [SourceType.GRAFANA]: "Grafana",
     };
     private static readonly sourceTypeHelp = {
-        [SourceType.WEB_PAGE]: "<li class='list-group-item'><b>Browser rendered</b> - A URL is loaded in the browser and the rendered " +
-                "contents of the page are taken as the generated report.</li>",
-        [SourceType.GRAFANA]: "<li class='list-group-item'><b>Grafana</b> - Like browser-rendered, but tweaked to pull data from a Grafana Report panel" +
-                " (which are loaded asynchronously after page-load, hence needing the specialization).</li>",
+        [SourceType.WEB_PAGE]: "<li class='list-group-item'><b>Browser rendered</b> - The specified URL is loaded in " +
+                "the browser and the page content is taken as the rendered report. This <i>only</i> supports static " +
+                "content.</li>",
+        [SourceType.GRAFANA]: "<li class='list-group-item'><b>Grafana</b> - Specialization of the Web Page source " +
+                "for capturing page content from Grafana based reports which may contain dynamic content. Additionally, " +
+                "these sources pass the scheduled date as the </li>",
     };
     readonly availableSourceTypes: {value: SourceType, text: string}[] = availableSourceTypes.map(
         sourceType => ({value: sourceType, text: EditSourceViewModel.sourceTypeDisplayNames[sourceType]})
@@ -252,7 +278,6 @@ class EditSourceViewModel extends BaseSourceViewModel {
                       sourceType => EditSourceViewModel.sourceTypeHelp[sourceType]
                   )+
               "</ul>",
-        eventName: "When an event with this name is triggered, the report is considered fully rendered.",
     };
 }
 
@@ -317,16 +342,21 @@ class EditScheduleViewModel extends BaseScheduleViewModel {
         }
     }
 
-    readonly availableRepeatTypes = [
-        {value: ScheduleRepetition.ONE_OFF, text: "Does not repeat"},
-        {value: ScheduleRepetition.HOURLY,  text: "Hourly"},
-        {value: ScheduleRepetition.DAILY,   text: "Daily"},
-        {value: ScheduleRepetition.WEEKLY,  text: "Weekly"},
-        {value: ScheduleRepetition.MONTHLY, text: "Monthly"},
-    ];
+    private static readonly repeatTypeDisplayNames = {
+        [ScheduleRepetition.ONE_OFF]: "Does not repeat",
+        [ScheduleRepetition.HOURLY]: "Hourly",
+        [ScheduleRepetition.DAILY]: "Daily",
+        [ScheduleRepetition.WEEKLY]: "Weekly",
+        [ScheduleRepetition.MONTHLY]: "Monthly",
+    };
+
+    readonly availableRepeatTypes: {value: ScheduleRepetition, text: string}[] = availableReportIntervals.map(
+        repeatType => ({value: repeatType, text: EditScheduleViewModel.repeatTypeDisplayNames[repeatType]})
+    );
 
     readonly helpMessages = {
-        offset: "This is the smallest amount of time to wait after the start of a period before generating the report.",
+        offset: "The minimum time to wait after the scheduled time before generating the report. This is commonly " +
+                "used to adjust report generation to account for delays from ingestion, aggregation or eventual consistency.",
     };
 }
 

--- a/app/assets/javascripts/classes/reports/Models.ts
+++ b/app/assets/javascripts/classes/reports/Models.ts
@@ -26,7 +26,10 @@ export enum ScheduleRepetition {
     MONTHLY,
 }
 
-export const availableSourceTypes: SourceType[] = features.sourceTypes.map((s: keyof typeof SourceType) => SourceType[s]);
+export const availableSourceTypes: SourceType[] = features.reportingSourceTypes.map((s: keyof typeof SourceType) => SourceType[s]);
+export const availableReportFormats: ReportFormat[] = features.reportingReportFormats.map((s: keyof typeof ReportFormat) => ReportFormat[s]);
+export const availableRecipientTypes: RecipientType[] = features.reportingRecipientTypes.map((s: keyof typeof RecipientType) => RecipientType[s]);
+export const availableReportIntervals: ScheduleRepetition[] = features.reportingIntervals.map((s: keyof typeof ScheduleRepetition) => ScheduleRepetition[s]);
 
 export class ZoneInfo {
     value: string;
@@ -81,7 +84,7 @@ export class BaseScheduleViewModel {
     offset = ko.pureComputed<moment.Duration>(() => moment.duration(this.offsetString()));
     zone = ko.observable<ZoneInfo>(new ZoneInfo(moment.tz.guess()));
 
-    offsetString = ko.observable<string>("");
+    offsetString = ko.observable<string>("PT10M");
 
     public load(raw: any): this {
         this.start(moment(raw.runAtAndAfter));

--- a/app/com/arpnetworking/metrics/portal/reports/ReportFormat.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportFormat.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.reports;
+
+/**
+ * Output formats for a rendered report.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public enum ReportFormat {
+    /**
+     * HTML.
+     */
+    HTML,
+    /**
+     * PDF.
+     */
+    PDF,
+}

--- a/app/com/arpnetworking/metrics/portal/reports/ReportInterval.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportInterval.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.reports;
+
+/**
+ * Delivery interval for repeating report delivery.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public enum ReportInterval {
+    /**
+     * One off.
+     */
+    ONE_OFF,
+    /**
+     * Hourly.
+     */
+    HOURLY,
+    /**
+     * Daily.
+     */
+    DAILY,
+    /**
+     * Weekly.
+     */
+    WEEKLY,
+    /**
+     * Monthly.
+     */
+    MONTHLY,
+}

--- a/app/models/internal/Features.java
+++ b/app/models/internal/Features.java
@@ -15,6 +15,9 @@
  */
 package models.internal;
 
+import com.arpnetworking.metrics.portal.reports.RecipientType;
+import com.arpnetworking.metrics.portal.reports.ReportFormat;
+import com.arpnetworking.metrics.portal.reports.ReportInterval;
 import com.arpnetworking.metrics.portal.reports.SourceType;
 import com.google.common.collect.ImmutableList;
 
@@ -82,9 +85,30 @@ public interface Features {
     ImmutableList<Integer> getMetricsAggregatorDaemonPorts();
 
     /**
-     * Names of {@link SourceType}s to display in the UI.
+     * Reporting {@link SourceType}s that are enabled.
      *
-     * @return list of names of {@link SourceType} enum values.
+     * @return list of enabled {@link SourceType} values.
      */
-    ImmutableList<String> getSourceTypes();
+    ImmutableList<SourceType> getReportingSourceTypes();
+
+    /**
+     * Reporting {@link ReportFormat}s that are enabled.
+     *
+     * @return list of {@link ReportFormat} values.
+     */
+    ImmutableList<ReportFormat> getReportingReportFormats();
+
+    /**
+     * Reporting {@link RecipientType}s that are enabled.
+     *
+     * @return list of {@link RecipientType} values.
+     */
+    ImmutableList<RecipientType> getReportingRecipientTypes();
+
+    /**
+     * Names of reporting {@link RecipientType}s that are enabled.
+     *
+     * @return list of {@link RecipientType} values.
+     */
+    ImmutableList<ReportInterval> getReportingIntervals();
 }

--- a/app/models/internal/impl/DefaultFeatures.java
+++ b/app/models/internal/impl/DefaultFeatures.java
@@ -16,6 +16,9 @@
 package models.internal.impl;
 
 import com.arpnetworking.logback.annotations.Loggable;
+import com.arpnetworking.metrics.portal.reports.RecipientType;
+import com.arpnetworking.metrics.portal.reports.ReportFormat;
+import com.arpnetworking.metrics.portal.reports.ReportInterval;
 import com.arpnetworking.metrics.portal.reports.SourceType;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
@@ -69,8 +72,23 @@ public final class DefaultFeatures implements Features {
     }
 
     @Override
-    public ImmutableList<String> getSourceTypes() {
-        return _sourceTypes.stream().map(SourceType::name).collect(ImmutableList.toImmutableList());
+    public ImmutableList<SourceType> getReportingSourceTypes() {
+        return _reportingSourceTypes;
+    }
+
+    @Override
+    public ImmutableList<ReportFormat> getReportingReportFormats() {
+        return _reportingReportFormats;
+    }
+
+    @Override
+    public ImmutableList<RecipientType> getReportingRecipientTypes() {
+        return _reportingRecipientTypes;
+    }
+
+    @Override
+    public ImmutableList<ReportInterval> getReportingIntervals() {
+        return _reportingIntervals;
     }
 
     @Override
@@ -83,6 +101,10 @@ public final class DefaultFeatures implements Features {
                 .append(", alertsEnabled=").append(_alertsEnabled)
                 .append(", rollupsEnabled=").append(_rollupsEnabled)
                 .append(", reportsEnabled=").append(_reportsEnabled)
+                .append(", reportingSourceTypes=").append(_reportingSourceTypes)
+                .append(", reportingReportFormats=").append(_reportingReportFormats)
+                .append(", reportingRecipientTypes=").append(_reportingRecipientTypes)
+                .append(", reportingIntervals=").append(_reportingIntervals)
                 .append(", metricsAggregatorDaemonPorts=").append(_metricsAggregatorDaemonPorts)
                 .append("}")
                 .toString();
@@ -103,9 +125,21 @@ public final class DefaultFeatures implements Features {
         _reportsEnabled = configuration.getBoolean("portal.features.reports.enabled");
         _metricsAggregatorDaemonPorts = ImmutableList.copyOf(
                 configuration.getIntList("portal.features.metricsAggregatorDaemonPorts"));
-        _sourceTypes = configuration.getStringList("portal.features.reports.sourceTypes")
+        _reportingSourceTypes = configuration.getStringList("portal.features.reports.sourceTypes")
                 .stream()
                 .map(SourceType::valueOf)
+                .collect(ImmutableList.toImmutableList());
+        _reportingReportFormats = configuration.getStringList("portal.features.reports.reportFormats")
+                .stream()
+                .map(ReportFormat::valueOf)
+                .collect(ImmutableList.toImmutableList());
+        _reportingRecipientTypes = configuration.getStringList("portal.features.reports.recipientTypes")
+                .stream()
+                .map(RecipientType::valueOf)
+                .collect(ImmutableList.toImmutableList());
+        _reportingIntervals = configuration.getStringList("portal.features.reports.intervals")
+                .stream()
+                .map(ReportInterval::valueOf)
                 .collect(ImmutableList.toImmutableList());
     }
 
@@ -117,5 +151,8 @@ public final class DefaultFeatures implements Features {
     private final boolean _rollupsEnabled;
     private final boolean _reportsEnabled;
     private final ImmutableList<Integer> _metricsAggregatorDaemonPorts;
-    private final ImmutableList<SourceType> _sourceTypes;
+    private final ImmutableList<SourceType> _reportingSourceTypes;
+    private final ImmutableList<ReportFormat> _reportingReportFormats;
+    private final ImmutableList<RecipientType> _reportingRecipientTypes;
+    private final ImmutableList<ReportInterval> _reportingIntervals;
 }

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -78,6 +78,9 @@ portal.features {
   # Reports
   reports.enabled = false
   reports.sourceTypes = [WEB_PAGE, GRAFANA]
+  reports.reportFormats = [HTML, PDF]
+  reports.recipientTypes = [EMAIL]
+  reports.intervals = [ONE_OFF, HOURLY, DAILY, WEEKLY, MONTHLY]
 
   # Metrics aggregator ports
   metricsAggregatorDaemonPorts = [7090]
@@ -187,7 +190,7 @@ reporting {
   senders {
     EMAIL {
       type = "com.arpnetworking.metrics.portal.reports.impl.EmailSender"
-      fromAddress = "no-reply+metrics-portal-reporting@invalid.net"
+      fromAddress = "no-reply+metrics-portal-reporting@example.com"
       allowedRecipients = [ ".+@.+" ]
     }
   }

--- a/public/html/reports/ReportsViewModel.html
+++ b/public/html/reports/ReportsViewModel.html
@@ -46,7 +46,6 @@
                             <div class="popover-content hidden" data-bind="attr: {'data-id': 'source-'+id}">
                                 <dl class="container col-md-12 dl-horizontal">
                                     <dt>url:</dt><dd data-bind="text: source.url"></dd>
-                                    <dt>event:</dt><dd data-bind="text: source.eventName"></dd>
                                     <dt>ignore cert errors:</dt><dd data-bind="text: source.ignoreCertificateErrors"></dd>
                                 </dl>
                             </div>


### PR DESCRIPTION
Extends the configuration, client-side injected features, as well as report ui code to support configuration of:

* Sources
* Formats
* Recipients
* Intervals

All are enabled by default, although reporting itself is off by default.