### PR TITLE
Add Jackson annotations to the Query interfaces

### DIFF
--- a/app/models/internal/TimeSeriesResult.java
+++ b/app/models/internal/TimeSeriesResult.java
@@ -15,7 +15,6 @@
  */
 package models.internal;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -41,7 +40,6 @@ public interface TimeSeriesResult {
      * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
      */
     interface Query {
-        @JsonProperty("sample_size")
         long getSampleSize();
 
         ImmutableList<? extends Result> getResults();

--- a/app/models/view/TimeSeriesResult.java
+++ b/app/models/view/TimeSeriesResult.java
@@ -19,7 +19,6 @@ import com.arpnetworking.commons.builder.OvalBuilder;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -142,7 +141,6 @@ public final class TimeSeriesResult {
             return _otherArgs;
         }
 
-        @JsonProperty("sample_size")
         public long getSampleSize() {
             return _sampleSize;
         }
@@ -212,7 +210,6 @@ public final class TimeSeriesResult {
              * @param value the sample size
              * @return this {@link Builder}
              */
-            @JsonProperty("sample_size")
             public Builder setSampleSize(final long value) {
                 _sampleSize = value;
                 return this;

--- a/app/models/view/TimeSeriesResult.java
+++ b/app/models/view/TimeSeriesResult.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -540,6 +542,20 @@ public final class TimeSeriesResult {
      *
      * @author Brandon Arp (brandon dot arp at smartsheet dot com)
      */
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            property = "name"
+    )
+    @JsonSubTypes({
+            @JsonSubTypes.Type(
+                    name = "tag",
+                    value = QueryTagGroupBy.class
+            ),
+            @JsonSubTypes.Type(
+                    name = "type",
+                    value = QueryTypeGroupBy.class
+            )
+    })
     public abstract static class QueryGroupBy {
         /**
          * Creates an internal model from this view model.


### PR DESCRIPTION
I'd like to include a bunch of testcases in a different diff as JSON files and this makes that possible. There were some annotations before but Jackson cannot resolve the interfaces without encoded type information. Since most of these types have a backing `DefaultXXX` class, I included those as the default deserialize types.