### PR TITLE
refactor out a chunk of rollup query-rewriting

### DIFF
--- a/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
+++ b/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
@@ -284,6 +284,15 @@ public final class KairosDbServiceImpl implements KairosDbService {
                 }).collect(ImmutableList.toImmutableList())));
     }
 
+    /**
+     * For a metric, find the corresponding rollup metric with the longest period not exceeding some threshold.
+     *
+     * @param metricName The metric we want to find a rollup for.
+     * @param rollupMetrics A list of all rollup metrics corresponding to the given metric.
+     * @param queryConfig Used to tell which rollup metrics are enabled when querying this metric.
+     * @param maxUsableRollupUnit The longest rollup-period we're willing to accept (for fear of changing the query's results).
+     * @return The given enabled {@code rollupMetric} with the greatest period not exceeding the threshold (if any).
+     */
     /* package private */ static Optional<String> getCoarsestUsableRollupMetric(
             final String metricName,
             final List<String> rollupMetrics,

--- a/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
+++ b/app/com/arpnetworking/kairos/service/KairosDbServiceImpl.java
@@ -265,7 +265,12 @@ public final class KairosDbServiceImpl implements KairosDbService {
 
 
                     if (maxUsableRollupUnit.isPresent()) {
-                        final Optional<String> rollupName = getCoarsestUsableRollupMetric(metricName, rollupMetrics, queryConfig, maxUsableRollupUnit.get());
+                        final Optional<String> rollupName = getCoarsestUsableRollupMetric(
+                                metricName,
+                                rollupMetrics,
+                                queryConfig,
+                                maxUsableRollupUnit.get()
+                        );
                         metrics.incrementCounter("kairosService/useRollups/noMatchingRollup", rollupName.isPresent() ? 0 : 1);
                         final String rewrittenMetricName = rollupName.orElse(metricName);
                         return Metric.Builder.<Metric, Metric.Builder>clone(metric)

--- a/test/java/com/arpnetworking/kairos/service/KairosDbServiceImplTest.java
+++ b/test/java/com/arpnetworking/kairos/service/KairosDbServiceImplTest.java
@@ -410,6 +410,37 @@ public class KairosDbServiceImplTest {
         assertEquals(original, rewritten);
     }
 
+    @Test
+    public void testGetCoarsestUsableRollupMetric() {
+        assertEquals(
+                Optional.of("my_metric_1h"),
+                KairosDbServiceImpl.getCoarsestUsableRollupMetric(
+                        "my_metric",
+                        ImmutableList.of("my_metric_1h", "my_metric_1d"),
+                        s -> ImmutableSet.of(SamplingUnit.HOURS),
+                        SamplingUnit.HOURS
+                )
+        );
+        assertEquals(
+                Optional.empty(),
+                KairosDbServiceImpl.getCoarsestUsableRollupMetric(
+                        "my_metric",
+                        ImmutableList.of("my_metric_1d"),
+                        s -> ImmutableSet.of(SamplingUnit.HOURS),
+                        SamplingUnit.HOURS
+                )
+        );
+        assertEquals(
+                Optional.empty(),
+                KairosDbServiceImpl.getCoarsestUsableRollupMetric(
+                        "my_metric",
+                        ImmutableList.of("my_metric_1h"),
+                        s -> ImmutableSet.of(),
+                        SamplingUnit.HOURS
+                )
+        );
+    }
+
     private Sampling simpleSampling(final int value, final SamplingUnit unit) {
         return new Sampling.Builder().setValue(value).setUnit(unit).build();
     }


### PR DESCRIPTION
Should be a behavioral no-op. Depends on #352 -- [this commit range](https://github.com/ArpNetworking/metrics-portal/pull/353/files/fd76e39437cb6563ea61acaf4901371022303a7d..5305ff56e9433e129e49fd5888716342b5de72f1) includes only changes since then.