### PR TITLE
QueryExecutor RFC: Time-bounded queries and delegated executor

### DIFF
--- a/app/com/arpnetworking/kairos/client/models/SamplingUnit.java
+++ b/app/com/arpnetworking/kairos/client/models/SamplingUnit.java
@@ -97,7 +97,8 @@ public enum SamplingUnit {
                 return ChronoUnit.MONTHS;
             case YEARS:
                 return ChronoUnit.YEARS;
+            default:
+                throw new IllegalStateException("Unknown value: " + unit);
         }
-        throw new IllegalStateException("Unknown value: " + unit);
     }
 }

--- a/app/com/arpnetworking/kairos/client/models/SamplingUnit.java
+++ b/app/com/arpnetworking/kairos/client/models/SamplingUnit.java
@@ -17,6 +17,7 @@ package com.arpnetworking.kairos.client.models;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
 /**
@@ -70,5 +71,33 @@ public enum SamplingUnit {
     @JsonValue
     public String toJson() {
         return name().toLowerCase(Locale.getDefault());
+    }
+
+    /**
+     * Convert a sampling unit to the equivalent {@code ChronoUnit}.
+     *
+     * @param unit The sampling unit to convert.
+     * @return A ChronoUnit representing the same unit of time.
+     */
+    public static ChronoUnit toChronoUnit(final SamplingUnit unit) {
+        switch (unit) {
+            case MILLISECONDS:
+                return ChronoUnit.MILLIS;
+            case SECONDS:
+                return ChronoUnit.SECONDS;
+            case MINUTES:
+                return ChronoUnit.MINUTES;
+            case HOURS:
+                return ChronoUnit.HOURS;
+            case DAYS:
+                return ChronoUnit.DAYS;
+            case WEEKS:
+                return ChronoUnit.WEEKS;
+            case MONTHS:
+                return ChronoUnit.MONTHS;
+            case YEARS:
+                return ChronoUnit.YEARS;
+        }
+        throw new IllegalStateException("Unknown value: " + unit);
     }
 }

--- a/app/com/arpnetworking/metrics/portal/query/QueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/QueryExecutor.java
@@ -15,13 +15,19 @@
  */
 package com.arpnetworking.metrics.portal.query;
 
+import models.internal.BoundedMetricsQuery;
 import models.internal.MetricsQuery;
 import models.internal.MetricsQueryResult;
 
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
  * Interface to describe classes that execute time series queries.
+ *
+ * @see MetricsQuery
+ * @see MetricsQueryResult
  *
  * @author Brandon Arp (brandon dot arp at smartsheet dot com)
  */
@@ -31,7 +37,23 @@ public interface QueryExecutor {
      *
      * @param query query to execute
      * @return {@link CompletionStage} of the result
-     * @throws QueryExecutionException on errors during query execution
      */
-    CompletionStage<MetricsQueryResult> executeQuery(MetricsQuery query) throws QueryExecutionException;
+    CompletionStage<MetricsQueryResult> executeQuery(BoundedMetricsQuery query);
+
+    /**
+     * Return a minimum period size for this query, if any.
+     *
+     * Consumers of this interface may take this hint into consideration to
+     * avoid querying for results at a higher frequency then what is actually
+     * necessary. This would allow you to avoid polling an hourly metric every
+     * minute, for example.
+     *
+     * By default, no hint is returned.
+     *
+     * @param query The query
+     * @return The minimum polling period necessary to avoid missing data.
+     */
+    default Optional<ChronoUnit> periodHint(final MetricsQuery query) {
+        return Optional.empty();
+    }
 }

--- a/app/com/arpnetworking/metrics/portal/query/QueryExecutorRegistry.java
+++ b/app/com/arpnetworking/metrics/portal/query/QueryExecutorRegistry.java
@@ -17,31 +17,33 @@ package com.arpnetworking.metrics.portal.query;
 
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.google.common.collect.ImmutableMap;
+import models.internal.MetricsQueryFormat;
 import net.sf.oval.constraint.NotNull;
 
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
- * Holds executor references and allows us to inject them into a controller for runtime selection.
+ * Holds executor references to allow for runtime selection by query format.
  *
  * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
  */
 public final class QueryExecutorRegistry {
+
+    private final ImmutableMap<MetricsQueryFormat, QueryExecutor> _executors;
+
     /**
-     * Gets a query executor by name.
-     * @param name name of the executor
-     * @return the executor, or null if an executor of that name does not exist
+     * Gets a query executor by format.
+     *
+     * @param format The query format
+     * @return the executor, or {@link Optional#empty} if an executor of that name does not exist
      */
-    @Nullable
-    public QueryExecutor getExecutor(final String name) {
-        return _executors.getOrDefault(name, null);
+    public Optional<QueryExecutor> getExecutor(final MetricsQueryFormat format) {
+        return Optional.ofNullable(_executors.getOrDefault(format, null));
     }
 
     private QueryExecutorRegistry(final Builder builder) {
         _executors = builder._executors;
     }
-
-    private final ImmutableMap<String, QueryExecutor> _executors;
 
     /**
      * Implementation of the Builder pattern for {@link QueryExecutorRegistry}.
@@ -49,6 +51,9 @@ public final class QueryExecutorRegistry {
      * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
      */
     public static class Builder extends OvalBuilder<QueryExecutorRegistry> {
+        @NotNull
+        private ImmutableMap<MetricsQueryFormat, QueryExecutor> _executors = ImmutableMap.of();
+
         /**
          * Public constructor.
          */
@@ -62,12 +67,9 @@ public final class QueryExecutorRegistry {
          * @param value the time
          * @return this {@link Builder}
          */
-        public Builder setExecutors(final ImmutableMap<String, QueryExecutor> value) {
+        public Builder setExecutors(final ImmutableMap<MetricsQueryFormat, QueryExecutor> value) {
             _executors = value;
             return this;
         }
-
-        @NotNull
-        private ImmutableMap<String, QueryExecutor> _executors = ImmutableMap.of();
     }
 }

--- a/app/com/arpnetworking/metrics/portal/query/impl/DelegatingQueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/impl/DelegatingQueryExecutor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.query.impl;
+
+import com.arpnetworking.metrics.portal.query.QueryExecutor;
+import com.arpnetworking.metrics.portal.query.QueryExecutorRegistry;
+import com.google.inject.Inject;
+import models.internal.BoundedMetricsQuery;
+import models.internal.MetricsQuery;
+import models.internal.MetricsQueryFormat;
+import models.internal.MetricsQueryResult;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A query executor implementation that delegates queries to registered executors
+ * within the wrapped {@link QueryExecutorRegistry}.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public class DelegatingQueryExecutor implements QueryExecutor {
+    private QueryExecutorRegistry _executors;
+
+    /**
+     * Default Constructor.
+     *
+     * @param executorRegistry Executor registry to delgate to
+     */
+    @Inject
+    public DelegatingQueryExecutor(final QueryExecutorRegistry executorRegistry) {
+        _executors = executorRegistry;
+    }
+
+    @Override
+    public CompletionStage<MetricsQueryResult> executeQuery(final BoundedMetricsQuery query) {
+        CompletableFuture.completedFuture(null).thenCompose(ignored -> executeQueryInner(query));
+    }
+
+    @Override
+    public Optional<ChronoUnit> periodHint(final MetricsQuery query) {
+        return _executors.getExecutor(query.getQueryFormat()).flatMap(exec -> exec.periodHint(query));
+    }
+
+    private CompletionStage<MetricsQueryResult> executeQueryInner(final BoundedMetricsQuery query) {
+        final MetricsQueryFormat format = query.getQueryFormat();
+        final QueryExecutor executor =  _executors.getExecutor(format).orElseThrow(() ->
+                new UnsupportedOperationException("No registered executor for format: " + format)
+        );
+        return executor.executeQuery(query);
+    }
+}

--- a/app/com/arpnetworking/metrics/portal/query/impl/DelegatingQueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/impl/DelegatingQueryExecutor.java
@@ -50,7 +50,7 @@ public class DelegatingQueryExecutor implements QueryExecutor {
 
     @Override
     public CompletionStage<MetricsQueryResult> executeQuery(final BoundedMetricsQuery query) {
-        CompletableFuture.completedFuture(null).thenCompose(ignored -> executeQueryInner(query));
+        return CompletableFuture.completedFuture(null).thenCompose(ignored -> executeQueryInner(query));
     }
 
     @Override

--- a/app/com/arpnetworking/metrics/portal/query/impl/NoQueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/impl/NoQueryExecutor.java
@@ -18,10 +18,11 @@ package com.arpnetworking.metrics.portal.query.impl;
 import com.arpnetworking.metrics.portal.query.QueryExecutionException;
 import com.arpnetworking.metrics.portal.query.QueryExecutor;
 import com.google.common.collect.ImmutableList;
-import models.internal.MetricsQuery;
+import models.internal.BoundedMetricsQuery;
 import models.internal.MetricsQueryResult;
 import models.internal.Problem;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Singleton;
 
@@ -33,8 +34,10 @@ import javax.inject.Singleton;
 @Singleton
 public class NoQueryExecutor implements QueryExecutor {
     @Override
-    public CompletionStage<MetricsQueryResult> executeQuery(final MetricsQuery query) throws QueryExecutionException {
+    public CompletionStage<MetricsQueryResult> executeQuery(final BoundedMetricsQuery query) {
         final Problem notEnabledProblem = new Problem.Builder().setProblemCode("NOT_ENABLED").build();
-        throw new QueryExecutionException("Queries are not enabled", ImmutableList.of(notEnabledProblem));
+        final CompletableFuture<MetricsQueryResult> cs = new CompletableFuture<>();
+        cs.completeExceptionally(new QueryExecutionException("Queries are not enabled", ImmutableList.of(notEnabledProblem)));
+        return cs;
     }
 }

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -98,6 +98,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import models.internal.Features;
+import models.internal.MetricsQueryFormat;
 import models.internal.impl.DefaultFeatures;
 import play.Environment;
 import play.api.Configuration;
@@ -304,14 +305,15 @@ public class MainModule extends AbstractModule {
             final Config configuration,
             final Injector injector,
             final Environment environment) {
-        final ImmutableMap.Builder<String, QueryExecutor> registryMapBuilder = ImmutableMap.builder();
+        final ImmutableMap.Builder<MetricsQueryFormat, QueryExecutor> registryMapBuilder = ImmutableMap.builder();
         final Config executorsConfig = configuration.getConfig("query.executors");
         final Set<String> keys = executorsConfig.root().keySet();
         for (final String key: keys) {
+            final MetricsQueryFormat format = MetricsQueryFormat.valueOf(key);
             final Config subconfig = executorsConfig.getConfig(key);
             final Injector childInjector = injector.createChildInjector(new ConfigurationOverrideModule(subconfig));
             final Class<? extends QueryExecutor> clazz = ConfigurationHelper.getType(environment, subconfig, "type");
-            registryMapBuilder.put(key, childInjector.getInstance(clazz));
+            registryMapBuilder.put(format, childInjector.getInstance(clazz));
         }
         return new QueryExecutorRegistry.Builder()
                 .setExecutors(registryMapBuilder.build())

--- a/app/models/internal/BoundedMetricsQuery.java
+++ b/app/models/internal/BoundedMetricsQuery.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.internal;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+/**
+ * A time-series query that is bounded by a time range.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public interface BoundedMetricsQuery extends MetricsQuery {
+    /**
+     * The inclusive start time of the query.
+     *
+     * @return the start time.
+     */
+    ZonedDateTime getStartTime();
+
+    /**
+     * The inclusive end time of the query.
+     *
+     * If this is not present, the current time is used as the end time.
+     *
+     * @return the end time.
+     */
+    Optional<ZonedDateTime> getEndTime();
+}

--- a/app/models/internal/impl/DefaultBoundedMetricsQuery.java
+++ b/app/models/internal/impl/DefaultBoundedMetricsQuery.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.internal.impl;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import models.internal.BoundedMetricsQuery;
+import models.internal.MetricsQueryFormat;
+import net.sf.oval.constraint.NotNull;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+/**
+ * Default implementation for {@code BoundedMetricsQuery}.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public final class DefaultBoundedMetricsQuery implements BoundedMetricsQuery {
+    private final String _query;
+    private final MetricsQueryFormat _format;
+    private final ZonedDateTime _startTime;
+    private final Optional<ZonedDateTime> _endTime;
+
+    private DefaultBoundedMetricsQuery(final Builder builder) {
+        _query = builder._query;
+        _format = builder._format;
+        _startTime = builder._startTime;
+        _endTime = Optional.ofNullable(builder._endTime);
+    }
+
+    @Override
+    public ZonedDateTime getStartTime() {
+        return _startTime;
+    }
+
+    @Override
+    public Optional<ZonedDateTime> getEndTime() {
+        return _endTime;
+    }
+
+    @Override
+    public String getQuery() {
+        return _query;
+    }
+
+    @Override
+    public MetricsQueryFormat getQueryFormat() {
+        return _format;
+    }
+
+    /**
+     * Builder class for instances of {@link DefaultBoundedMetricsQuery}.
+     */
+    public static class Builder extends OvalBuilder<DefaultBoundedMetricsQuery> {
+        @NotNull
+        private String _query;
+        @NotNull
+        private MetricsQueryFormat _format;
+        @NotNull
+        private ZonedDateTime _startTime;
+        @Nullable
+        private ZonedDateTime _endTime;
+
+        /**
+         * Default constructor.
+         */
+        public Builder() {
+            super(DefaultBoundedMetricsQuery::new);
+        }
+
+        /**
+         * Sets the query. Required. Cannot be null.
+         *
+         * @param query the query.
+         * @return This instance of {@code Builder} for chaining.
+         */
+        public Builder setQuery(final String query) {
+            _query = query;
+            return this;
+        }
+
+        /**
+         * Sets the format. Required. Cannot be null.
+         *
+         * @param format the format.
+         * @return This instance of {@code Builder} for chaining.
+         */
+        public Builder setFormat(final MetricsQueryFormat format) {
+            _format = format;
+            return this;
+        }
+
+        /**
+         * Sets the start time. Required. Cannot be null.
+         *
+         * @param startTime the start time.
+         * @return This instance of {@code Builder} for chaining.
+         */
+        public Builder setStartTime(final ZonedDateTime startTime) {
+            _startTime = startTime;
+            return this;
+        }
+
+        /**
+         * Sets the end time. Optional.
+         *
+         * @param endTime the end time.
+         * @return This instance of {@code Builder} for chaining.
+         */
+        public Builder setEndTime(final ZonedDateTime endTime) {
+            _endTime = endTime;
+            return this;
+        }
+    }
+}

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -245,7 +245,7 @@ chrome {
 # ~~~~~
 query {
   executors {
-    default {
+    KAIROS_DB {
       type = "com.arpnetworking.metrics.portal.query.impl.NoQueryExecutor"
     }
   }


### PR DESCRIPTION
I've isolated these changes from the Alert execution code I've written, since there were a few things necessary to get that into a working state.

Changes Introduced

* We need a notion of time range on the query model used for the executor. This was previously in the class `MetricsQuery`, but instead I've introduced a separate `BoundedMetricsQuery` that keeps all the same fields along with a time range. This distinction is necessary because alert query definitions do not need a time range specified since it's inferred at execution time based on the scheduler and period hint (see next bullet).

* executors can now specify a "periodHint" via `QueryExecutor#periodHint`. This is *necessary* for alert evaluation to ensure we don't miss any gaps in a query. For example, an alert query can be aggregated hourly, and if we polled minutely, we will miss the last data point most of the time and think the alert has stopped firing.

* `QueryExecutorRegistry` and `DelegatingQueryExecutor` - these go hand-in-hand. I've essentially replaced arbitrary registration via names by a more static registration using queryFormat. We need this to delegate `MetricsQuery` instances to the correct executor. Example: `QueryFormat.KAIROS_DB -> KairosDbQueryExecutor`