### PR TITLE
[RFC] add TTL to rollup-jobs

### DIFF
--- a/app/com/arpnetworking/rollups/RollupDefinition.java
+++ b/app/com/arpnetworking/rollups/RollupDefinition.java
@@ -40,6 +40,7 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
     private final Instant _startTime;
     private final ImmutableMap<String, String> _filterTags;
     private final ImmutableMultimap<String, String> _allMetricTags;
+    private final Instant _giveUpAfter;
 
     private RollupDefinition(final Builder builder) {
         _sourceMetricName = builder._sourceMetricName;
@@ -48,6 +49,7 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         _startTime = builder._startTime;
         _filterTags = builder._filterTags;
         _allMetricTags = builder._allMetricTags;
+        _giveUpAfter = builder._giveUpAfter;
     }
 
     public String getSourceMetricName() {
@@ -74,6 +76,10 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         return _allMetricTags;
     }
 
+    public Instant getGiveUpAfter() {
+        return _giveUpAfter;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -88,12 +94,13 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
                 && _period == that._period
                 && _startTime.equals(that._startTime)
                 && _filterTags.equals(that._filterTags)
-                && _allMetricTags.equals(that._allMetricTags);
+                && _allMetricTags.equals(that._allMetricTags)
+                && _giveUpAfter.equals(that._giveUpAfter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_sourceMetricName, _destinationMetricName, _period, _startTime, _filterTags, _allMetricTags);
+        return Objects.hash(_sourceMetricName, _destinationMetricName, _period, _startTime, _filterTags, _allMetricTags, _giveUpAfter);
     }
 
     @Override
@@ -105,6 +112,7 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
                 .add("_startTime", _startTime)
                 .add("_filterTags", _filterTags)
                 .add("_allMetricTags", _allMetricTags)
+                .add("_giveUpAfter", _giveUpAfter)
                 .toString();
     }
 
@@ -135,6 +143,8 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
         private ImmutableMap<String, String> _filterTags = ImmutableMap.of();
         @NotNull
         private ImmutableMultimap<String, String> _allMetricTags;
+        @NotNull
+        private Instant _giveUpAfter;
 
         /**
          * Creates a builder for a RollupDefinition.
@@ -206,6 +216,17 @@ public final class RollupDefinition implements Serializable, ConsistentHashingRo
          */
         public Builder setAllMetricTags(final ImmutableMultimap<String, String> value) {
             _allMetricTags = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@code _giveUpAfter} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param value the {@code _giveUpAfter} to set
+         * @return a reference to this Builder
+         */
+        public Builder setGiveUpAfter(final Instant value) {
+            _giveUpAfter = value;
             return this;
         }
     }

--- a/app/com/arpnetworking/rollups/RollupGenerator.java
+++ b/app/com/arpnetworking/rollups/RollupGenerator.java
@@ -313,7 +313,8 @@ public class RollupGenerator extends AbstractActorWithTimers {
                         .setSourceMetricName(message.getSourceMetricName())
                         .setDestinationMetricName(rollupMetricName)
                         .setPeriod(period)
-                        .setAllMetricTags(message.getTags());
+                        .setAllMetricTags(message.getTags())
+                        .setGiveUpAfter(Instant.now().plus(period.periodCountToDuration(1)));
 
                 for (final Instant startTime : startTimes) {
                     rollupDefBuilder.setStartTime(startTime);

--- a/app/com/arpnetworking/rollups/RollupManager.java
+++ b/app/com/arpnetworking/rollups/RollupManager.java
@@ -26,6 +26,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.TreeSet;
@@ -140,7 +141,29 @@ public class RollupManager extends AbstractActorWithTimers {
     }
 
     private Optional<RollupDefinition> getNextRollup() {
-        return Optional.ofNullable(_rollupDefinitions.pollFirst());
+        while (!_rollupDefinitions.isEmpty()) {
+            final RollupDefinition earliest = _rollupDefinitions.pollFirst();
+            if (earliest == null) {
+                LOGGER.error()
+                        .setMessage("got null job out of set despite verifying non-emptiness; should be impossible")
+                        .log();
+                return Optional.empty();
+            }
+            final Instant now = Instant.now();
+            if (earliest.getGiveUpAfter().isAfter(now)) {
+                return Optional.of(earliest);
+            }
+            LOGGER.warn()
+                    .setMessage("rollup definition aged out")
+                    .addData("rollupDefinition", earliest)
+                    .addData("timeAgedOut", now)
+                    .log();
+            final Metrics metrics = _metricsFactory.create();
+            metrics.addAnnotation("rollup_metric", earliest.getDestinationMetricName());
+            metrics.incrementCounter("rollup/manager/aged_out");
+            metrics.close();
+        }
+        return Optional.empty();
     }
 
     private static class RollupComparator implements Comparator<RollupDefinition>, Serializable {

--- a/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
+++ b/test/java/com/arpnetworking/metrics/portal/TestBeanFactory.java
@@ -238,7 +238,8 @@ public final class TestBeanFactory {
                 .setDestinationMetricName("my_metric_1h")
                 .setPeriod(RollupPeriod.HOURLY)
                 .setAllMetricTags(ImmutableMultimap.of("tag", "val"))
-                .setFilterTags(ImmutableMap.of());
+                .setFilterTags(ImmutableMap.of())
+                .setGiveUpAfter(Instant.now().plus(Duration.ofDays(1)));
     }
 
     /**

--- a/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
@@ -29,6 +29,7 @@ import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
 import com.arpnetworking.kairos.client.models.Sampling;
 import com.arpnetworking.kairos.client.models.SamplingUnit;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
+import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -126,14 +127,7 @@ public class RollupExecutorTest {
         _probe.expectMsg(RollupExecutor.FETCH_ROLLUP);
         final RollupExecutor.FinishRollupMessage finished = ThreadLocalBuilder.build(
                 RollupExecutor.FinishRollupMessage.Builder.class,
-                b -> b.setRollupDefinition(new RollupDefinition.Builder()
-                        .setSourceMetricName("metric")
-                        .setDestinationMetricName("metric_1h")
-                        .setPeriod(RollupPeriod.HOURLY)
-                        .setStartTime(Instant.EPOCH)
-                        .setAllMetricTags(ImmutableMultimap.of())
-                        .build()
-                )
+                b -> b.setRollupDefinition(TestBeanFactory.createRollupDefinitionBuilder().build())
         );
         actor.tell(finished, ActorRef.noSender());
         _probe.expectMsg(finished);
@@ -172,7 +166,7 @@ public class RollupExecutorTest {
         _probe.expectMsg(RollupExecutor.FETCH_ROLLUP);
 
         actor.tell(
-                new RollupDefinition.Builder()
+                TestBeanFactory.createRollupDefinitionBuilder()
                         .setSourceMetricName("metric")
                         .setDestinationMetricName("metric_1h")
                         .setPeriod(RollupPeriod.HOURLY)
@@ -219,7 +213,7 @@ public class RollupExecutorTest {
 
     @Test
     public void testBuildRollupQuery() {
-        RollupDefinition definition = new RollupDefinition.Builder()
+        RollupDefinition definition = TestBeanFactory.createRollupDefinitionBuilder()
                 .setSourceMetricName("my_metric")
                 .setDestinationMetricName("my_metric_1h")
                 .setAllMetricTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))
@@ -256,7 +250,7 @@ public class RollupExecutorTest {
                 RollupExecutor.buildQueryRollup(definition)
         );
 
-        definition = new RollupDefinition.Builder()
+        definition = TestBeanFactory.createRollupDefinitionBuilder()
                 .setSourceMetricName("my_metric_1h")
                 .setDestinationMetricName("my_metric_1d")
                 .setAllMetricTags(ImmutableMultimap.of("tag1", "val1", "tag2", "val2"))

--- a/test/java/com/arpnetworking/rollups/RollupManagerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupManagerTest.java
@@ -26,6 +26,7 @@ import com.arpnetworking.metrics.MetricsFactory;
 import com.arpnetworking.metrics.impl.NoOpMetricsFactory;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.AkkaClusteringConfigFactory;
+import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -102,7 +103,7 @@ public final class RollupManagerTest {
         final TestKit testKit = new TestKit(_system);
         final ActorRef actor = createActor();
         final ActorRef testActor = testKit.getTestActor();
-        final RollupDefinition.Builder rollupDefBuilder = new RollupDefinition.Builder()
+        final RollupDefinition.Builder rollupDefBuilder = TestBeanFactory.createRollupDefinitionBuilder()
                 .setSourceMetricName("foo")
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
@@ -128,7 +129,7 @@ public final class RollupManagerTest {
         final TestKit testKit = new TestKit(_system);
         final ActorRef actor = createActor();
         final ActorRef testActor = testKit.getTestActor();
-        final RollupDefinition.Builder rollupDefBuilder = new RollupDefinition.Builder()
+        final RollupDefinition.Builder rollupDefBuilder = TestBeanFactory.createRollupDefinitionBuilder()
                 .setSourceMetricName("foo")
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
@@ -149,7 +150,7 @@ public final class RollupManagerTest {
         final TestKit testKit = new TestKit(_system);
         final ActorRef actor = createActor();
         final ActorRef testActor = testKit.getTestActor();
-        final RollupDefinition.Builder rollupDefBuilder = new RollupDefinition.Builder()
+        final RollupDefinition.Builder rollupDefBuilder = TestBeanFactory.createRollupDefinitionBuilder()
                 .setSourceMetricName("foo")
                 .setDestinationMetricName("foo_1h")
                 .setPeriod(RollupPeriod.HOURLY)
@@ -174,12 +175,8 @@ public final class RollupManagerTest {
         final TestKit testKit = new TestKit(_system);
         final ActorRef actor = createActor();
         final ActorRef testActor = testKit.getTestActor();
-        final RollupDefinition rollupDef = new RollupDefinition.Builder()
-                .setSourceMetricName("foo")
-                .setDestinationMetricName("foo_1h")
-                .setPeriod(RollupPeriod.HOURLY)
+        final RollupDefinition rollupDef = TestBeanFactory.createRollupDefinitionBuilder()
                 .setAllMetricTags(ImmutableMultimap.of("tag", "val1", "tag", "val2"))
-                .setStartTime(Instant.EPOCH)
                 .build();
 
         final ImmutableSet<RollupDefinition> children = ImmutableSet.of("val1", "val2").stream()
@@ -200,6 +197,21 @@ public final class RollupManagerTest {
         actor.tell(RollupFetch.getInstance(), testActor);
         actor.tell(RollupFetch.getInstance(), testActor);
         testKit.expectMsgAllOf(children.toArray());
+
+        actor.tell(RollupFetch.getInstance(), testActor);
+        testKit.expectMsg(NoMoreRollups.getInstance());
+    }
+
+    @Test
+    public void testAgesOutExpiredRollups() {
+        final TestKit testKit = new TestKit(_system);
+        final ActorRef actor = createActor();
+        final ActorRef testActor = testKit.getTestActor();
+        final RollupDefinition rollupDef = TestBeanFactory.createRollupDefinitionBuilder()
+                .setGiveUpAfter(Instant.now().minusMillis(1))
+                .build();
+
+        actor.tell(rollupDef, testActor);
 
         actor.tell(RollupFetch.getInstance(), testActor);
         testKit.expectMsg(NoMoreRollups.getInstance());

--- a/test/java/com/arpnetworking/rollups/RollupManagerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupManagerTest.java
@@ -129,12 +129,7 @@ public final class RollupManagerTest {
         final TestKit testKit = new TestKit(_system);
         final ActorRef actor = createActor();
         final ActorRef testActor = testKit.getTestActor();
-        final RollupDefinition.Builder rollupDefBuilder = TestBeanFactory.createRollupDefinitionBuilder()
-                .setSourceMetricName("foo")
-                .setDestinationMetricName("foo_1h")
-                .setPeriod(RollupPeriod.HOURLY)
-                .setAllMetricTags(ImmutableMultimap.of("bar", "val"))
-                .setStartTime(Instant.EPOCH);
+        final RollupDefinition.Builder rollupDefBuilder = TestBeanFactory.createRollupDefinitionBuilder();
         final RollupDefinition rollupDef = rollupDefBuilder.build();
         final RollupDefinition rollupDef2 = rollupDefBuilder.build();
         actor.tell(rollupDef, testActor);
@@ -150,14 +145,9 @@ public final class RollupManagerTest {
         final TestKit testKit = new TestKit(_system);
         final ActorRef actor = createActor();
         final ActorRef testActor = testKit.getTestActor();
-        final RollupDefinition.Builder rollupDefBuilder = TestBeanFactory.createRollupDefinitionBuilder()
-                .setSourceMetricName("foo")
-                .setDestinationMetricName("foo_1h")
-                .setPeriod(RollupPeriod.HOURLY)
-                .setAllMetricTags(ImmutableMultimap.of("bar", "val"))
-                .setStartTime(Instant.EPOCH);
+        final RollupDefinition.Builder rollupDefBuilder = TestBeanFactory.createRollupDefinitionBuilder();
         final RollupDefinition rollupDef = rollupDefBuilder.build();
-        final RollupDefinition rollupDef2 = rollupDefBuilder.setStartTime(Instant.EPOCH.plus(1, ChronoUnit.HOURS)).build();
+        final RollupDefinition rollupDef2 = rollupDefBuilder.setStartTime(rollupDef.getStartTime().plus(1, ChronoUnit.HOURS)).build();
         actor.tell(rollupDef2, testActor);
         actor.tell(rollupDef, testActor);
         actor.tell(RollupFetch.getInstance(), testActor);


### PR DESCRIPTION
Now that rollup-jobs have retry logic, [Gil points out](https://github.com/ArpNetworking/metrics-portal/pull/366#issuecomment-622010513) that we probably want some safeguard against the jobs rattling around forever. Maybe we should assign each job an Instant to give up after?

Failure modes this defends against:
- An error in the job-splitting logic results in a job being retried indefinitely, thereby clogging up one or more of our RollupExecutor actors.

Failure modes it doesn't:
- Kairos gets super slow for some reason, making a lot of jobs time out when they "shouldn't", resulting in a backlog of millions of tiny jobs that will clog the system even after Kairos comes back up.

Failure modes it makes worse:
- Rollups fall far behind, _without_ MPortal going down, so we age jobs out of a legitimate backlog when the right thing to do is chew through them.

I'm not delighted by this tradeoff. It seems fundamentally difficult to distinguish between "a large legitimate backlog because we're behind" and "a large illegitimate backlog caused by some job being broken." Thoughts on this would be appreciated; or maybe I'll revisit this and see some clever solution later this week.