### PR TITLE
compute rollup-job end time from start time and period, to increase atomicity

### DIFF
--- a/app/com/arpnetworking/rollups/RollupDefinition.java
+++ b/app/com/arpnetworking/rollups/RollupDefinition.java
@@ -36,7 +36,6 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
     private final String _destinationMetricName;
     private final RollupPeriod _period;
     private final Instant _startTime;
-    private final Instant _endTime;
     private final ImmutableSet<String> _groupByTags;
 
     private RollupDefinition(final Builder builder) {
@@ -44,7 +43,6 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         _destinationMetricName = builder._destinationMetricName;
         _period = builder._period;
         _startTime = builder._startTime;
-        _endTime = builder._endTime;
         _groupByTags = builder._groupByTags;
     }
 
@@ -64,10 +62,6 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         return _startTime;
     }
 
-    public Instant getEndTime() {
-        return _endTime;
-    }
-
     public ImmutableSet<String> getGroupByTags() {
         return _groupByTags;
     }
@@ -84,18 +78,21 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         return _sourceMetricName.equals(that._sourceMetricName)
                 && _destinationMetricName.equals(that._destinationMetricName)
                 && _period == that._period
-                && _startTime.equals(that._startTime)
-                && _endTime.equals(that._endTime);
+                && _startTime.equals(that._startTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_sourceMetricName, _destinationMetricName, _period, _startTime, _endTime, _groupByTags);
+        return Objects.hash(_sourceMetricName, _destinationMetricName, _period, _startTime, _groupByTags);
     }
 
     @Override
     public Object consistentHashKey() {
         return hashCode();
+    }
+
+    public Instant getEndTime() {
+        return _startTime.plus(_period.periodCountToDuration(1)).minusMillis(1);
     }
 
     /**
@@ -112,8 +109,6 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         private RollupPeriod _period;
         @NotNull
         private Instant _startTime;
-        @NotNull
-        private Instant _endTime;
         @NotNull
         private ImmutableSet<String> _groupByTags;
 
@@ -165,17 +160,6 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
          */
         public Builder setStartTime(final Instant value) {
             _startTime = value;
-            return this;
-        }
-
-        /**
-         * Sets the {@code _endTime} and returns a reference to this Builder so that the methods can be chained together.
-         *
-         * @param value the {@code _endTime} to set
-         * @return a reference to this Builder
-         */
-        public Builder setEndTime(final Instant value) {
-            _endTime = value;
             return this;
         }
 

--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -331,8 +331,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
 
                 while (!startTimes.isEmpty()) {
                     final Instant startTime = startTimes.poll();
-                    rollupDefBuilder.setStartTime(startTime)
-                            .setEndTime(startTime.plus(period.periodCountToDuration(1)).minusMillis(1));
+                    rollupDefBuilder.setStartTime(startTime);
                     _rollupManagerPool.tell(rollupDefBuilder.build(), self());
                 }
             }

--- a/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
@@ -124,7 +124,6 @@ public class RollupExecutorTest {
                                 .setDestinationMetricName("metric_1h")
                                 .setPeriod(RollupPeriod.HOURLY)
                                 .setStartTime(Instant.EPOCH)
-                                .setEndTime(Instant.EPOCH.plusMillis(1))
                                 .setGroupByTags(ImmutableSet.of())
                                 .build()
                         )
@@ -172,7 +171,6 @@ public class RollupExecutorTest {
                         .setPeriod(RollupPeriod.HOURLY)
                         .setGroupByTags(ImmutableSet.of("tag1", "tag2"))
                         .setStartTime(Instant.EPOCH)
-                        .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS))
                         .build(),
                 ActorRef.noSender());
 
@@ -187,7 +185,7 @@ public class RollupExecutorTest {
         assertEquals("metric", rollupQuery.getMetrics().get(0).getName());
         assertEquals(Optional.of(Instant.EPOCH), rollupQuery.getStartTime());
         assertTrue(rollupQuery.getEndTime().isPresent());
-        assertEquals(Instant.EPOCH.plus(1, ChronoUnit.HOURS), rollupQuery.getEndTime().get());
+        assertEquals(Instant.EPOCH.plus(1, ChronoUnit.HOURS).minusMillis(1), rollupQuery.getEndTime().get());
         assertEquals(1, rollupQuery.getMetrics().size());
         final Metric metric = rollupQuery.getMetrics().get(0);
         assertEquals(1, metric.getGroupBy().size());

--- a/test/java/com/arpnetworking/rollups/RollupManagerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupManagerTest.java
@@ -94,8 +94,7 @@ public final class RollupManagerTest {
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
                 .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
-                .setStartTime(Instant.EPOCH)
-                .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS));
+                .setStartTime(Instant.EPOCH);
         final RollupDefinition rollupDef = rollupDefBuilder.build();
         final RollupDefinition rollupDef2 = rollupDefBuilder
                 .setDestinationMetricName("foo_1d")
@@ -121,8 +120,7 @@ public final class RollupManagerTest {
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
                 .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
-                .setStartTime(Instant.EPOCH)
-                .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS));
+                .setStartTime(Instant.EPOCH);
         final RollupDefinition rollupDef = rollupDefBuilder.build();
         final RollupDefinition rollupDef2 = rollupDefBuilder.build();
         actor.tell(rollupDef, testActor);
@@ -143,8 +141,7 @@ public final class RollupManagerTest {
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
                 .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
-                .setStartTime(Instant.EPOCH)
-                .setEndTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS));
+                .setStartTime(Instant.EPOCH);
         final RollupDefinition rollupDef = rollupDefBuilder.build();
         final RollupDefinition rollupDef2 = rollupDefBuilder.setStartTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS)).build();
         actor.tell(rollupDef2, testActor);


### PR DESCRIPTION
I think we want each rollup-job to be as atomic as feasible, and that means having each job consist of writing a _single_ timestamp, not multiple.

(We were already doing this in practice. I'm just simplifying the data model to enforce this constraint.)