### PR TITLE
add alert anti-entropy role to cluster

### DIFF
--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -299,6 +299,7 @@ akka {
         "rollup_metrics_discovery",
         "rollup_manager",
         "report_repository_anti_entropy",
+        "alert_repository_anti_entropy",
     ]
     sharding {
       guardian-name="sharding"


### PR DESCRIPTION
Role was missing from configuration so the actor is never instantiated.