### PR TITLE
Implement JobExecutionRepository for Reports

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.reports;
+
+import com.arpnetworking.metrics.portal.scheduling.JobExecutionRepository;
+import models.internal.reports.Report;
+
+/**
+ * A repository for storing and retrieving {@link models.internal.scheduling.JobExecution}s for a report.
+ *
+ * @apiNote
+ * This class is intended for use as a type-token so that Guice can reflectively instantiate
+ * the JobExecutionRepository at runtime. Scheduling code should be using a generic JobExecutionRepository.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public interface ReportExecutionRepository extends JobExecutionRepository<Report.Result> {
+}
+

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportExecutionRepository.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2018 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.reports.impl;
+
+import com.arpnetworking.metrics.portal.scheduling.JobExecutionRepository;
+import com.arpnetworking.steno.Logger;
+import com.arpnetworking.steno.LoggerFactory;
+import io.ebean.EbeanServer;
+import io.ebean.Transaction;
+import models.ebean.ReportExecution;
+import models.internal.Organization;
+import models.internal.reports.Report;
+import models.internal.scheduling.JobExecution;
+
+import java.time.Instant;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceException;
+
+/**
+ * Implementation of {@link JobExecutionRepository} for {@link Report} jobs using a SQL database.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public final class DatabaseReportExecutionRepository implements JobExecutionRepository<Report.Result> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseReportExecutionRepository.class);
+
+    private final AtomicBoolean _isOpen = new AtomicBoolean(false);
+    private final EbeanServer _ebeanServer;
+
+    /**
+     * Public constructor.
+     *
+     * @param ebeanServer Play's {@code EbeanServer} for this repository.
+     */
+    @Inject
+    public DatabaseReportExecutionRepository(@Named("metrics_portal") final EbeanServer ebeanServer) {
+        _ebeanServer = ebeanServer;
+    }
+
+    @Override
+    public void open() {
+        assertIsOpen(false);
+        LOGGER.debug().setMessage("Opening DatabaseReportExecutionRepository").log();
+        _isOpen.set(true);
+    }
+
+    @Override
+    public void close() {
+        assertIsOpen();
+        LOGGER.debug().setMessage("Closing DatabaseReportExecutionRepository").log();
+        _isOpen.set(false);
+    }
+
+
+    /**
+     * Get the most recently scheduled execution, if any.
+     *
+     * This could possibly return an execution that's pending completion.
+     *
+     * @param jobId The UUID of the job that completed.
+     * @param organization The organization owning the job.
+     * @throws NoSuchElementException if no job has the given UUID.
+     * @return The last successful execution.
+     */
+    public Optional<JobExecution<Report.Result>> getLastScheduled(final UUID jobId, final Organization organization) throws NoSuchElementException {
+        assertIsOpen();
+        return _ebeanServer.find(ReportExecution.class)
+                .orderBy()
+                .desc("scheduled")
+                .where()
+                .eq("report.uuid", jobId)
+                .eq("report.organization.uuid", organization.getId())
+                .setMaxRows(1)
+                .findOneOrEmpty()
+                .map(this::toInternalModel);
+    }
+
+    @Override
+    public Optional<JobExecution.Success<Report.Result>> getLastSuccess(final UUID jobId, final Organization organization) throws NoSuchElementException {
+        assertIsOpen();
+        final Optional<ReportExecution> row = _ebeanServer.find(ReportExecution.class)
+                .orderBy()
+                .desc("completed_at")
+                .where()
+                .eq("report.uuid", jobId)
+                .eq("report.organization.uuid", organization.getId())
+                .eq("state", ReportExecution.State.SUCCESS)
+                .setMaxRows(1)
+                .findOneOrEmpty();
+        if (row.isPresent()) {
+            final JobExecution<Report.Result> execution = toInternalModel(row.get());
+            if (execution instanceof JobExecution.Success) {
+                return Optional.of((JobExecution.Success<Report.Result>) execution);
+            }
+            throw new IllegalStateException("execution returned was not a success");
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<JobExecution<Report.Result>> getLastCompleted(final UUID jobId, final Organization organization) throws NoSuchElementException {
+        assertIsOpen();
+        return _ebeanServer.find(ReportExecution.class)
+                .orderBy()
+                .desc("completed_at")
+                .where()
+                .eq("report.uuid", jobId)
+                .eq("report.organization.uuid", organization.getId())
+                .in("state", ReportExecution.State.SUCCESS, ReportExecution.State.FAILURE)
+                .setMaxRows(1)
+                .findOneOrEmpty()
+                .map(this::toInternalModel);
+    }
+
+    @Override
+    public void jobStarted(final UUID reportId, final Organization organization, final Instant scheduled) {
+        assertIsOpen();
+        updateExecutionState(
+                reportId,
+                organization,
+                scheduled,
+                ReportExecution.State.STARTED,
+                null,
+                null
+        );
+    }
+
+    @Override
+    public void jobSucceeded(final UUID reportId, final Organization organization, final Instant scheduled, final Report.Result result) {
+        assertIsOpen();
+        updateExecutionState(
+                reportId,
+                organization,
+                scheduled,
+                ReportExecution.State.SUCCESS,
+                result,
+                null
+        );
+    }
+
+    @Override
+    public void jobFailed(final UUID reportId, final Organization organization, final Instant scheduled, final Throwable error) {
+        assertIsOpen();
+        updateExecutionState(
+                reportId,
+                organization,
+                scheduled,
+                ReportExecution.State.FAILURE,
+                null,
+                error
+        );
+    }
+
+    private void updateExecutionState(
+            final UUID reportId,
+            final Organization organization,
+            final Instant scheduled,
+            final ReportExecution.State state,
+            @Nullable final Report.Result result,
+            @Nullable final Throwable error
+    ) {
+        LOGGER.debug()
+                .setMessage("Updating report executions")
+                .addData("report.uuid", reportId)
+                .addData("scheduled", scheduled)
+                .addData("state", state)
+                .log();
+        try (Transaction transaction = _ebeanServer.beginTransaction()) {
+            final Optional<models.ebean.Report> report = models.ebean.Organization.findByOrganization(_ebeanServer, organization)
+                    .flatMap(beanOrg -> models.ebean.Report.findByUUID(
+                            _ebeanServer,
+                            beanOrg,
+                            reportId
+                    ));
+            if (!report.isPresent()) {
+                final String message = String.format(
+                        "Could not find report with uuid=%s, organization.uuid=%s",
+                        reportId.toString(),
+                        organization.getId()
+                );
+                throw new EntityNotFoundException(message);
+            }
+
+            final Optional<ReportExecution> existingExecution =
+                    _ebeanServer.createQuery(ReportExecution.class)
+                            .where()
+                            .eq("report.uuid", reportId)
+                            .eq("scheduled", scheduled)
+                            .findOneOrEmpty();
+            final ReportExecution newOrUpdatedExecution = existingExecution.orElse(new ReportExecution());
+            newOrUpdatedExecution.setError(error);
+            newOrUpdatedExecution.setReport(report.get());
+            newOrUpdatedExecution.setResult(result);
+            newOrUpdatedExecution.setScheduled(scheduled);
+            newOrUpdatedExecution.setState(state);
+
+            switch (state) {
+                case STARTED:
+                    newOrUpdatedExecution.setStartedAt(Instant.now());
+                    newOrUpdatedExecution.setCompletedAt(null);
+                    break;
+                case FAILURE:
+                case SUCCESS:
+                    newOrUpdatedExecution.setCompletedAt(Instant.now());
+                    break;
+                default:
+                    throw new AssertionError("unexpected state: " + state);
+            }
+
+            if (existingExecution.isPresent()) {
+                _ebeanServer.update(newOrUpdatedExecution);
+            } else {
+                _ebeanServer.save(newOrUpdatedExecution);
+            }
+
+            LOGGER.debug()
+                    .setMessage("Updated report execution")
+                    .addData("report.uuid", reportId)
+                    .addData("scheduled", scheduled)
+                    .addData("state", state)
+                    .log();
+            transaction.commit();
+            // CHECKSTYLE.OFF: IllegalCatchCheck
+        } catch (final RuntimeException e) {
+            // CHECKSTYLE.ON: IllegalCatchCheck
+            LOGGER.error()
+                    .setMessage("Failed to update report executions")
+                    .addData("report.uuid", reportId)
+                    .addData("scheduled", scheduled)
+                    .addData("state", state)
+                    .setThrowable(e)
+                    .log();
+            throw new PersistenceException("Failed to update report executions", e);
+        }
+    }
+
+    private JobExecution<Report.Result> toInternalModel(final ReportExecution beanModel) {
+        final ReportExecution.State state = beanModel.getState();
+        switch (state) {
+            case STARTED:
+                return new JobExecution.Started.Builder<Report.Result>()
+                        .setJobId(beanModel.getReport().getUuid())
+                        .setScheduled(beanModel.getScheduled())
+                        .setStartedAt(beanModel.getStartedAt())
+                        .build();
+            case FAILURE:
+                return new JobExecution.Failure.Builder<Report.Result>()
+                        .setJobId(beanModel.getReport().getUuid())
+                        .setScheduled(beanModel.getScheduled())
+                        .setStartedAt(beanModel.getStartedAt())
+                        .setCompletedAt(beanModel.getCompletedAt())
+                        .setError(new Throwable(beanModel.getError())) // TODO(cbriones): should not create a fresh error.
+                        .build();
+            case SUCCESS:
+                return new JobExecution.Success.Builder<Report.Result>()
+                        .setJobId(beanModel.getReport().getUuid())
+                        .setScheduled(beanModel.getScheduled())
+                        .setCompletedAt(beanModel.getCompletedAt())
+                        .setStartedAt(beanModel.getStartedAt())
+                        .setResult(beanModel.getResult())
+                        .build();
+            default:
+                throw new AssertionError("unexpected state: " + state);
+        }
+    }
+
+    private void assertIsOpen() {
+        assertIsOpen(true);
+    }
+
+    private void assertIsOpen(final boolean expectedState) {
+        if (_isOpen.get() != expectedState) {
+            throw new IllegalStateException(String.format("DatabaseReportExecutionRepository is not %s", expectedState ? "open" : "closed"));
+        }
+    }
+}

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportExecutionRepository.java
@@ -117,7 +117,9 @@ public final class DatabaseReportExecutionRepository implements JobExecutionRepo
             if (execution instanceof JobExecution.Success) {
                 return Optional.of((JobExecution.Success<Report.Result>) execution);
             }
-            throw new IllegalStateException("execution returned was not a success");
+            throw new IllegalStateException(
+                    String.format("execution returned was not a success when specified by the query: %s", row.get())
+            );
         }
         return Optional.empty();
     }
@@ -176,7 +178,7 @@ public final class DatabaseReportExecutionRepository implements JobExecutionRepo
                 scheduled,
                 ReportExecution.State.FAILURE,
                 execution -> {
-                    execution.setError(new ReportExecution.ErrorString(Throwables.getStackTraceAsString(error)));
+                    execution.setError(Throwables.getStackTraceAsString(error));
                     execution.setCompletedAt(Instant.now());
                 }
         );
@@ -262,7 +264,7 @@ public final class DatabaseReportExecutionRepository implements JobExecutionRepo
                         .setStartedAt(beanModel.getStartedAt())
                         .build();
             case FAILURE:
-                @Nullable final Throwable throwable = beanModel.getError() == null ? null : beanModel.getError().getThrowable();
+                @Nullable final Throwable throwable = beanModel.getError() == null ? null : new Throwable(beanModel.getError());
                 return new JobExecution.Failure.Builder<Report.Result>()
                         .setJobId(beanModel.getReport().getUuid())
                         .setScheduled(beanModel.getScheduled())

--- a/app/com/arpnetworking/metrics/portal/reports/impl/NoReportExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/NoReportExecutionRepository.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.reports.impl;
+
+import com.arpnetworking.metrics.portal.reports.ReportExecutionRepository;
+import models.internal.Organization;
+import models.internal.reports.Report;
+import models.internal.scheduling.JobExecution;
+
+import java.time.Instant;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * An empty {@code ReportExecutionRepository}.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com).
+ */
+public final class NoReportExecutionRepository implements ReportExecutionRepository {
+    @Override
+    public void open() {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public Optional<JobExecution.Success<Report.Result>> getLastSuccess(
+            final UUID jobId,
+            final Organization organization
+    ) throws NoSuchElementException {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<JobExecution<Report.Result>> getLastCompleted(
+            final UUID jobId,
+            final Organization organization
+    ) throws NoSuchElementException {
+        return Optional.empty();
+    }
+
+    @Override
+    public void jobStarted(final UUID jobId, final Organization organization, final Instant scheduled) {
+
+    }
+
+    @Override
+    public void jobSucceeded(final UUID jobId, final Organization organization, final Instant scheduled, final Report.Result result) {
+
+    }
+
+    @Override
+    public void jobFailed(final UUID jobId, final Organization organization, final Instant scheduled, final Throwable error) {
+
+    }
+}

--- a/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/NoReportRepository.java
@@ -29,8 +29,6 @@ import models.internal.impl.DefaultQueryResult;
 import models.internal.reports.Report;
 import models.internal.scheduling.Job;
 
-import java.time.Instant;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -99,48 +97,6 @@ public final class NoReportRepository implements ReportRepository {
     @Override
     public Optional<Job<Report.Result>> getJob(final UUID id, final Organization organization) {
         return getReport(id, organization).map(Function.identity());
-    }
-
-    @Override
-    public Optional<Instant> getLastScheduledTimeWhereExecutionCompleted(final UUID id, final Organization organization)
-            throws NoSuchElementException {
-        assertIsOpen();
-        return Optional.empty();
-    }
-
-    @Override
-    public void jobStarted(final UUID id, final Organization organization, final Instant scheduled) {
-        assertIsOpen();
-        LOGGER.debug()
-                .setMessage("Report job started")
-                .addData("report.uuid", id)
-                .addData("organization", organization)
-                .addData("scheduled", scheduled)
-                .log();
-    }
-
-    @Override
-    public void jobSucceeded(final UUID id, final Organization organization, final Instant scheduled, final Report.Result result) {
-        assertIsOpen();
-        LOGGER.debug()
-                .setMessage("Report job succeeded")
-                .addData("report.uuid", id)
-                .addData("organization", organization)
-                .addData("scheduled", scheduled)
-                .addData("result", result)
-                .log();
-    }
-
-    @Override
-    public void jobFailed(final UUID id, final Organization organization, final Instant scheduled, final Throwable error) {
-        assertIsOpen();
-        LOGGER.debug()
-                .setMessage("Report job failed")
-                .addData("report.uuid", id)
-                .addData("organization", organization)
-                .addData("scheduled", scheduled)
-                .addData("error", error)
-                .log();
     }
 
     @Override

--- a/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/CachedJob.java
@@ -22,6 +22,7 @@ import com.arpnetworking.steno.LoggerFactory;
 import com.google.common.base.MoreObjects;
 import com.google.inject.Injector;
 import models.internal.scheduling.Job;
+import models.internal.scheduling.JobExecution;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -102,7 +103,9 @@ public final class CachedJob<T> implements Job<T> {
         }
         _periodicMetrics.recordCounter("cached_job_reload_success", 1);
         _cached = loaded.get();
-        _lastRun = _ref.getRepository(injector).getLastScheduledTimeWhereExecutionCompleted(_ref.getJobId(), _ref.getOrganization());
+        _lastRun = _ref.getExecutionRepository(injector)
+                .getLastCompleted(_ref.getJobId(), _ref.getOrganization())
+                .map(JobExecution::getScheduled);
     }
 
     /**

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobCoordinator.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobCoordinator.java
@@ -153,6 +153,7 @@ public final class JobCoordinator<T> extends AbstractPersistentActorWithTimers {
                 .build();
     }
 
+    // CHECKSTYLE.OFF: ParameterNumber - This is only called in one location.
     private static <T> void runAntiEntropy(
             final Injector injector,
             final Clock clock,
@@ -217,6 +218,7 @@ public final class JobCoordinator<T> extends AbstractPersistentActorWithTimers {
         }
 
     }
+    // CHECKSTYLE.ON: ParameterNumber
 
     private Runnable createAntiEntropyRunnable() {
         // Explicitly capture all instance variables for good practice, even though they're final

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -165,7 +165,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
 
         final JobRef<T> ref = cachedJob.getRef();
         final Job<T> job = cachedJob.getJob();
-        final JobRepository<T> repo = ref.getRepository(_injector);
+        final JobExecutionRepository<T> repo = ref.getExecutionRepository(_injector);
 
         if (_currentlyExecuting) {
             return;
@@ -297,7 +297,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
 
         @SuppressWarnings("unchecked")
         final JobCompleted<T> typedMessage = (JobCompleted<T>) message;
-        final JobRepository<T> repo = ref.getRepository(_injector);
+        final JobExecutionRepository<T> repo = ref.getExecutionRepository(_injector);
         try {
             final int successMetricValue = message.getError() == null ? 1 : 0;
             _periodicMetrics.recordCounter(

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobRef.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobRef.java
@@ -41,9 +41,11 @@ public final class JobRef<T> implements Serializable {
     private final Class<? extends JobRepository<T>> _repositoryType;
     private final UUID _jobId;
     private final UUID _orgId;
+    private final Class<? extends JobExecutionRepository<T>> _execRepositoryType;
 
     private JobRef(final Builder<T> builder) {
         _repositoryType = builder._repositoryType;
+        _execRepositoryType = builder._execRepositoryType;
         _jobId = builder._jobId;
         _orgId = builder._orgId;
     }
@@ -96,6 +98,16 @@ public final class JobRef<T> implements Serializable {
         return injector.getInstance(_repositoryType);
     }
 
+    /**
+     * Loads the {@link JobExecutionRepository} that {@code execRepositoryType} refers to.
+     *
+     * @param injector The Guice injector to load the repository through.
+     * @return The repository that the given injector has for this ref's {@code repositoryType}.
+     */
+    public JobExecutionRepository<T> getExecutionRepository(final Injector injector) {
+        return injector.getInstance(_execRepositoryType);
+    }
+
     public Class<? extends JobRepository<T>> getRepositoryType() {
         return _repositoryType;
     }
@@ -121,6 +133,8 @@ public final class JobRef<T> implements Serializable {
         @NotNull
         private Class<? extends JobRepository<T>> _repositoryType;
         @NotNull
+        private Class<? extends JobExecutionRepository<T>> _execRepositoryType;
+        @NotNull
         private UUID _jobId;
         @NotNull
         private UUID _orgId;
@@ -140,6 +154,17 @@ public final class JobRef<T> implements Serializable {
          */
         public Builder<T> setRepositoryType(final Class<? extends JobRepository<T>> repositoryType) {
             _repositoryType = repositoryType;
+            return this;
+        }
+
+        /**
+         * The type of the {@link JobExecutionRepository} that contains the results of each job. Required. Cannot be null.
+         *
+         * @param repositoryType The type of the repository, later used to load the repository via Guice.
+         * @return This instance of Builder.
+         */
+        public Builder<T> setExecutionRepositoryType(final Class<? extends JobExecutionRepository<T>> repositoryType) {
+            _execRepositoryType = repositoryType;
             return this;
         }
 

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobRepository.java
@@ -19,8 +19,6 @@ import models.internal.Organization;
 import models.internal.QueryResult;
 import models.internal.scheduling.Job;
 
-import java.time.Instant;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -51,47 +49,6 @@ public interface JobRepository<T> {
      * @return The Job stored with that key.
      */
     Optional<Job<T>> getJob(UUID id, Organization organization);
-
-    /**
-     * Get the last time that any completed execution for a given job was scheduled for.
-     *
-     * More precisely, in pseudocode, {@code job.executions().filter(hasCompleted).map(scheduledFor).max()}.
-     *
-     * @param id The id assigned to the Job by a previous call to {@code add}.
-     * @param organization The organization owning the job.
-     * @return The last time that any completed execution for the job was scheduled for.
-     * @throws NoSuchElementException if no job has the given UUID.
-     */
-    Optional<Instant> getLastScheduledTimeWhereExecutionCompleted(UUID id, Organization organization) throws NoSuchElementException;
-
-    /**
-     * Notify the repository that a job has started executing.
-     *
-     * @param id The UUID of the job that completed.
-     * @param organization The organization owning the job.
-     * @param scheduled The time that the job started running for.
-     */
-    void jobStarted(UUID id, Organization organization, Instant scheduled);
-
-    /**
-     * Notify the repository that a job finished executing successfully.
-     *
-     * @param id The UUID of the job that completed.
-     * @param organization The organization owning the job.
-     * @param scheduled The time that the completed job-run was scheduled for.
-     * @param result The result that the job computed.
-     */
-    void jobSucceeded(UUID id, Organization organization, Instant scheduled, T result);
-
-    /**
-     * Notify the repository that a job encountered an error and aborted execution.
-     *
-     * @param id The UUID of the job that failed.
-     * @param organization The organization owning the job.
-     * @param scheduled The time that the failed job-run was scheduled for.
-     * @param error The exception that caused the job to fail.
-     */
-    void jobFailed(UUID id, Organization organization, Instant scheduled, Throwable error);
 
     /**
      * Create a job query against this repository.

--- a/app/controllers/ReportController.java
+++ b/app/controllers/ReportController.java
@@ -20,6 +20,7 @@ import akka.cluster.sharding.ClusterSharding;
 import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
 import com.arpnetworking.metrics.portal.organizations.OrganizationRepository;
 import com.arpnetworking.metrics.portal.reports.ReportExecutionContext;
+import com.arpnetworking.metrics.portal.reports.ReportExecutionRepository;
 import com.arpnetworking.metrics.portal.reports.ReportQuery;
 import com.arpnetworking.metrics.portal.reports.ReportRepository;
 import com.arpnetworking.metrics.portal.scheduling.JobExecutorActor;
@@ -261,6 +262,7 @@ public class ReportController extends Controller {
                                 .setId(reportId)
                                 .setOrganization(_organizationRepository.get(request()))
                                 .setRepositoryType(ReportRepository.class)
+                                .setExecutionRepositoryType(ReportExecutionRepository.class)
                                 .build())
                         .build(),
                 ActorRef.noSender());

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -59,6 +59,7 @@ import com.arpnetworking.metrics.portal.query.QueryExecutor;
 import com.arpnetworking.metrics.portal.query.QueryExecutorRegistry;
 import com.arpnetworking.metrics.portal.reports.ReportExecutionContext;
 import com.arpnetworking.metrics.portal.reports.ReportRepository;
+import com.arpnetworking.metrics.portal.reports.impl.DatabaseReportExecutionRepository;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.DefaultDevToolsFactory;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.DevToolsFactory;
 import com.arpnetworking.metrics.portal.scheduling.JobCoordinator;
@@ -565,7 +566,12 @@ public class MainModule extends AbstractModule {
             // Start a singleton instance of the scheduler on a "host_indexer" node in the cluster.
             if (cluster.selfRoles().contains(ANTI_ENTROPY_ROLE)) {
                 return _system.actorOf(ClusterSingletonManager.props(
-                        JobCoordinator.props(_injector, ReportRepository.class, _organizationRepository, _executorRegion, _periodicMetrics),
+                        JobCoordinator.props(_injector,
+                                ReportRepository.class,
+                                DatabaseReportExecutionRepository.class,
+                                _organizationRepository,
+                                _executorRegion,
+                                _periodicMetrics),
                         PoisonPill.getInstance(),
                         ClusterSingletonManagerSettings.create(_system).withRole(ANTI_ENTROPY_ROLE)),
                         "ReportJobCoordinator");

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -58,8 +58,8 @@ import com.arpnetworking.metrics.portal.organizations.OrganizationRepository;
 import com.arpnetworking.metrics.portal.query.QueryExecutor;
 import com.arpnetworking.metrics.portal.query.QueryExecutorRegistry;
 import com.arpnetworking.metrics.portal.reports.ReportExecutionContext;
+import com.arpnetworking.metrics.portal.reports.ReportExecutionRepository;
 import com.arpnetworking.metrics.portal.reports.ReportRepository;
-import com.arpnetworking.metrics.portal.reports.impl.DatabaseReportExecutionRepository;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.DefaultDevToolsFactory;
 import com.arpnetworking.metrics.portal.reports.impl.chrome.DevToolsFactory;
 import com.arpnetworking.metrics.portal.scheduling.JobCoordinator;
@@ -148,6 +148,9 @@ public class MainModule extends AbstractModule {
                 .asEagerSingleton();
         bind(ReportRepository.class)
                 .toProvider(ReportRepositoryProvider.class)
+                .asEagerSingleton();
+        bind(ReportExecutionRepository.class)
+                .toProvider(ReportExecutionRepositoryProvider.class)
                 .asEagerSingleton();
 
         // Background tasks
@@ -515,6 +518,38 @@ public class MainModule extends AbstractModule {
         private final ApplicationLifecycle _lifecycle;
     }
 
+    private static final class ReportExecutionRepositoryProvider implements Provider<ReportExecutionRepository> {
+        @Inject
+        ReportExecutionRepositoryProvider(
+                final Injector injector,
+                final Environment environment,
+                final Config configuration,
+                final ApplicationLifecycle lifecycle) {
+            _injector = injector;
+            _environment = environment;
+            _configuration = configuration;
+            _lifecycle = lifecycle;
+        }
+
+        @Override
+        public ReportExecutionRepository get() {
+            final ReportExecutionRepository executionRepository = _injector.getInstance(
+                    ConfigurationHelper.<ReportExecutionRepository>getType(_environment, _configuration, "reportExecutionRepository.type"));
+            executionRepository.open();
+            _lifecycle.addStopHook(
+                    () -> {
+                        executionRepository.close();
+                        return CompletableFuture.completedFuture(null);
+                    });
+            return executionRepository;
+        }
+
+        private final Injector _injector;
+        private final Environment _environment;
+        private final Config _configuration;
+        private final ApplicationLifecycle _lifecycle;
+    }
+
     private static final class HostProviderProvider implements Provider<ActorRef> {
         @Inject
         HostProviderProvider(
@@ -568,7 +603,7 @@ public class MainModule extends AbstractModule {
                 return _system.actorOf(ClusterSingletonManager.props(
                         JobCoordinator.props(_injector,
                                 ReportRepository.class,
-                                DatabaseReportExecutionRepository.class,
+                                ReportExecutionRepository.class,
                                 _organizationRepository,
                                 _executorRegion,
                                 _periodicMetrics),

--- a/app/models/ebean/Report.java
+++ b/app/models/ebean/Report.java
@@ -17,6 +17,7 @@ package models.ebean;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import io.ebean.EbeanServer;
 import io.ebean.annotation.CreatedTimestamp;
 import io.ebean.annotation.SoftDelete;
 import io.ebean.annotation.UpdatedTimestamp;
@@ -28,6 +29,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -194,6 +196,24 @@ public class Report {
         organization = value;
     }
 
+    /**
+     * Finds a {@link Report} when given a uuid.
+     *
+     * @param ebeanServer The {@code EbeanServer} instance to use.
+     * @param organization The parent organization for this report.
+     * @param reportId The report uuid to lookup.
+     * @return The report from the database.
+     */
+    public static Optional<Report> findByUUID(
+            final EbeanServer ebeanServer,
+            final models.ebean.Organization organization,
+            final UUID reportId) {
+        return ebeanServer.find(models.ebean.Report.class)
+                .where()
+                .eq("uuid", reportId)
+                .eq("organization.uuid", organization.getUuid())
+                .findOneOrEmpty();
+    }
 
     /**
      * Transform this object into its internal representation.

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -113,9 +113,10 @@ hostRepository.type = com.arpnetworking.metrics.portal.hosts.impl.NoHostReposito
 # ~~~~~
 alertRepository.type = com.arpnetworking.metrics.portal.alerts.impl.NoAlertRepository
 
-# Report repository
+# Report repositories
 # ~~~~~
 reportRepository.type = com.arpnetworking.metrics.portal.reports.impl.NoReportRepository
+reportExecutionRepository.type = com.arpnetworking.metrics.portal.reports.impl.NoReportExecutionRepository
 
 # Host provider
 # ~~~~~

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -72,6 +72,7 @@ public final class TestBeanFactory {
     private static final String TEST_NAME = "test-name";
     private static final String TEST_ETAG = "test-etag";
     private static final String TEST_TITLE = "test-title";
+    private static final URI TEST_URI = URI.create("http://example.com");
     private static final List<Operator> OPERATORS = Arrays.asList(
             Operator.EQUAL_TO,
             Operator.GREATER_THAN,
@@ -148,6 +149,24 @@ public final class TestBeanFactory {
                                 .build()))
                 .setReportSource(createWebPageReportSourceBuilder().build())
                 .setSchedule(schedule);
+    }
+
+    public static models.ebean.Report createEbeanReport(final models.ebean.Organization organization) {
+        final models.ebean.NeverReportSchedule schedule = new models.ebean.NeverReportSchedule();
+        schedule.setRunAt(Instant.EPOCH); // This can't be empty but will never run.
+
+        final models.ebean.WebPageReportSource source = new models.ebean.WebPageReportSource();
+        source.setUuid(UUID.randomUUID());
+        source.setTitle(TEST_TITLE);
+        source.setUri(TEST_URI);
+
+        final models.ebean.Report ebeanReport = new models.ebean.Report();
+        ebeanReport.setOrganization(organization);
+        ebeanReport.setUuid(UUID.randomUUID());
+        ebeanReport.setName(TEST_NAME + UUID.randomUUID().toString());
+        ebeanReport.setReportSource(source);
+        ebeanReport.setSchedule(schedule);
+        return ebeanReport;
     }
 
     /**

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -151,6 +151,12 @@ public final class TestBeanFactory {
                 .setSchedule(schedule);
     }
 
+    /**
+     * Factory method for creating a test bean report.
+     *
+     * @param organization The parent organization of the report.
+     * @return a report
+     */
     public static models.ebean.Report createEbeanReport(final models.ebean.Organization organization) {
         final models.ebean.NeverReportSchedule schedule = new models.ebean.NeverReportSchedule();
         schedule.setRunAt(Instant.EPOCH); // This can't be empty but will never run.

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportExecutionRepositoryIT.java
@@ -1,0 +1,244 @@
+package com.arpnetworking.metrics.portal.integration.repositories;
+
+import com.arpnetworking.metrics.portal.TestBeanFactory;
+import com.arpnetworking.metrics.portal.integration.test.EbeanServerHelper;
+import com.arpnetworking.metrics.portal.reports.impl.DatabaseReportExecutionRepository;
+import com.google.common.base.Throwables;
+import io.ebean.EbeanServer;
+import models.internal.Organization;
+import models.internal.impl.DefaultReportResult;
+import models.internal.reports.Report;
+import models.internal.scheduling.JobExecution;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DatabaseReportExecutionRepositoryIT {
+    private DatabaseReportExecutionRepository _repository;
+    private Organization _organization;
+    private UUID _reportId;
+
+    @Before
+    public void setUp() {
+        final EbeanServer _server = EbeanServerHelper.getMetricsDatabase();
+        _repository = new DatabaseReportExecutionRepository(_server);
+        _repository.open();
+
+        final models.ebean.Organization _ebeanOrganization = TestBeanFactory.createEbeanOrganization();
+        _server.save(_ebeanOrganization);
+        _organization = TestBeanFactory.organizationFrom(_ebeanOrganization);
+
+        final models.ebean.Report ebeanReport = TestBeanFactory.createEbeanReport(_ebeanOrganization);
+        _reportId = ebeanReport.getUuid();
+        // TODO(cbriones): I'm not sure why schedule / source need to be explicitly saved; I would expect a cascade to occur.
+        _server.save(ebeanReport.getSchedule());
+        _server.save(ebeanReport.getReportSource());
+        _server.save(ebeanReport);
+    }
+
+    @After
+    public void tearDown() {
+        _repository.close();
+    }
+
+    @Test
+    public void testJobStarted() {
+        final Instant scheduled = Instant.now();
+
+        _repository.jobStarted(_reportId, _organization, scheduled);
+
+        final Optional<JobExecution<Report.Result>> executionResult = _repository.getLastScheduled(_reportId, _organization);
+
+        assertTrue(executionResult.isPresent());
+        final JobExecution<Report.Result> execution = executionResult.get();
+
+        assertThat(execution.getJobId(), equalTo(_reportId));
+        assertThat(execution.getScheduled(), equalTo(scheduled));
+
+        assertThat(_repository.getLastCompleted(_reportId, _organization), equalTo(Optional.empty()));
+
+        (new JobExecution.Visitor<Report.Result, Void>() {
+            @Override
+            public Void visit(final JobExecution.Success<Report.Result> state) {
+                fail("Got a success state when expecting started.");
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Failure<Report.Result> state) {
+                fail("Got a failure state when expecting started.");
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Started<Report.Result> state) {
+                assertThat(state.getStartedAt(), not(nullValue()));
+                return null;
+            }
+        }).visit(execution);
+    }
+
+    @Test
+    public void testJobSucceeded() {
+        final Report.Result result = newResult();
+        final Instant scheduled = Instant.now();
+
+        _repository.jobStarted(_reportId, _organization, scheduled);
+        _repository.jobSucceeded(_reportId, _organization, scheduled, result);
+
+        final Optional<JobExecution.Success<Report.Result>> executionResult = _repository.getLastSuccess(_reportId, _organization);
+
+        assertTrue(executionResult.isPresent());
+
+        final JobExecution.Success<Report.Result> execution = executionResult.get();
+        assertThat(execution.getCompletedAt(), not(nullValue()));
+        assertThat(execution.getJobId(), equalTo(_reportId));
+        assertThat(execution.getStartedAt(), not(nullValue()));
+        assertThat(execution.getScheduled(), equalTo(scheduled));
+        assertThat(execution.getResult(), not(nullValue()));
+
+        // If we get the last completed run, it should retrieve the same execution.
+
+        final Optional<JobExecution<Report.Result>> lastRun = _repository.getLastCompleted(_reportId, _organization);
+        assertThat(lastRun, not(equalTo(Optional.empty())));
+
+        (new JobExecution.Visitor<Report.Result, Void>() {
+            @Override
+            public Void visit(final JobExecution.Success<Report.Result> state) {
+                assertThat(state.getCompletedAt(), not(nullValue()));
+                assertThat(state.getJobId(), equalTo(_reportId));
+                assertThat(state.getStartedAt(), not(nullValue()));
+                assertThat(state.getScheduled(), equalTo(scheduled));
+                assertThat(state.getResult(), not(nullValue()));
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Failure<Report.Result> state) {
+                fail("Got a failure state when expecting success.");
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Started<Report.Result> state) {
+                fail("Got a started state when expecting success.");
+                return null;
+            }
+        }).visit(lastRun.get());
+    }
+
+    @Test
+    public void testJobFailed() {
+        final Instant scheduled = Instant.now();
+        final Throwable error = new RuntimeException("something went wrong.");
+
+        _repository.jobStarted(_reportId, _organization, scheduled);
+        _repository.jobFailed(_reportId, _organization, scheduled, error);
+
+        final Optional<JobExecution<Report.Result>> lastRun = _repository.getLastCompleted(_reportId, _organization);
+        assertThat(lastRun, not(equalTo(Optional.empty())));
+
+        (new JobExecution.Visitor<Report.Result, Void>() {
+            @Override
+            public Void visit(final JobExecution.Success<Report.Result> state) {
+                fail("Got a success state when expecting failure.");
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Failure<Report.Result> state) {
+                final Throwable retrievedError = state.getError();
+                assertThat(state.getCompletedAt(), not(nullValue()));
+                assertThat(state.getJobId(), equalTo(_reportId));
+                assertThat(state.getStartedAt(), not(nullValue()));
+                assertThat(state.getScheduled(), equalTo(scheduled));
+                assertThat(retrievedError.getMessage(), equalTo(Throwables.getStackTraceAsString(error)));
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Started<Report.Result> state) {
+                fail("Got a started state when expecting failure.");
+                return null;
+            }
+        }).visit(lastRun.get());
+    }
+
+    @Test
+    public void testJobMultipleRuns() {
+        final Instant t0 = Instant.now();
+        final Duration dt = Duration.ofDays(1);
+
+        final int NUM_JOBS = 4;
+        for (int i = 0; i < NUM_JOBS; i++) {
+            _repository.jobStarted(_reportId, _organization, t0.plus(dt.multipliedBy(i)));
+        }
+
+        _repository.jobFailed(_reportId, _organization, t0.plus(dt.multipliedBy(0)), new IllegalStateException());
+        _repository.jobFailed(_reportId, _organization, t0.plus(dt.multipliedBy(1)), new IllegalStateException());
+        _repository.jobSucceeded(_reportId, _organization, t0.plus(dt.multipliedBy(2)), newResult());
+        _repository.jobSucceeded(_reportId, _organization, t0.plus(dt.multipliedBy(3)), newResult());
+
+        assertEquals(
+                t0.plus(dt.multipliedBy(3)),
+                _repository.getLastCompleted(_reportId, _organization).get().getScheduled()
+        );
+    }
+
+    @Test
+    public void testStateChange() {
+        final Report.Result result = newResult();
+        final Instant scheduled = Instant.now();
+        final Throwable error = new RuntimeException("something went wrong.");
+
+        _repository.jobStarted(_reportId, _organization, scheduled);
+        _repository.jobSucceeded(_reportId, _organization, scheduled, result);
+
+        final JobExecution.Success<Report.Result> execution = _repository.getLastSuccess(_reportId, _organization).get();
+        assertThat(execution.getResult(), not(nullValue()));
+
+        // A failed updated should *not* clear the start time but it should clear the result
+        _repository.jobFailed(_reportId, _organization, scheduled, error);
+        final JobExecution<Report.Result> updatedExecution = _repository.getLastCompleted(_reportId, _organization).get();
+
+        (new JobExecution.Visitor<Report.Result, Void>() {
+            @Override
+            public Void visit(final JobExecution.Success<Report.Result> state) {
+                fail("Got a success state when expecting failure.");
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Failure<Report.Result> state) {
+                final Throwable retrievedError = state.getError();
+                assertThat(state.getCompletedAt(), not(nullValue()));
+                assertThat(state.getJobId(), equalTo(_reportId));
+                assertThat(state.getStartedAt(), not(nullValue()));
+                assertThat(state.getScheduled(), equalTo(scheduled));
+                assertThat(retrievedError.getMessage(), equalTo(Throwables.getStackTraceAsString(error)));
+                return null;
+            }
+
+            @Override
+            public Void visit(final JobExecution.Started<Report.Result> state) {
+                fail("Got a started state when expecting failure.");
+                return null;
+            }
+        }).visit(updatedExecution);
+    }
+
+    private Report.Result newResult() {
+        return new DefaultReportResult();
+    }
+}

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportExecutionRepositoryIT.java
@@ -19,11 +19,8 @@ package com.arpnetworking.metrics.portal.integration.repositories;
 import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.arpnetworking.metrics.portal.integration.test.EbeanServerHelper;
 import com.arpnetworking.metrics.portal.reports.impl.DatabaseReportExecutionRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
 import io.ebean.EbeanServer;
-import models.ebean.ReportExecution;
 import models.internal.Organization;
 import models.internal.impl.DefaultReportResult;
 import models.internal.reports.Report;
@@ -34,7 +31,6 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -263,18 +259,6 @@ public class DatabaseReportExecutionRepositoryIT {
                 return null;
             }
         }).apply(updatedExecution);
-    }
-
-    @Test
-    public void testErrorSerializationIsBackwardsCompatible() throws Exception {
-        final String errorMessage = "boom";
-        final Map<String, String> oldErrorMap = ImmutableMap.of("exception", errorMessage);
-
-        final ObjectMapper mapper = new ObjectMapper();
-        final String serialized = mapper.writeValueAsString(oldErrorMap);
-        final ReportExecution.Error newError = mapper.readValue(serialized, ReportExecution.Error.class);
-
-        assertThat(newError.getThrowable().getMessage(), equalTo(errorMessage));
     }
 
     private Report.Result newResult() {

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportRepositoryIT.java
@@ -24,7 +24,6 @@ import com.arpnetworking.metrics.portal.scheduling.impl.PeriodicSchedule;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import io.ebean.EbeanServer;
-import models.ebean.ReportExecution;
 import models.internal.Organization;
 import models.internal.QueryResult;
 import models.internal.impl.DefaultReport;
@@ -369,14 +368,5 @@ public class DatabaseReportRepositoryIT {
         final JobQuery<Report.Result> query = _repository.createJobQuery(_organization);
         final List<? extends Job<Report.Result>> results = query.execute().values();
         assertThat(results, empty());
-    }
-
-    private Optional<ReportExecution> getExecution(final UUID reportId, final Organization organization, final Instant scheduled) {
-        return _server.find(ReportExecution.class)
-                .where()
-                .eq("report.uuid", reportId)
-                .eq("report.organization.uuid", organization.getId())
-                .eq("scheduled", scheduled)
-                .findOneOrEmpty();
     }
 }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/JobCoordinatorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/JobCoordinatorTest.java
@@ -24,6 +24,7 @@ import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.AkkaClusteringConfigFactory;
 import com.arpnetworking.metrics.portal.organizations.OrganizationRepository;
 import com.arpnetworking.metrics.portal.organizations.impl.DefaultOrganizationRepository;
+import com.arpnetworking.metrics.portal.scheduling.impl.MapJobExecutionRepository;
 import com.arpnetworking.metrics.portal.scheduling.impl.MapJobRepository;
 import com.arpnetworking.metrics.portal.scheduling.mocks.DummyJob;
 import com.google.inject.AbstractModule;
@@ -111,6 +112,7 @@ public class JobCoordinatorTest {
                 .setId(job.getId())
                 .setOrganization(_organization)
                 .setRepositoryType(MockableIntJobRepository.class)
+                .setExecutionRepositoryType(MockableIntJobExecutionRepository.class)
                 .build();
     }
 
@@ -119,6 +121,7 @@ public class JobCoordinatorTest {
                 _injector,
                 _clock,
                 MockableIntJobRepository.class,
+                MockableIntJobExecutionRepository.class,
                 _organizationRepo,
                 _messageExtractor.getRef(),
                 _periodicMetrics);
@@ -160,4 +163,5 @@ public class JobCoordinatorTest {
     }
 
     private static class MockableIntJobRepository extends MapJobRepository<Integer> {}
+    private static class MockableIntJobExecutionRepository extends MapJobExecutionRepository<Integer> {}
 }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/JobExecutorActorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/JobExecutorActorTest.java
@@ -59,6 +59,17 @@ import java.util.concurrent.atomic.AtomicLong;
 public final class JobExecutorActorTest {
 
 
+    private static final Instant T_0 = Instant.ofEpochMilli(0);
+    private static final java.time.Duration TICK_SIZE = java.time.Duration.ofSeconds(1);
+    private static final Organization ORGANIZATION = TestBeanFactory.organizationFrom(TestBeanFactory.createEbeanOrganization());
+    private static final AtomicLong SYSTEM_NAME_NONCE = new AtomicLong(0);
+    private Injector _injector;
+    private MockableIntJobRepository _repo;
+    private MockableIntJobExecutionRepository _execRepo;
+    private ManualClock _clock;
+    private PeriodicMetrics _periodicMetrics;
+    private ActorSystem _system;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -194,9 +205,15 @@ public final class JobExecutorActorTest {
         executor.tell(JobExecutorActor.Tick.INSTANCE, null);
         executor.tell(JobExecutorActor.Tick.INSTANCE, null);
         // (ensure that the job didn't weirdly complete for some reason)
-        Mockito.verify(_execRepo, Mockito.after(1000).never()).jobSucceeded(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(_execRepo, Mockito.after(1000).never()).jobSucceeded(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any());
         // Ensure that, despite the ticks, still only a single execution for the job has ever started
-        Mockito.verify(_execRepo, Mockito.timeout(1000).times(1)).jobStarted(Mockito.eq(job.getId()), Mockito.eq(ORGANIZATION), Mockito.any());
+        Mockito.verify(_execRepo, Mockito.timeout(1000).times(1)).jobStarted(Mockito.eq(job.getId()),
+                Mockito.eq(ORGANIZATION),
+                Mockito.any());
 
         blocker.complete(null);
 
@@ -208,18 +225,9 @@ public final class JobExecutorActorTest {
                 .jobStarted(Mockito.eq(job.getId()), Mockito.eq(ORGANIZATION), Mockito.any());
     }
 
-    private Injector _injector;
-    private MockableIntJobRepository _repo;
-    private MockableIntJobExecutionRepository _execRepo;
-    private ManualClock _clock;
-    private PeriodicMetrics _periodicMetrics;
-    private ActorSystem _system;
+    private static class MockableIntJobRepository extends MapJobRepository<Integer> {
+    }
 
-    private static final Instant T_0 = Instant.ofEpochMilli(0);
-    private static final java.time.Duration TICK_SIZE = java.time.Duration.ofSeconds(1);
-    private static final Organization ORGANIZATION = TestBeanFactory.organizationFrom(TestBeanFactory.createEbeanOrganization());
-    private static final AtomicLong SYSTEM_NAME_NONCE = new AtomicLong(0);
-
-    private static class MockableIntJobRepository extends MapJobRepository<Integer> {}
-    private static class MockableIntJobExecutionRepository extends MapJobExecutionRepository<Integer> {}
+    private static class MockableIntJobExecutionRepository extends MapJobExecutionRepository<Integer> {
+    }
 }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/JobExecutorActorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/JobExecutorActorTest.java
@@ -86,6 +86,7 @@ public final class JobExecutorActorTest {
             @Override
             protected void configure() {
                 bind(MockableIntJobRepository.class).toInstance(_repo);
+                bind(MockableIntJobExecutionRepository.class).toInstance(_execRepo);
                 bind(MetricsFactory.class).toInstance(TsdMetricsFactory.newInstance("test", "test"));
             }
         });
@@ -106,7 +107,6 @@ public final class JobExecutorActorTest {
 
     private DummyJob<Integer> addJobToRepo(final DummyJob<Integer> job) {
         _repo.addOrUpdateJob(job, ORGANIZATION);
-        _execRepo.close();
         return job;
     }
 

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/JobMessageExtractorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/JobMessageExtractorTest.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.scheduling;
 
+import com.arpnetworking.metrics.portal.scheduling.impl.MapJobExecutionRepository;
 import com.arpnetworking.metrics.portal.scheduling.impl.MapJobRepository;
 import models.internal.Organization;
 import models.internal.impl.DefaultOrganization;
@@ -38,6 +39,7 @@ public final class JobMessageExtractorTest {
                 .setId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
                 .setOrganization(ORGANIZATION)
                 .setRepositoryType(MockableIntJobRepository.class)
+                .setExecutionRepositoryType(MockableIntJobExecutionRepository.class)
                 .build();
         assertEquals(
                 String.join(
@@ -54,5 +56,5 @@ public final class JobMessageExtractorTest {
             .build();
 
     private static class MockableIntJobRepository extends MapJobRepository<Integer> {}
-
+    private static class MockableIntJobExecutionRepository extends MapJobExecutionRepository<Integer> {}
 }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/MapJobRepository.java
@@ -29,10 +29,8 @@ import models.internal.impl.DefaultJobQuery;
 import models.internal.impl.DefaultQueryResult;
 import models.internal.scheduling.Job;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,7 +52,6 @@ public class MapJobRepository<T> implements JobRepository<T> {
 
     private final AtomicBoolean _open = new AtomicBoolean();
     private final Map<Organization, Map<UUID, Job<T>>> _jobs = Maps.newHashMap();
-    private final Map<Organization, Map<UUID, Instant>> _lastRuns = Maps.newHashMap();
 
     @Override
     public void open() {
@@ -84,34 +81,6 @@ public class MapJobRepository<T> implements JobRepository<T> {
     public Optional<Job<T>> getJob(final UUID id, final Organization organization) {
         assertIsOpen();
         return Optional.ofNullable(_jobs.getOrDefault(organization, Maps.newHashMap()).get(id));
-    }
-
-    @Override
-    public Optional<Instant> getLastScheduledTimeWhereExecutionCompleted(final UUID id, final Organization organization)
-            throws NoSuchElementException {
-        assertIsOpen();
-        return Optional.ofNullable(_lastRuns.getOrDefault(organization, Maps.newHashMap()).get(id));
-    }
-
-    @Override
-    public void jobStarted(final UUID id, final Organization organization, final Instant scheduled) {
-        assertIsOpen();
-        _lastRuns.computeIfAbsent(organization, o -> Maps.newHashMap())
-                .compute(id, (id0, t1) -> (t1 == null) ? scheduled : t1.isAfter(scheduled) ? t1 : scheduled);
-    }
-
-    @Override
-    public void jobSucceeded(final UUID id, final Organization organization, final Instant scheduled, final Object result) {
-        assertIsOpen();
-        _lastRuns.computeIfAbsent(organization, o -> Maps.newHashMap())
-                .compute(id, (id0, t1) -> (t1 == null) ? scheduled : t1.isAfter(scheduled) ? t1 : scheduled);
-    }
-
-    @Override
-    public void jobFailed(final UUID id, final Organization organization, final Instant scheduled, final Throwable error) {
-        assertIsOpen();
-        _lastRuns.computeIfAbsent(organization, o -> Maps.newHashMap())
-                .compute(id, (id0, t1) -> (t1 == null) ? scheduled : t1.isAfter(scheduled) ? t1 : scheduled);
     }
 
     @Override


### PR DESCRIPTION
This pulls out all relevant execution logic from `DatabaseReportRepository` into `DatabaseReportExecutionRepository`.

Depends on #360.