### PR TITLE
rollups: retry: dig into exception cause to find KDB exception

### DIFF
--- a/app/com/arpnetworking/rollups/RollupPartitioner.java
+++ b/app/com/arpnetworking/rollups/RollupPartitioner.java
@@ -86,7 +86,8 @@ public class RollupPartitioner {
      */
     public boolean mightSplittingFixFailure(final Throwable failure) {
         if (!(failure instanceof KairosDbRequestException)) {
-            return false;
+            final Throwable cause = failure.getCause();
+            return cause != null && mightSplittingFixFailure(cause);
         }
 
         // TODO(spencerpearson): I hate how ad-hoc this is, but Kairos's behavior when it barfs

--- a/test/java/com/arpnetworking/rollups/RollupPartitionerTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupPartitionerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.concurrent.CompletionException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -90,6 +91,12 @@ public final class RollupPartitionerTest {
                 URI.create("http://kairos"),
                 Duration.ofMinutes(2)
         )));
+        assertTrue(partitioner.mightSplittingFixFailure(new CompletionException(new KairosDbRequestException(
+                500,
+                "some error message",
+                URI.create("http://kairos"),
+                Duration.ofMinutes(2)
+        ))));
         assertFalse(partitioner.mightSplittingFixFailure(new KairosDbRequestException(
                 500,
                 "some error message",


### PR DESCRIPTION
(In practice, it looks like the failures passed in here are CompletionExceptions.)