### PR TITLE
Schedules should disallow Instant.MIN for runAtAndAfter

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/BaseSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/BaseSchedule.java
@@ -127,6 +127,10 @@ public abstract class BaseSchedule implements Schedule {
 
         /**
          * The earliest time at which the schedule should run. Required. Cannot be null.
+         * <p>
+         * This time cannot be {@link Instant#MIN} since it must correspond to a valid
+         * date. If you need an arbitrary point in the past, you should instead use
+         * {@link Instant#EPOCH}.
          *
          * @param runAtAndAfter The time.
          * @return This instance of {@link Builder}.
@@ -149,7 +153,7 @@ public abstract class BaseSchedule implements Schedule {
 
         @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "invoked reflectively by @ValidateWithMethod")
         private boolean validateRunAtAndAfter(final Instant runAtAndAfter) {
-            return (_runUntil == null) || !runAtAndAfter.isAfter(_runUntil);
+            return !runAtAndAfter.equals(Instant.MIN) && ((_runUntil == null) || !runAtAndAfter.isAfter(_runUntil));
         }
     }
 }

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -232,11 +232,16 @@ public class MainModule extends AbstractModule {
         final FiniteDuration interval = ConfigurationHelper.getFiniteDuration(config, "alerting.execution.defaultInterval");
         final java.time.Duration queryOffset = ConfigurationHelper.getJavaDuration(config, "alerting.execution.queryOffset");
 
+        // The Epoch start is arbitrary - we can't use Instant.MIN since a ZonedDateTime
+        // cannot be constructed from it.
+        //
+        // All alerts should be unconditionally valid for periodic execution after
+        // some arbitrary point in the past, so the epoch is as good as any.
         final Schedule defaultAlertSchedule = new PeriodicSchedule.Builder()
                 .setPeriod(TimeAdapters.toChronoUnit(interval.unit()))
                 .setPeriodCount(interval.length())
                 .setZone(ZoneOffset.UTC)
-                .setRunAtAndAfter(Instant.MIN)
+                .setRunAtAndAfter(Instant.EPOCH)
                 .build();
         return new AlertExecutionContext(defaultAlertSchedule, executor, queryOffset);
     }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
+import net.sf.oval.exception.ConstraintsViolatedException;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -28,11 +29,18 @@ import java.util.Optional;
  */
 public final class BaseScheduleTest {
 
-    @Test(expected = net.sf.oval.exception.ConstraintsViolatedException.class)
+    @Test(expected = ConstraintsViolatedException.class)
     public void testBuilderRejectsRunAfterAfterRunUntil() {
         new MinimalSchedule.Builder()
                 .setRunAtAndAfter(T0)
                 .setRunUntil(T0.minus(Duration.ofSeconds(1)))
+                .build();
+    }
+
+    @Test(expected = ConstraintsViolatedException.class)
+    public void testCannotSetRunAtToTheMinInstant() {
+        new MinimalSchedule.Builder()
+                .setRunAtAndAfter(Instant.MIN)
                 .build();
     }
 


### PR DESCRIPTION
This is causing a failure in alert execution, since the schedule was set to run after `Instant.MIN` but the PeriodicSchedule internally requires that this instant correspond to a valid Date.

I think it would make more sense to place this constraint on PeriodicSchedule rather than BaseSchedule (since the latter does not expose any zoned functionality) but it isn't clear how I can do that since the `runAtAndAfter` field is defined in the BaseSchedule.