### PR TITLE
Fix query-rewriting for rollups

### DIFF
--- a/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
+++ b/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
@@ -219,7 +219,7 @@ public final class KairosDbServiceImpl implements KairosDbService {
         return response;
     }
 
-    private static MetricsQuery useAvailableRollups(
+    /* package private */ static MetricsQuery useAvailableRollups(
             final List<String> metricNames,
             final MetricsQuery originalQuery,
             final MetricsQueryConfig queryConfig,

--- a/test/java/com/arpnetworking/kairos/service/KairosDbServiceImplTest.java
+++ b/test/java/com/arpnetworking/kairos/service/KairosDbServiceImplTest.java
@@ -328,7 +328,7 @@ public class KairosDbServiceImplTest {
     }
 
     @Test
-    public void testRollupQueryRewriting_BasicRewrite() {
+    public void testRollupQueryRewritingBasicRewrite() {
         final ImmutableList<Aggregator> aggregators = ImmutableList.of(
                 TestBeanFactory.createAggregatorBuilder()
                         .setSampling(simpleSampling(3, SamplingUnit.HOURS))
@@ -339,7 +339,7 @@ public class KairosDbServiceImplTest {
         final MetricsQuery rewritten = KairosDbServiceImpl.useAvailableRollups(
                 ImmutableList.of("my_metric_1h"),
                 original,
-                (s) -> ImmutableSet.of(SamplingUnit.HOURS),
+                s -> ImmutableSet.of(SamplingUnit.HOURS),
                 new NoOpMetrics()
         );
         final MetricsQuery expected = simpleMetricsQuery("my_metric_1h", aggregators);
@@ -347,7 +347,7 @@ public class KairosDbServiceImplTest {
     }
 
     @Test
-    public void testRollupQueryRewriting_OddInterval() {
+    public void testRollupQueryRewritingDoesNotRewriteOddInterval() {
         final MetricsQuery original = simpleMetricsQuery(
                 "my_metric",
                 ImmutableList.of(
@@ -360,14 +360,14 @@ public class KairosDbServiceImplTest {
         final MetricsQuery rewritten = KairosDbServiceImpl.useAvailableRollups(
                 ImmutableList.of("my_metric_1h"),
                 original,
-                (s) -> ImmutableSet.of(SamplingUnit.HOURS),
+                s -> ImmutableSet.of(SamplingUnit.HOURS),
                 new NoOpMetrics()
         );
         assertEquals(original, rewritten);
     }
 
     @Test
-    public void testRollupQueryRewriting_NotAligned() {
+    public void testRollupQueryRewritingDoesNotRewriteUnaligned() {
         final MetricsQuery original = simpleMetricsQuery(
                 "my_metric",
                 ImmutableList.of(
@@ -380,14 +380,14 @@ public class KairosDbServiceImplTest {
         final MetricsQuery rewritten = KairosDbServiceImpl.useAvailableRollups(
                 ImmutableList.of("my_metric_1h"),
                 original,
-                (s) -> ImmutableSet.of(SamplingUnit.HOURS),
+                s -> ImmutableSet.of(SamplingUnit.HOURS),
                 new NoOpMetrics()
         );
         assertEquals(original, rewritten);
     }
 
     @Test
-    public void testRollupQueryRewriting_RegressionTest() {
+    public void testRollupQueryRewritingDoesNotIgnoreUnaligned() {
         final MetricsQuery original = simpleMetricsQuery(
                 "my_metric",
                 ImmutableList.of(
@@ -404,7 +404,7 @@ public class KairosDbServiceImplTest {
         final MetricsQuery rewritten = KairosDbServiceImpl.useAvailableRollups(
                 ImmutableList.of("my_metric_1h"),
                 original,
-                (s) -> ImmutableSet.of(SamplingUnit.HOURS),
+                s -> ImmutableSet.of(SamplingUnit.HOURS),
                 new NoOpMetrics()
         );
         assertEquals(original, rewritten);

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -16,8 +16,6 @@
 package com.arpnetworking.metrics.portal;
 
 import com.arpnetworking.kairos.client.models.Aggregator;
-import com.arpnetworking.kairos.client.models.Metric;
-import com.arpnetworking.kairos.client.models.MetricsQuery;
 import com.arpnetworking.kairos.client.models.Sampling;
 import com.arpnetworking.kairos.client.models.SamplingUnit;
 import com.arpnetworking.metrics.portal.reports.RecipientType;
@@ -25,7 +23,6 @@ import com.arpnetworking.metrics.portal.scheduling.Schedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.NeverSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.PeriodicSchedule;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import models.cassandra.Host;
@@ -192,10 +189,20 @@ public final class TestBeanFactory {
                 .setIgnoreCertificateErrors(false);
     }
 
+    /**
+     * Factory method for creating a {@link Sampling.Builder}.
+     *
+     * @return the builder.
+     */
     public static Sampling.Builder createSamplingBuilder() {
         return new Sampling.Builder().setValue(1).setUnit(SamplingUnit.HOURS);
     }
 
+    /**
+     * Factory method for creating a {@link Aggregator.Builder}.
+     *
+     * @return the builder.
+     */
     public static Aggregator.Builder createAggregatorBuilder() {
         return new Aggregator.Builder()
                 .setName("count")

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -15,11 +15,17 @@
  */
 package com.arpnetworking.metrics.portal;
 
+import com.arpnetworking.kairos.client.models.Aggregator;
+import com.arpnetworking.kairos.client.models.Metric;
+import com.arpnetworking.kairos.client.models.MetricsQuery;
+import com.arpnetworking.kairos.client.models.Sampling;
+import com.arpnetworking.kairos.client.models.SamplingUnit;
 import com.arpnetworking.metrics.portal.reports.RecipientType;
 import com.arpnetworking.metrics.portal.scheduling.Schedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.NeverSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.PeriodicSchedule;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import models.cassandra.Host;
@@ -184,6 +190,16 @@ public final class TestBeanFactory {
                 .setId(UUID.randomUUID())
                 .setUri(URI.create("http://" + UUID.randomUUID().toString().replace("-", "") + ".example.com"))
                 .setIgnoreCertificateErrors(false);
+    }
+
+    public static Sampling.Builder createSamplingBuilder() {
+        return new Sampling.Builder().setValue(1).setUnit(SamplingUnit.HOURS);
+    }
+
+    public static Aggregator.Builder createAggregatorBuilder() {
+        return new Aggregator.Builder()
+                .setName("count")
+                .setSampling(createSamplingBuilder().build());
     }
 
     /**


### PR DESCRIPTION
The logic for determining whether a query can be optimized to use rollups / which rollup to use is broken, and it will sometimes use a rollup even when it shouldn't.

## Demonstration
This is a problem in Dropbox's production environment: [Grafana](http://drl/q34th87h4378og)
<img width="1661" alt="Screenshot 2020-04-14 21 31 00" src="https://user-images.githubusercontent.com/1899701/79299600-59359000-7e99-11ea-9731-25bc1c5d8bc5.png">
- There are two queries, identical except that one uses the `_!` feature to prevent use of rollups.
- Clearly, they should return the same value, because rollup-usage should be a pure optimization, invisible to the user. But they don't.

### Explanation
- The query has two aggregators: `count(1m)` and `count(1h)`. The first aggregator, though, is not sampling-aligned, which leads to [it being ignored](https://github.com/ArpNetworking/metrics-portal/blob/e8b8df96e566963f2dbd94c59a539fe5a5731091/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java#L266) when MPortal is checking whether it can use rollups, so MPortal only sees the 1h aggregator and mistakenly thinks it can use rollups.
- The **correct** answer for this query is "one datapoint per hour, with value 60." (Reasoning: this is a very busy metric, with data every minute, so the `count(1m)` produces one datapoint (with irrelevant value) per minute, so the `count(1h)` should count 60 datapoints per hour.)  The `_!` ("force non-use of rollups") query gets this right.
- The **incorrect** answer is "one datapoint per hour, with value 1." This occurs when MPortal mistakenly uses the rollup and therefore the `count(1m)` produces only 1 datapoint per hour instead of 1 per minute. The non-`_!` query gets this wrong.


## Fix
Explained by a comment in the new `getMaxUsableRollupUnit` method.
