### PR TITLE
Enable DatabaseReportExecutionRepository for postgres config

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportExecutionRepository.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.reports.impl;
 
+import com.arpnetworking.metrics.portal.reports.ReportExecutionRepository;
 import com.arpnetworking.metrics.portal.scheduling.JobExecutionRepository;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
@@ -43,7 +44,7 @@ import javax.persistence.PersistenceException;
  *
  * @author Christian Briones (cbriones at dropbox dot com)
  */
-public final class DatabaseReportExecutionRepository implements JobExecutionRepository<Report.Result> {
+public final class DatabaseReportExecutionRepository implements ReportExecutionRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseReportExecutionRepository.class);
 

--- a/conf/postgresql.application.conf
+++ b/conf/postgresql.application.conf
@@ -98,6 +98,7 @@ alertRepository.type = "com.arpnetworking.metrics.portal.alerts.impl.DatabaseAle
 # Reports
 # ~~~~~
 reportRepository.type = "com.arpnetworking.metrics.portal.reports.impl.DatabaseReportRepository"
+reportExecutionRepository.type = "com.arpnetworking.metrics.portal.reports.impl.DatabaseReportExecutionRepository"
 
 # Akka
 # ~~~~~


### PR DESCRIPTION
It's currently not bound to anything by default so the injector throws from within CachedJob as it tries to fetch the repository impl.