### PR TITLE
interfaces for internal JobExecution

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
@@ -19,7 +19,6 @@ import models.internal.Organization;
 import models.internal.scheduling.Job;
 import models.internal.scheduling.JobExecution;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -49,10 +48,9 @@ public interface JobExecutionRepository<T> {
      * @param jobId The UUID of the job that completed.
      * @param organization The organization owning the job.
      * @throws NoSuchElementException if no job has the given UUID.
-     * @throws IOException if deserializing the job result fails.
      * @return The last successful execution.
      */
-    Optional<JobExecution.Success<T>> getLastSuccess(UUID jobId, Organization organization) throws NoSuchElementException, IOException;
+    Optional<JobExecution.Success<T>> getLastSuccess(UUID jobId, Organization organization) throws NoSuchElementException;
 
     /**
      * Get the last completed execution, regardless of if it succeeded.
@@ -60,10 +58,9 @@ public interface JobExecutionRepository<T> {
      * @param jobId The UUID of the job that completed.
      * @param organization The organization owning the job.
      * @throws NoSuchElementException if no job has the given UUID.
-     * @throws IOException if deserializing a job result fails.
      * @return The last completed execution.
      */
-    Optional<JobExecution<T>> getLastCompleted(UUID jobId, Organization organization) throws NoSuchElementException, IOException;
+    Optional<JobExecution<T>> getLastCompleted(UUID jobId, Organization organization) throws NoSuchElementException;
 
     /**
      * Notify the repository that a job has started executing.

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.scheduling;
+
+import models.internal.Organization;
+import models.internal.scheduling.Job;
+import models.internal.scheduling.JobExecution;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * A storage medium for {@link JobExecution}s.
+ *
+ * @param <T> The type of result produced by the {@link Job}s.
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public interface JobExecutionRepository<T> {
+
+    /**
+     * Open / connect to the repository. Must be called before any other methods.
+     */
+    void open();
+
+    /**
+     * Close the repository. Any further operations are illegal until the next open() call.
+     */
+    void close();
+
+    /**
+     * Get the last successful execution, if any.
+     *
+     * @param jobId The UUID of the job that completed.
+     * @param organization The organization owning the job.
+     * @throws NoSuchElementException if no job has the given UUID.
+     * @throws IOException if deserializing the job result fails.
+     * @return The last successful execution.
+     */
+    Optional<JobExecution.Success<T>> getLastSuccess(UUID jobId, Organization organization) throws NoSuchElementException, IOException;
+
+    /**
+     * Get the last completed execution, regardless of if it succeeded.
+     *
+     * @param jobId The UUID of the job that completed.
+     * @param organization The organization owning the job.
+     * @throws NoSuchElementException if no job has the given UUID.
+     * @throws IOException if deserializing a job result fails.
+     * @return The last completed execution.
+     */
+    Optional<JobExecution<T>> getLastCompleted(UUID jobId, Organization organization) throws NoSuchElementException, IOException;
+
+    /**
+     * Notify the repository that a job has started executing.
+     *
+     * @param jobId The UUID of the job that completed.
+     * @param organization The organization owning the job.
+     * @param scheduled The time that the job started running for.
+     */
+    void jobStarted(UUID jobId, Organization organization, Instant scheduled);
+
+    /**
+     * Notify the repository that a job finished executing successfully.
+     *
+     * @param jobId The UUID of the job that completed.
+     * @param organization The organization owning the job.
+     * @param scheduled The time that the completed job-run was scheduled for.
+     * @param result The result that the job computed.
+     */
+    void jobSucceeded(UUID jobId, Organization organization, Instant scheduled, T result);
+
+    /**
+     * Notify the repository that a job encountered an error and aborted execution.
+     *
+     * @param jobId The UUID of the job that failed.
+     * @param organization The organization owning the job.
+     * @param scheduled The time that the failed job-run was scheduled for.
+     * @param error The exception that caused the job to fail.
+     */
+    void jobFailed(UUID jobId, Organization organization, Instant scheduled, Throwable error);
+}

--- a/app/models/internal/scheduling/JobExecution.java
+++ b/app/models/internal/scheduling/JobExecution.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package models.internal.scheduling;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import net.sf.oval.constraint.NotNull;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * Internal model for the execution state of a given {@link Job}.
+ * <p>
+ * An execution is uniquely identified by its Job ID and scheduled time, since a single job will likely have
+ * many executions over its lifetime.
+ *
+ * @param <T> The type of result produced by the corresponding {@code Job}.
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public abstract class JobExecution<T> {
+    private final UUID _jobId;
+    private final Instant _scheduled;
+
+    private <B extends Builder<B, T, U>, U extends JobExecution<T>> JobExecution(final Builder<B, T, U> builder) {
+        _jobId = builder._jobId;
+        _scheduled = builder._scheduled;
+    }
+
+    /**
+     * Get the UUID of the parent job for this execution.
+     *
+     * @return the job ID
+     */
+    public UUID getJobId() {
+        return _jobId;
+    }
+
+    /**
+     * Get the scheduled time for this execution.
+     *
+     * @return the scheduled time.
+     */
+    public Instant getScheduled() {
+        return _scheduled;
+    }
+
+    abstract <U> U accept(Visitor<T, U> visitor);
+
+    /**
+     * A visitor for {@code JobExecution}s.
+     * <p>
+     * This provides a type-safe way to uniformly access information about the particular state of a JobExecution.
+     *
+     * @param <T> The result produced by this {@code JobExecution}.
+     * @param <U> The result produced by this visitor.
+     */
+    public interface Visitor<T, U> {
+        /**
+         * Convenience wrapper around {@code state.accept(visitor)}.
+         *
+         * @param state The state to visit.
+         * @return The result produced by this visitor.
+         */
+        default U visit(final JobExecution<T> state) {
+            return state.accept(this);
+        }
+
+        /**
+         * Visit a started state.
+         *
+         * @param state The state to visit.
+         * @return The result produced by this visitor.
+         */
+        U visit(JobExecution.Started<T> state);
+
+        /**
+         * Visit a success state.
+         *
+         * @param state The state to visit.
+         * @return The result produced by this visitor.
+         */
+        U visit(JobExecution.Success<T> state);
+
+        /**
+         * Visit a failure state.
+         *
+         * @param state The state to visit.
+         * @return The result produced by this visitor.
+         */
+        U visit(JobExecution.Failure<T> state);
+    }
+
+    /**
+     * Base builder class for all subclasses of {@code JobExecution}.
+     *
+     * @param <B> The concrete type of this builder.
+     * @param <T> The result produced by the output JobExecution.
+     * @param <U> The output of this builder.
+     */
+    protected abstract static class Builder<B extends Builder<B, T, U>, T, U extends JobExecution<T>> extends OvalBuilder<U> {
+        @NotNull
+        private UUID _jobId;
+        @NotNull
+        private Instant _scheduled;
+
+        /**
+         * Forwarding Constructor.
+         *
+         * @param targetConstructor The constructor for a {@code U}.
+         */
+        protected Builder(final Function<B, U> targetConstructor) {
+            super(targetConstructor);
+        }
+
+        /**
+         * Set the jobId for this execution.
+         *
+         * @param jobId The job Id.
+         * @return This instance of builder.
+         */
+        public B setJobId(@Nullable final UUID jobId) {
+            _jobId = jobId;
+            return self();
+        }
+
+        /**
+         * Set the scheduled time this execution.
+         *
+         * @param scheduled The instant this execution is scheduled for.
+         * @return This instance of builder.
+         */
+        public B setScheduled(@Nullable final Instant scheduled) {
+            _scheduled = scheduled;
+            return self();
+        }
+
+        /**
+         * Wrapper for propagating the concrete type of a derived builder instance.
+         *
+         * @return This instance of builder.
+         */
+        protected abstract B self();
+    }
+
+    /**
+     * An execution that has been started but not yet completed.
+     *
+     * @param <T> The result type of this execution.
+     */
+    public static final class Started<T> extends JobExecution<T> {
+        private final Instant _startedAt;
+
+        private Started(final Builder<T> builder) {
+            super(builder);
+            _startedAt = builder._startedAt;
+        }
+
+        /**
+         * Get the instant when this execution was started.
+         *
+         * @return The instant this execution was started.
+         */
+        public Instant getStartedAt() {
+            return _startedAt;
+        }
+
+        @Override
+        public <U> U accept(final Visitor<T, U> visitor) {
+            return visitor.visit(this);
+        }
+
+        /**
+         * A builder for instances of {@link Started}.
+         *
+         * @param <T> The result type of this {@code JobExecution}.
+         */
+        public static class Builder<T> extends JobExecution.Builder<Builder<T>, T, Started<T>> {
+            @NotNull
+            private Instant _startedAt;
+
+            /**
+             * A builder for instances of {@link Started}.
+             */
+            public Builder() {
+                super(Started::new);
+            }
+
+            /**
+             * Set the startedAt for this execution.
+             *
+             * @param startedAt The instant this job was started.
+             * @return This builder instance.
+             */
+            public Builder<T> setStartedAt(@Nullable final Instant startedAt) {
+                _startedAt = startedAt;
+                return self();
+            }
+
+            @Override
+            protected Builder<T> self() {
+                return this;
+            }
+        }
+    }
+
+    /**
+     * An execution that completed with a successful output result.
+     *
+     * @param <T> The result type of this execution.
+     */
+    public static final class Success<T> extends JobExecution<T> {
+        private final Instant _startedAt;
+        private final Instant _completedAt;
+        private final T _result;
+
+        private Success(final Builder<T> builder) {
+            super(builder);
+            _completedAt = builder._completedAt;
+            _startedAt = builder._startedAt;
+            _result = builder._result;
+        }
+
+        /**
+         * Get the instant when this execution was started.
+         *
+         * @return The instant this execution was started.
+         */
+        public Instant getStartedAt() {
+            return _startedAt;
+        }
+
+        /**
+         * Get the instant when this execution was completed.
+         *
+         * @return The instant this execution was completed.
+         */
+        public Instant getCompletedAt() {
+            return _completedAt;
+        }
+
+        public T getResult() {
+            return _result;
+        }
+
+        @Override
+        public <U> U accept(final Visitor<T, U> visitor) {
+            return visitor.visit(this);
+        }
+
+        /**
+         * A builder for instances of {@link Success}.
+         *
+         * @param <T> The result type of this {@code JobExecution}.
+         */
+        public static class Builder<T> extends JobExecution.Builder<Builder<T>, T, Success<T>> {
+            @NotNull
+            private Instant _startedAt;
+            @NotNull
+            private Instant _completedAt;
+            @NotNull
+            private T _result;
+
+            /**
+             * A builder for instances of {@link Success}.
+             */
+            public Builder() {
+                super(Success::new);
+            }
+
+            @Override
+            protected Builder<T> self() {
+                return this;
+            }
+
+            /**
+             * Set the startedAt for this execution.
+             *
+             * @param startedAt The instant this job was started.
+             * @return This builder instance.
+             */
+            public Builder<T> setStartedAt(@Nullable final Instant startedAt) {
+                _startedAt = startedAt;
+                return this;
+            }
+
+            /**
+             * Set the completedAt for this execution.
+             *
+             * @param completedAt The instant this job was completed.
+             * @return This builder instance.
+             */
+            public Builder<T> setCompletedAt(@Nullable final Instant completedAt) {
+                _completedAt = completedAt;
+                return this;
+            }
+
+            /**
+             * Set the result for this execution.
+             *
+             * @param result The result that completed this job.
+             * @return This builder instance.
+             */
+            public Builder<T> setResult(@Nullable final T result) {
+                _result = result;
+                return this;
+            }
+        }
+    }
+
+    /**
+     * An execution that completed with an error result.
+     *
+     * @param <T> The result type of this execution.
+     */
+    public static final class Failure<T> extends JobExecution<T> {
+        private final Instant _startedAt;
+        private final Instant _completedAt;
+        private final Throwable _result;
+
+        private Failure(final Builder<T> builder) {
+            super(builder);
+            _completedAt = builder._completedAt;
+            _startedAt = builder._startedAt;
+            _result = builder._result;
+        }
+
+        /**
+         * Get the instant when this execution was started.
+         *
+         * @return The instant this execution was started.
+         */
+        public Instant getStartedAt() {
+            return _startedAt;
+        }
+
+        /**
+         * Get the instant when this execution was completed.
+         *
+         * @return The instant this execution was completed.
+         */
+        public Instant getCompletedAt() {
+            return _completedAt;
+        }
+
+        /**
+         * Get the error that completed this execution.
+         *
+         * @return The error.
+         */
+        public Throwable getError() {
+            return _result;
+        }
+
+        @Override
+        public <U> U accept(final Visitor<T, U> visitor) {
+            return visitor.visit(this);
+        }
+
+        /**
+         * A builder for instances of {@link Failure}.
+         *
+         * @param <T> The result type of this {@code JobExecution}.
+         */
+        public static class Builder<T> extends JobExecution.Builder<Builder<T>, T, Failure<T>> {
+            @NotNull
+            private Instant _startedAt;
+            @NotNull
+            private Instant _completedAt;
+            @NotNull
+            private Throwable _result;
+
+            /**
+             * A builder for instances of {@link Failure}.
+             */
+            public Builder() {
+                super(Failure::new);
+            }
+
+            /**
+             * Set the startedAt for this execution.
+             *
+             * @param startedAt The instant this job was started.
+             * @return This builder instance.
+             */
+            public Builder<T> setStartedAt(@Nullable final Instant startedAt) {
+                _startedAt = startedAt;
+                return this;
+            }
+
+            /**
+             * Set the completedAt for this execution.
+             *
+             * @param completedAt The instant this job was completed.
+             * @return This builder instance.
+             */
+            public Builder<T> setCompletedAt(@Nullable final Instant completedAt) {
+                _completedAt = completedAt;
+                return this;
+            }
+
+            /**
+             * Set the error for this execution.
+             *
+             * @param result The error that completed this job.
+             * @return This builder instance.
+             */
+            public Builder<T> setError(@Nullable final Throwable result) {
+                _result = result;
+                return this;
+            }
+
+            @Override
+            public Builder<T> self() {
+                return this;
+            }
+        }
+
+    }
+}

--- a/app/models/internal/scheduling/JobExecution.java
+++ b/app/models/internal/scheduling/JobExecution.java
@@ -69,7 +69,7 @@ public abstract class JobExecution<T> {
      * @param <T> The result produced by this {@code JobExecution}.
      * @param <U> The result produced by this visitor.
      */
-    public interface Visitor<T, U> {
+    public interface Visitor<T, U> extends Function<JobExecution<T>, U> {
         /**
          * Convenience wrapper around {@code state.accept(visitor)}.
          *
@@ -78,6 +78,11 @@ public abstract class JobExecution<T> {
          */
         default U visit(final JobExecution<T> state) {
             return state.accept(this);
+        }
+
+        @Override
+        default U apply(final JobExecution<T> state) {
+            return visit(state);
         }
 
         /**

--- a/app/models/internal/scheduling/JobExecution.java
+++ b/app/models/internal/scheduling/JobExecution.java
@@ -76,13 +76,9 @@ public abstract class JobExecution<T> {
          * @param state The state to visit.
          * @return The result produced by this visitor.
          */
-        default U visit(final JobExecution<T> state) {
-            return state.accept(this);
-        }
-
         @Override
         default U apply(final JobExecution<T> state) {
-            return visit(state);
+            return state.accept(this);
         }
 
         /**

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
@@ -1,0 +1,146 @@
+package com.arpnetworking.metrics.portal.scheduling.impl;
+
+import com.arpnetworking.metrics.portal.scheduling.JobExecutionRepository;
+import com.arpnetworking.steno.Logger;
+import com.arpnetworking.steno.LoggerFactory;
+import com.google.common.collect.Maps;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import models.internal.Organization;
+import models.internal.scheduling.Job;
+import models.internal.scheduling.JobExecution;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@code JobExecutionRepository} backed by a {@link Map}.
+ *
+ * This repository only holds the most recent execution for a given Job, overwriting one if it exists.
+ *
+ * @param <T> The result type of the underlying {@link Job}s.
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public class MapJobExecutionRepository<T> implements JobExecutionRepository<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MapJobRepository.class);
+    private final AtomicBoolean _open = new AtomicBoolean();
+    private final Map<Organization, Map<UUID, JobExecution<T>>> _lastRuns = Maps.newHashMap();
+
+    @Override
+    public void open() {
+        assertIsOpen(false);
+        LOGGER.debug().setMessage("opening JobRepository").log();
+        _open.set(true);
+    }
+
+    @Override
+    public void close() {
+        assertIsOpen();
+        LOGGER.debug().setMessage("opening JobRepository").log();
+        _open.set(false);
+    }
+
+
+    @Override
+    public Optional<JobExecution.Success<T>> getLastSuccess(final UUID jobId, final Organization organization) throws NoSuchElementException {
+        return getLastCompleted(jobId, organization).flatMap(execution -> {
+            return (new JobExecution.Visitor<T, Optional<JobExecution.Success<T>>>() {
+                @Override
+                public Optional<JobExecution.Success<T>> visit(final JobExecution.Started<T> state) {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<JobExecution.Success<T>> visit(final JobExecution.Success<T> state) {
+                    return Optional.of(state);
+                }
+
+                @Override
+                public Optional<JobExecution.Success<T>> visit(final JobExecution.Failure<T> state) {
+                    return Optional.empty();
+                }
+            }).visit(execution);
+        });
+    }
+
+    @Override
+    public Optional<JobExecution<T>> getLastCompleted(final UUID jobId, final Organization organization) throws NoSuchElementException {
+        @Nullable final JobExecution<T> execution = _lastRuns.getOrDefault(organization, Collections.emptyMap()).get(jobId);
+        if (execution == null) {
+            return Optional.empty();
+        }
+        return (new JobExecution.Visitor<T, Optional<JobExecution<T>>>() {
+            @Override
+            public Optional<JobExecution<T>> visit(final JobExecution.Started<T> state) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<JobExecution<T>> visit(final JobExecution.Success<T> state) {
+                return Optional.of(state);
+            }
+
+            @Override
+            public Optional<JobExecution<T>> visit(final JobExecution.Failure<T> state) {
+                return Optional.of(state);
+            }
+        }).visit(execution);
+    }
+
+    @Override
+    public void jobStarted(final UUID id, final Organization organization, final Instant scheduled) {
+        final JobExecution.Started<T> execution = new JobExecution.Started.Builder<T>()
+                .setJobId(id)
+                .setScheduled(scheduled)
+                .setStartedAt(Instant.now())
+                .build();
+
+        assertIsOpen();
+        _lastRuns.computeIfAbsent(organization, o -> Maps.newHashMap())
+                .compute(id, (id0, t1) -> (t1 == null) ? execution : t1.getScheduled().isAfter(scheduled) ? t1 : execution);
+    }
+
+    @Override
+    public void jobSucceeded(final UUID jobId, final Organization organization, final Instant scheduled, final T result) {
+        final JobExecution.Success<T> execution = new JobExecution.Success.Builder<T>()
+                .setJobId(jobId)
+                .setScheduled(scheduled)
+                .setStartedAt(Instant.now())
+                .setCompletedAt(Instant.now())
+                .setResult(result)
+                .build();
+
+        assertIsOpen();
+        _lastRuns.computeIfAbsent(organization, o -> Maps.newHashMap())
+                .compute(jobId, (id0, t1) -> (t1 == null) ? execution : t1.getScheduled().isAfter(scheduled) ? t1 : execution);
+    }
+
+    @Override
+    public void jobFailed(final UUID jobId, final Organization organization, final Instant scheduled, final Throwable error) {
+        final JobExecution.Failure<T> execution = new JobExecution.Failure.Builder<T>()
+                .setJobId(jobId)
+                .setScheduled(scheduled)
+                .setStartedAt(Instant.now())
+                .setCompletedAt(Instant.now())
+                .setError(error)
+                .build();
+
+        assertIsOpen();
+        _lastRuns.computeIfAbsent(organization, o -> Maps.newHashMap())
+                .compute(jobId, (id0, t1) -> (t1 == null) ? execution : t1.getScheduled().isAfter(scheduled) ? t1 : execution);
+    }
+
+    private void assertIsOpen() {
+        assertIsOpen(true);
+    }
+
+    private void assertIsOpen(final boolean expectedState) {
+        if (_open.get() != expectedState) {
+            throw new IllegalStateException("MapJobRepository is not " + (expectedState ? "open" : "closed"));
+        }
+    }
+}

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
@@ -27,7 +27,6 @@ import models.internal.scheduling.JobExecution;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
@@ -47,23 +47,21 @@ public class MapJobExecutionRepository<T> implements JobExecutionRepository<T> {
 
     @Override
     public Optional<JobExecution.Success<T>> getLastSuccess(final UUID jobId, final Organization organization) throws NoSuchElementException {
-        return getLastCompleted(jobId, organization).flatMap(execution -> {
-            return (new JobExecution.Visitor<T, Optional<JobExecution.Success<T>>>() {
-                @Override
-                public Optional<JobExecution.Success<T>> visit(final JobExecution.Started<T> state) {
-                    return Optional.empty();
-                }
+        return getLastCompleted(jobId, organization).flatMap(new JobExecution.Visitor<T, Optional<JobExecution.Success<T>>>() {
+            @Override
+            public Optional<JobExecution.Success<T>> visit(final JobExecution.Started<T> state) {
+                return Optional.empty();
+            }
 
-                @Override
-                public Optional<JobExecution.Success<T>> visit(final JobExecution.Success<T> state) {
-                    return Optional.of(state);
-                }
+            @Override
+            public Optional<JobExecution.Success<T>> visit(final JobExecution.Success<T> state) {
+                return Optional.of(state);
+            }
 
-                @Override
-                public Optional<JobExecution.Success<T>> visit(final JobExecution.Failure<T> state) {
-                    return Optional.empty();
-                }
-            }).visit(execution);
+            @Override
+            public Optional<JobExecution.Success<T>> visit(final JobExecution.Failure<T> state) {
+                return Optional.empty();
+            }
         });
     }
 

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobExecutionRepository.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
 import com.arpnetworking.metrics.portal.scheduling.JobExecutionRepository;
@@ -19,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A {@code JobExecutionRepository} backed by a {@link Map}.
- *
+ * <p>
  * This repository only holds the most recent execution for a given Job, overwriting one if it exists.
  *
  * @param <T> The result type of the underlying {@link Job}s.
@@ -46,7 +61,7 @@ public class MapJobExecutionRepository<T> implements JobExecutionRepository<T> {
 
 
     @Override
-    public Optional<JobExecution.Success<T>> getLastSuccess(final UUID jobId, final Organization organization) throws NoSuchElementException {
+    public Optional<JobExecution.Success<T>> getLastSuccess(final UUID jobId, final Organization organization) {
         return getLastCompleted(jobId, organization).flatMap(new JobExecution.Visitor<T, Optional<JobExecution.Success<T>>>() {
             @Override
             public Optional<JobExecution.Success<T>> visit(final JobExecution.Started<T> state) {
@@ -66,7 +81,7 @@ public class MapJobExecutionRepository<T> implements JobExecutionRepository<T> {
     }
 
     @Override
-    public Optional<JobExecution<T>> getLastCompleted(final UUID jobId, final Organization organization) throws NoSuchElementException {
+    public Optional<JobExecution<T>> getLastCompleted(final UUID jobId, final Organization organization) {
         @Nullable final JobExecution<T> execution = _lastRuns.getOrDefault(organization, Collections.emptyMap()).get(jobId);
         if (execution == null) {
             return Optional.empty();
@@ -86,7 +101,7 @@ public class MapJobExecutionRepository<T> implements JobExecutionRepository<T> {
             public Optional<JobExecution<T>> visit(final JobExecution.Failure<T> state) {
                 return Optional.of(state);
             }
-        }).visit(execution);
+        }).apply(execution);
     }
 
     @Override


### PR DESCRIPTION
Introduce a new type of repository, `JobExecutionRepository`, that pulls out all execution related methods from the `JobRepository` interface.

In the case of Alerts, these two repos will not be backed by the same implementation, and in general that is not a strict requirement and so it makes sense to consider them separately (although in the case of reports, both will still just use the same SQL Ebean impls underneath).

Relatedly, some alert APIs will need to retrieve the state of the most recent execution and so we need an internal model to represent these. We did not have this defined previously because reports are write-only at the moment.

Perhaps somewhat contentiously, I've added another ADT-like hiearchy in `JobExecution` rather than stuff all fields as top-level `Optional`s. This prevents you from, for example, attempting to call `getResult` from an execution that hasn't completed.