### PR TITLE
use protobuf V3 endpoint instead of V1

### DIFF
--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -260,7 +260,7 @@ public class MainModule extends AbstractModule {
                 .setServiceName(configuration.getString("metrics.service"))
                 .setSinks(Collections.singletonList(
                         new ApacheHttpSink.Builder()
-                                .setUri(URI.create(configuration.getString("metrics.uri") + "/metrics/v1/application"))
+                                .setUri(URI.create(configuration.getString("metrics.uri") + "/metrics/v3/application"))
                                 .build()
                 ))
                 .build();


### PR DESCRIPTION
[v0.9.31 bumped our version of `apache-http-sink-extra` from 0.8.2 to 0.11.1.](https://github.com/ArpNetworking/metrics-portal/compare/metrics-portal-0.9.30...metrics-portal-0.9.31#diff-600376dffeb79835ede4a0b285078036R107) (ctrl-f `metrics.client.http.version`)

[This changed the default Protobuf version from V1 to V3.](https://github.com/ArpNetworking/metrics-apache-http-sink-extra/compare/apache-http-sink-extra-0.8.2...apache-http-sink-extra-0.11.1#diff-02eafa443f9a5351d82c7a69783fc847R241) (ctrl-f `Sink.java`, unfold, ctrl-f `ClientV3`)

So, that version bump _should_ have been accompanied by this endpoint modification, but it wasn't.

I've verified using the `metrics/build/start.sh` script that there are loads of ProtobufV1 parse-failures in MAD's logs on master; and that this change makes those failures go away; and that (with this change) MPortal's self-instrumentation makes it into KairosDB, which is not currently happening in our production environment with the latest version of MPortal.