### PR TITLE
fix actor name conflict

### DIFF
--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -932,7 +932,7 @@ public class MainModule extends AbstractModule {
                         ),
                         PoisonPill.getInstance(),
                         ClusterSingletonManagerSettings.create(_system).withRole(ROLLUP_MANAGER_ROLE)),
-                        "rollup-metrics-discovery"
+                        "rollup-manager"
                 );
                 return _system.actorOf(ClusterSingletonProxy.props(
                         manager.path().toStringWithoutAddress(),


### PR DESCRIPTION
Stack trace in prod:

```
Caused by: akka.actor.InvalidActorNameException: actor name [rollup-metrics-discovery] is not unique!
	at akka.actor.dungeon.ChildrenContainer$NormalChildrenContainer.reserve(ChildrenContainer.scala:129)
	at akka.actor.dungeon.Children$class.reserveChild(Children.scala:135)
	at akka.actor.ActorCell.reserveChild(ActorCell.scala:429)
	at akka.actor.dungeon.Children$class.makeChild(Children.scala:275)
	at akka.actor.dungeon.Children$class.attachChild(Children.scala:49)
	at akka.actor.ActorCell.attachChild(ActorCell.scala:429)
	at akka.actor.ActorSystemImpl.actorOf(ActorSystem.scala:753)
	at global.MainModule$RollupManagerProvider.get(MainModule.java:925)
	at global.MainModule$RollupManagerProvider.get(MainModule.java:1)
```