### PR TITLE
Add a TTL to rollup series

### DIFF
--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -132,7 +132,7 @@ hostProvider {
 rollup {
   # TTL on the individual rollup series.
   # Specifying 0 will use the global TTL configured by KairosDB.
-  ttl = 0
+  ttl = 0s
 
   generator.count = 5
   executor.count = 5

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -130,6 +130,10 @@ hostProvider {
 # Rollups
 # ~~~~~
 rollup {
+  # TTL on the individual rollup series.
+  # Specifying 0 will use the global TTL configured by KairosDB.
+  ttl = 0
+
   generator.count = 5
   executor.count = 5
   executor.pollInterval = "5min"

--- a/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
+++ b/test/java/com/arpnetworking/rollups/RollupExecutorTest.java
@@ -86,6 +86,7 @@ public class RollupExecutorTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         when(_config.getString(eq("rollup.executor.pollInterval"))).thenReturn("3sec");
+        when(_config.getString(eq("rollup.ttl"))).thenReturn("0sec");
 
         _system = ActorSystem.create();
 
@@ -228,6 +229,7 @@ public class RollupExecutorTest {
                 .setPeriod(RollupPeriod.HOURLY)
                 .setStartTime(Instant.EPOCH)
                 .build();
+        long ttl = 0;
         assertEquals(
                 new MetricsQuery.Builder()
                         .setMetrics(ImmutableList.of(new Metric.Builder()
@@ -245,7 +247,8 @@ public class RollupExecutorTest {
                                             .setName("save_as")
                                                 .setOtherArgs(ImmutableMap.of(
                                                         "metric_name", "my_metric_1h",
-                                                        "add_saved_from", false
+                                                        "add_saved_from", false,
+                                                        "ttl", ttl
                                                 ))
                                             .build(),
                                         new Aggregator.Builder()
@@ -255,7 +258,7 @@ public class RollupExecutorTest {
                         .setStartTime(Instant.EPOCH)
                         .setEndTime(Instant.EPOCH.plus(Duration.ofHours(1)).minusMillis(1))
                         .build(),
-                RollupExecutor.buildQueryRollup(definition)
+                RollupExecutor.buildQueryRollup(definition, ttl)
         );
 
         definition = new RollupDefinition.Builder()
@@ -265,6 +268,7 @@ public class RollupExecutorTest {
                 .setPeriod(RollupPeriod.DAILY)
                 .setStartTime(Instant.EPOCH)
                 .build();
+        ttl = 1234;
         assertEquals(
                 new MetricsQuery.Builder()
                         .setMetrics(ImmutableList.of(new Metric.Builder()
@@ -282,7 +286,8 @@ public class RollupExecutorTest {
                                                 .setName("save_as")
                                                 .setOtherArgs(ImmutableMap.of(
                                                         "metric_name", "my_metric_1d",
-                                                        "add_saved_from", false
+                                                        "add_saved_from", false,
+                                                        "ttl", ttl
                                                 ))
                                                 .build(),
                                         new Aggregator.Builder()
@@ -292,7 +297,7 @@ public class RollupExecutorTest {
                         .setStartTime(Instant.EPOCH)
                         .setEndTime(Instant.EPOCH.plus(Duration.ofDays(1)).minusMillis(1))
                         .build(),
-                RollupExecutor.buildQueryRollup(definition)
+                RollupExecutor.buildQueryRollup(definition, ttl)
         );
     }
 


### PR DESCRIPTION
I opted for leaving this non-optional since the documented behavior is to use whatever is configured in kairos if you set it to 0.

I suppose this means the only use case that would not be covered would be if you have a default TTL but never want your rollups to have a TTL (but this seems weird so I left as is)