### PR TITLE
fix KairosDB query-logging to actually include the query

### DIFF
--- a/app/com/arpnetworking/kairos/client/KairosDbClientImpl.java
+++ b/app/com/arpnetworking/kairos/client/KairosDbClientImpl.java
@@ -65,7 +65,7 @@ public final class KairosDbClientImpl implements KairosDbClient {
     public CompletionStage<MetricsQueryResponse> queryMetrics(final MetricsQuery query) {
         final UUID queryUuid = UUID.randomUUID();
         final JsonNode queryJson = _mapper.valueToTree(query);
-        LOGGER.debug()
+        LOGGER.trace()
                 .setMessage("starting queryMetrics")
                 .addData("queryUuid", queryUuid)
                 .addData("query", queryJson)
@@ -75,7 +75,7 @@ public final class KairosDbClientImpl implements KairosDbClient {
         final Instant startTime = Instant.now();
         return fireRequest(request, MetricsQueryResponse.class)
                 .whenComplete((response, error) -> {
-                    LOGGER.debug()
+                    LOGGER.trace()
                             .setMessage("finished queryMetrics")
                             .addData("queryUuid", queryUuid)
                             .addData("query", queryJson)

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -247,12 +247,15 @@ public class MainModule extends AbstractModule {
     private KairosDbClient provideKairosDbClient(
             final ActorSystem actorSystem,
             final ObjectMapper mapper,
-            final Config configuration) {
+            final Config configuration,
+            final MetricsFactory metricsFactory
+    ) {
         return new KairosDbClientImpl.Builder()
                 .setActorSystem(actorSystem)
                 .setMapper(mapper)
                 .setUri(URI.create(configuration.getString("kairosdb.uri")))
                 .setReadTimeout(ConfigurationHelper.getFiniteDuration(configuration, "kairosdb.timeout"))
+                .setMetricsFactory(metricsFactory)
                 .build();
     }
 

--- a/test/java/com/arpnetworking/kairos/client/KairosDbClientImplTest.java
+++ b/test/java/com/arpnetworking/kairos/client/KairosDbClientImplTest.java
@@ -27,6 +27,8 @@ import com.arpnetworking.kairos.client.models.Sampling;
 import com.arpnetworking.kairos.client.models.SamplingUnit;
 import com.arpnetworking.kairos.client.models.TagNamesResponse;
 import com.arpnetworking.kairos.client.models.TagsQuery;
+import com.arpnetworking.metrics.MetricsFactory;
+import com.arpnetworking.metrics.impl.NoOpMetricsFactory;
 import com.arpnetworking.testing.SerializationTestUtils;
 import com.arpnetworking.utility.test.ResourceHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -76,6 +78,7 @@ public class KairosDbClientImplTest {
                 .setActorSystem(_actorSystem)
                 .setMapper(OBJECT_MAPPER)
                 .setReadTimeout(new FiniteDuration(30, TimeUnit.SECONDS))
+                .setMetricsFactory(new NoOpMetricsFactory())
                 .build();
     }
 

--- a/test/java/com/arpnetworking/kairos/client/KairosDbClientImplTest.java
+++ b/test/java/com/arpnetworking/kairos/client/KairosDbClientImplTest.java
@@ -27,7 +27,6 @@ import com.arpnetworking.kairos.client.models.Sampling;
 import com.arpnetworking.kairos.client.models.SamplingUnit;
 import com.arpnetworking.kairos.client.models.TagNamesResponse;
 import com.arpnetworking.kairos.client.models.TagsQuery;
-import com.arpnetworking.metrics.MetricsFactory;
 import com.arpnetworking.metrics.impl.NoOpMetricsFactory;
 import com.arpnetworking.testing.SerializationTestUtils;
 import com.arpnetworking.utility.test.ResourceHelper;

--- a/test/java/com/arpnetworking/metrics/portal/integration/controllers/KairosDbProxyControllerIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/controllers/KairosDbProxyControllerIT.java
@@ -28,6 +28,7 @@ import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
 import com.arpnetworking.kairos.client.models.Sampling;
 import com.arpnetworking.kairos.client.models.SamplingUnit;
 import com.arpnetworking.kairos.client.models.TagsQuery;
+import com.arpnetworking.metrics.impl.NoOpMetricsFactory;
 import com.arpnetworking.metrics.portal.integration.test.WebServerHelper;
 import com.arpnetworking.testing.SerializationTestUtils;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -75,6 +76,7 @@ public final class KairosDbProxyControllerIT {
                 .setMapper(SerializationTestUtils.getApiObjectMapper())
                 .setReadTimeout(FiniteDuration.apply(10, TimeUnit.SECONDS))
                 .setUri(URI.create(urlBuilder.toString()))
+                .setMetricsFactory(new NoOpMetricsFactory())
                 .build();
 
         _kairosDbClientProxied = new KairosDbClientImpl.Builder()
@@ -82,6 +84,7 @@ public final class KairosDbProxyControllerIT {
                 .setMapper(SerializationTestUtils.getApiObjectMapper())
                 .setReadTimeout(FiniteDuration.apply(10, TimeUnit.SECONDS))
                 .setUri(URI.create(WebServerHelper.getUri("")))
+                .setMetricsFactory(new NoOpMetricsFactory())
                 .build();
 
         // Record data on the minute, 30 minutes back to make it easy to fetch via the KDB UI


### PR DESCRIPTION
Log line before (gotten by tailing the logs after `mvn docker:start` with a tweaked Logback config to enable debug-level logging, then hitting the container with a KairosDB query request):
```
{
    ...
    "query": {
      "_id": "356c4af6",
      "_class": "com.arpnetworking.kairos.client.models.MetricsQuery",
      "cache_time": 0
    }
    ...
}
```

Log line after:
```
{
    ...
    "query": {
      "metrics": [
        {
          "aggregators": [
            {
              "sampling": {
                "unit": "minutes",
                "value": 1
              },
              "name": "percentile",
              "align_sampling": true,
              "align_start_time": true,
              "percentile": "0.999"
            }
          ],
          "limit": 0,
          "tags": {
            "build_channel": [
              "beta",
              "stable"
            ]
          },
          "name": "some_metric/foo/bar",
          "group_by": [
            {
              "name": "tag",
              "tags": [
                "platform",
                "build_channel"
              ]
            }
          ]
        }
      ],
      "start_absolute": 1586772000000,
      "end_absolute": 1586772000000,
      "cache_time": 0
    }
    ...
}
```