### PR TITLE
Rollups: add filter-by-tag field(s) to RollupDefinition

### DIFF
--- a/app/com/arpnetworking/rollups/LastDataPointsMessage.java
+++ b/app/com/arpnetworking/rollups/LastDataPointsMessage.java
@@ -16,7 +16,6 @@
 package com.arpnetworking.rollups;
 
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 

--- a/app/com/arpnetworking/rollups/LastDataPointsMessage.java
+++ b/app/com/arpnetworking/rollups/LastDataPointsMessage.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.rollups;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
@@ -43,7 +44,7 @@ public final class LastDataPointsMessage extends FailableMessage {
         return _rollupMetricName;
     }
 
-    public ImmutableSet<String> getTags() {
+    public ImmutableMultimap<String, String> getTags() {
         return _tags;
     }
 
@@ -72,7 +73,7 @@ public final class LastDataPointsMessage extends FailableMessage {
     private final String _sourceMetricName;
     private final String _rollupMetricName;
     private final RollupPeriod _period;
-    private final ImmutableSet<String> _tags;
+    private final ImmutableMultimap<String, String> _tags;
     private final Instant _sourceLastDataPointTime;
     private final Instant _rollupLastDataPointTime;
     private static final long serialVersionUID = 2800761302248621189L;
@@ -118,7 +119,7 @@ public final class LastDataPointsMessage extends FailableMessage {
          * @param value the {@code tags} to set
          * @return a reference to this Builder
          */
-        public Builder setTags(final ImmutableSet<String> value) {
+        public Builder setTags(final ImmutableMultimap<String, String> value) {
             _tags = value;
             return this;
         }
@@ -161,7 +162,7 @@ public final class LastDataPointsMessage extends FailableMessage {
             _sourceMetricName = null;
              _rollupMetricName = null;
             _period = null;
-            _tags = ImmutableSet.of();
+            _tags = ImmutableMultimap.of();
             _sourceLastDataPointTime = null;
             _rollupLastDataPointTime = null;
         }
@@ -180,7 +181,7 @@ public final class LastDataPointsMessage extends FailableMessage {
         @NotNull
         private RollupPeriod _period;
         @NotNull
-        private ImmutableSet<String> _tags = ImmutableSet.of();
+        private ImmutableMultimap<String, String> _tags = ImmutableMultimap.of();
 
         private Instant _rollupLastDataPointTime;
         private Instant _sourceLastDataPointTime;

--- a/app/com/arpnetworking/rollups/RollupDefinition.java
+++ b/app/com/arpnetworking/rollups/RollupDefinition.java
@@ -176,9 +176,9 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         }
 
         /**
-         * Sets the {@code _allMetricTags} and returns a reference to this Builder so that the methods can be chained together.
+         * Sets the {@code _filterTags} and returns a reference to this Builder so that the methods can be chained together.
          *
-         * @param value the {@code _allMetricTags} to set
+         * @param value the {@code _filterTags} to set
          * @return a reference to this Builder
          */
         public Builder setFilterTags(final ImmutableMap<String, String> value) {

--- a/app/com/arpnetworking/rollups/RollupDefinition.java
+++ b/app/com/arpnetworking/rollups/RollupDefinition.java
@@ -17,6 +17,8 @@ package com.arpnetworking.rollups;
 
 import akka.routing.ConsistentHashingRouter;
 import com.arpnetworking.commons.builder.OvalBuilder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
@@ -36,14 +38,16 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
     private final String _destinationMetricName;
     private final RollupPeriod _period;
     private final Instant _startTime;
-    private final ImmutableSet<String> _groupByTags;
+    private final ImmutableMap<String, String> _filterTags;
+    private final ImmutableMultimap<String, String> _allMetricTags;
 
     private RollupDefinition(final Builder builder) {
         _sourceMetricName = builder._sourceMetricName;
         _destinationMetricName = builder._destinationMetricName;
         _period = builder._period;
         _startTime = builder._startTime;
-        _groupByTags = builder._groupByTags;
+        _filterTags = builder._filterTags;
+        _allMetricTags = builder._allMetricTags;
     }
 
     public String getSourceMetricName() {
@@ -62,8 +66,12 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         return _startTime;
     }
 
-    public ImmutableSet<String> getGroupByTags() {
-        return _groupByTags;
+    public ImmutableMap<String, String> getFilterTags() {
+        return _filterTags;
+    }
+
+    public ImmutableMultimap<String, String> getAllMetricTags() {
+        return _allMetricTags;
     }
 
     @Override
@@ -78,12 +86,14 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         return _sourceMetricName.equals(that._sourceMetricName)
                 && _destinationMetricName.equals(that._destinationMetricName)
                 && _period == that._period
-                && _startTime.equals(that._startTime);
+                && _startTime.equals(that._startTime)
+                && _filterTags.equals(that._filterTags)
+                && _allMetricTags.equals(that._allMetricTags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_sourceMetricName, _destinationMetricName, _period, _startTime, _groupByTags);
+        return Objects.hash(_sourceMetricName, _destinationMetricName, _period, _startTime, _filterTags, _allMetricTags);
     }
 
     @Override
@@ -110,7 +120,9 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         @NotNull
         private Instant _startTime;
         @NotNull
-        private ImmutableSet<String> _groupByTags;
+        private ImmutableMap<String, String> _filterTags = ImmutableMap.of();
+        @NotNull
+        private ImmutableMultimap<String, String> _allMetricTags;
 
         /**
          * Creates a builder for a RollupDefinition.
@@ -164,13 +176,24 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         }
 
         /**
-         * Sets the {@code _groupByTags} and returns a reference to this Builder so that the methods can be chained together.
+         * Sets the {@code _allMetricTags} and returns a reference to this Builder so that the methods can be chained together.
          *
-         * @param value the {@code _groupByTags} to set
+         * @param value the {@code _allMetricTags} to set
          * @return a reference to this Builder
          */
-        public Builder setGroupByTags(final ImmutableSet<String> value) {
-            _groupByTags = value;
+        public Builder setFilterTags(final ImmutableMap<String, String> value) {
+            _filterTags = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@code _allMetricTags} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _allMetricTags} to set
+         * @return a reference to this Builder
+         */
+        public Builder setAllMetricTags(final ImmutableMultimap<String, String> value) {
+            _allMetricTags = value;
             return this;
         }
     }

--- a/app/com/arpnetworking/rollups/RollupDefinition.java
+++ b/app/com/arpnetworking/rollups/RollupDefinition.java
@@ -19,7 +19,6 @@ import akka.routing.ConsistentHashingRouter;
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 

--- a/app/com/arpnetworking/rollups/RollupExecutor.java
+++ b/app/com/arpnetworking/rollups/RollupExecutor.java
@@ -107,11 +107,12 @@ public class RollupExecutor extends AbstractActorWithTimers {
         queryBuilder.setEndTime(rollupDefinition.getEndTime());
 
         metricBuilder.setName(rollupDefinition.getSourceMetricName());
+        metricBuilder.setTags(rollupDefinition.getFilterTags().asMultimap());
 
-        if (!rollupDefinition.getGroupByTags().isEmpty()) {
+        if (!rollupDefinition.getAllMetricTags().isEmpty()) {
             metricBuilder.setGroupBy(ImmutableList.of(
                     new MetricsQuery.QueryTagGroupBy.Builder()
-                            .setTags(rollupDefinition.getGroupByTags())
+                            .setTags(rollupDefinition.getAllMetricTags().keySet())
                             .build()
             ));
         }

--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -34,7 +34,7 @@ import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigUtil;
@@ -172,7 +172,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
                         } else {
                             return new TagNamesMessage.Builder()
                                     .setMetricName(metricName)
-                                    .setTagNames(response.getQueries().get(0).getResults().get(0).getTags().keySet())
+                                    .setTags(response.getQueries().get(0).getResults().get(0).getTags())
                                     .build();
                         }
                     }
@@ -219,7 +219,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
                                 sourceMetricName,
                                 rollupMetricName,
                                 period,
-                                message.getTagNames(),
+                                message.getTags(),
                                 response,
                                 failure
                             );
@@ -312,7 +312,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
                         .setSourceMetricName(message.getSourceMetricName())
                         .setDestinationMetricName(rollupMetricName)
                         .setPeriod(period)
-                        .setGroupByTags(message.getTags());
+                        .setAllMetricTags(message.getTags());
 
                 for (final Instant startTime : startTimes) {
                     rollupDefBuilder.setStartTime(startTime);
@@ -373,7 +373,7 @@ public class RollupGenerator extends AbstractActorWithTimers {
             final String sourceMetricName,
             final String rollupMetricName,
             final RollupPeriod period,
-            final ImmutableSet<String> tags,
+            final ImmutableMultimap<String, String> tags,
             final MetricsQueryResponse response,
             @Nullable final Throwable failure) {
         final LastDataPointsMessage.Builder builder = new LastDataPointsMessage.Builder()

--- a/app/com/arpnetworking/rollups/TagNamesMessage.java
+++ b/app/com/arpnetworking/rollups/TagNamesMessage.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.rollups;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
@@ -30,18 +31,18 @@ public final class TagNamesMessage extends FailableMessage {
         return _metricName;
     }
 
-    public ImmutableSet<String> getTagNames() {
-        return _tagNames;
+    public ImmutableMultimap<String, String> getTags() {
+        return _tags;
     }
 
     private TagNamesMessage(final Builder builder) {
         super(builder);
         _metricName = builder._metricName;
-        _tagNames = builder._tagNames;
+        _tags = builder._tags;
     }
 
     private final String _metricName;
-    private final ImmutableSet<String> _tagNames;
+    private final ImmutableMultimap<String, String> _tags;
     private static final long serialVersionUID = 7474007527385332990L;
 
     /**
@@ -73,15 +74,15 @@ public final class TagNamesMessage extends FailableMessage {
          * @param value tag names set
          * @return this builder
          */
-        public Builder setTagNames(final ImmutableSet<String> value) {
-            _tagNames = value;
+        public Builder setTags(final ImmutableMultimap<String, String> value) {
+            _tags = value;
             return this;
         }
 
         @Override
         protected void reset() {
             super.reset();;
-            _tagNames = ImmutableSet.of();
+            _tags = ImmutableMultimap.of();
             _metricName = null;
         }
 
@@ -94,6 +95,6 @@ public final class TagNamesMessage extends FailableMessage {
         @NotEmpty
         private String _metricName;
         @NotNull
-        private ImmutableSet<String> _tagNames = ImmutableSet.of();
+        private ImmutableMultimap<String, String> _tags = ImmutableMultimap.of();
     }
 }

--- a/app/com/arpnetworking/rollups/TagNamesMessage.java
+++ b/app/com/arpnetworking/rollups/TagNamesMessage.java
@@ -16,7 +16,6 @@
 package com.arpnetworking.rollups;
 
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 

--- a/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
@@ -30,6 +30,7 @@ import com.arpnetworking.kairos.client.models.SamplingUnit;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -128,7 +129,7 @@ public class RollupExecutorTest {
                                 .setDestinationMetricName("metric_1h")
                                 .setPeriod(RollupPeriod.HOURLY)
                                 .setStartTime(Instant.EPOCH)
-                                .setGroupByTags(ImmutableSet.of())
+                                .setAllMetricTags(ImmutableMultimap.of())
                                 .build()
                         )
                         .build(),
@@ -173,7 +174,7 @@ public class RollupExecutorTest {
                         .setSourceMetricName("metric")
                         .setDestinationMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setGroupByTags(ImmutableSet.of("tag1", "tag2"))
+                        .setAllMetricTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setStartTime(Instant.EPOCH)
                         .build(),
                 ActorRef.noSender());
@@ -219,7 +220,7 @@ public class RollupExecutorTest {
         RollupDefinition definition = new RollupDefinition.Builder()
                 .setSourceMetricName("my_metric")
                 .setDestinationMetricName("my_metric_1h")
-                .setGroupByTags(ImmutableSet.of("tag1", "tag2"))
+                .setAllMetricTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                 .setPeriod(RollupPeriod.HOURLY)
                 .setStartTime(Instant.EPOCH)
                 .build();
@@ -256,7 +257,7 @@ public class RollupExecutorTest {
         definition = new RollupDefinition.Builder()
                 .setSourceMetricName("my_metric_1h")
                 .setDestinationMetricName("my_metric_1d")
-                .setGroupByTags(ImmutableSet.of("tag1", "tag2"))
+                .setAllMetricTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                 .setPeriod(RollupPeriod.DAILY)
                 .setStartTime(Instant.EPOCH)
                 .build();

--- a/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
@@ -162,7 +162,7 @@ public class RollupGeneratorTest {
         final TagNamesMessage tagNamesMessage = _probe.expectMsgClass(TagNamesMessage.class);
         assertFalse(tagNamesMessage.isFailure());
         assertEquals("metric", tagNamesMessage.getMetricName());
-        assertEquals(2, tagNamesMessage.getTagNames().size());
+        assertEquals(2, tagNamesMessage.getTags().size());
 
         verify(_kairosDbClient, times(1)).queryMetricTags(captor.capture());
         final TagsQuery tagQuery = captor.getValue();
@@ -200,7 +200,7 @@ public class RollupGeneratorTest {
         actor.tell(
                 new TagNamesMessage.Builder()
                         .setMetricName("metric")
-                        .setTagNames(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .build(),
                 ActorRef.noSender());
 
@@ -247,7 +247,7 @@ public class RollupGeneratorTest {
         actor.tell(
                 new TagNamesMessage.Builder()
                         .setMetricName("metric")
-                        .setTagNames(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .build(),
                 ActorRef.noSender());
 
@@ -308,7 +308,7 @@ public class RollupGeneratorTest {
         actor.tell(
                 new TagNamesMessage.Builder()
                         .setMetricName("metric")
-                        .setTagNames(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .build(),
                 ActorRef.noSender());
         final Instant expectedStartTime = RollupPeriod.HOURLY.recentEndTime(_clock.instant())
@@ -356,7 +356,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(_clock.instant())
                         .setRollupLastDataPointTime(null)
                         .build(),
@@ -394,7 +394,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(_clock.instant())
                         .setRollupLastDataPointTime(Instant.EPOCH)
                         .build(),
@@ -436,7 +436,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(_clock.instant())
                         .setRollupLastDataPointTime(lastDataPoint)
                         .build(),
@@ -477,7 +477,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(_clock.instant())
                         .setRollupLastDataPointTime(lastDataPoint)
                         .build(),
@@ -503,7 +503,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setFailure(new RuntimeException("Failure"))
                         .build(),
                 ActorRef.noSender());
@@ -526,7 +526,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(null)
                         .setRollupLastDataPointTime(null)
                         .build(),
@@ -553,7 +553,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(startTime.plus(RollupPeriod.HOURLY.periodCountToDuration(periodsBehind)))
                         .setRollupLastDataPointTime(null)
                         .build(),
@@ -590,7 +590,7 @@ public class RollupGeneratorTest {
         actor.tell(
                 new TagNamesMessage.Builder()
                         .setMetricName("metric")
-                        .setTagNames(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .build(),
                 ActorRef.noSender());
 
@@ -618,7 +618,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1d")
                         .setPeriod(RollupPeriod.DAILY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(_clock.instant())
                         .setRollupLastDataPointTime(lastDataPointTime)
                         .build(),
@@ -645,7 +645,7 @@ public class RollupGeneratorTest {
                         .setSourceMetricName("metric")
                         .setRollupMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
-                        .setTags(ImmutableSet.of("tag1", "tag2"))
+                        .setTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
                         .setSourceLastDataPointTime(_clock.instant())
                         .setRollupLastDataPointTime(lastDataPointTime)
                         .build(),

--- a/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupGeneratorTest.java
@@ -30,7 +30,6 @@ import com.arpnetworking.metrics.portal.AkkaClusteringConfigFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;

--- a/test/java/com/arpnetworking/rollups/RollupManagerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupManagerTest.java
@@ -22,6 +22,7 @@ import akka.testkit.javadsl.TestKit;
 import com.arpnetworking.commons.akka.GuiceActorCreator;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.AkkaClusteringConfigFactory;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -93,7 +94,7 @@ public final class RollupManagerTest {
                 .setSourceMetricName("foo")
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
-                .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
+                .setAllMetricTags(ImmutableMultimap.of("bar", "val"))
                 .setStartTime(Instant.EPOCH);
         final RollupDefinition rollupDef = rollupDefBuilder.build();
         final RollupDefinition rollupDef2 = rollupDefBuilder
@@ -119,7 +120,7 @@ public final class RollupManagerTest {
                 .setSourceMetricName("foo")
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
-                .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
+                .setAllMetricTags(ImmutableMultimap.of("bar", "val"))
                 .setStartTime(Instant.EPOCH);
         final RollupDefinition rollupDef = rollupDefBuilder.build();
         final RollupDefinition rollupDef2 = rollupDefBuilder.build();
@@ -140,7 +141,7 @@ public final class RollupManagerTest {
                 .setSourceMetricName("foo")
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
-                .setGroupByTags(ImmutableSet.<String>builder().add("bar").build())
+                .setAllMetricTags(ImmutableMultimap.of("bar", "val"))
                 .setStartTime(Instant.EPOCH);
         final RollupDefinition rollupDef = rollupDefBuilder.build();
         final RollupDefinition rollupDef2 = rollupDefBuilder.setStartTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS)).build();

--- a/test/java/com/arpnetworking/rollups/RollupManagerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupManagerTest.java
@@ -23,7 +23,6 @@ import com.arpnetworking.commons.akka.GuiceActorCreator;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.AkkaClusteringConfigFactory;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;


### PR DESCRIPTION
This consists of:

- Adding the `_filterTags` field to tell the RollupExecutors which tags to slice on. This field isn't used yet, it's just left at its default empty value, but that will change.

- Generalizing `_groupByTags` (used to populate the rollup-query's `group_by`) to include tag _values_ as well as names. (new name `_allMetricTags`)

Together, these will facilitate partition-and-retry logic: when a job fails, we can pick a tag from `_allMetricTags` that we haven't yet filtered by, and add various values to `_filterTags` for various sub-jobs.