### PR TITLE
Run anti-entropy at JobCoordinator startup

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/JobCoordinator.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobCoordinator.java
@@ -135,6 +135,8 @@ public final class JobCoordinator<T> extends AbstractPersistentActorWithTimers {
     @Override
     public void preStart() throws Exception {
         super.preStart();
+        // Tick once at startup, then periodically thereafter.
+        self().tell(AntiEntropyTick.INSTANCE, self());
         timers().startPeriodicTimer(
                 ANTI_ENTROPY_PERIODIC_TIMER_NAME,
                 AntiEntropyTick.INSTANCE,

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -299,6 +299,7 @@ akka {
         "rollup_metrics_discovery",
         "rollup_manager",
         "report_repository_anti_entropy",
+        "alert_repository_anti_entropy",
     ]
     sharding {
       guardian-name="sharding"

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/JobCoordinatorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/JobCoordinatorTest.java
@@ -15,7 +15,6 @@
  */
 package com.arpnetworking.metrics.portal.scheduling;
 
-import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.testkit.javadsl.TestKit;
@@ -127,8 +126,8 @@ public class JobCoordinatorTest {
                 _periodicMetrics);
     }
 
-    private ActorRef makeCoordinatorActor() {
-        return _system.actorOf(makeCoordinatorActorProps());
+    private void makeCoordinatorActor() {
+        _system.actorOf(makeCoordinatorActorProps());
     }
 
     @Test
@@ -146,8 +145,8 @@ public class JobCoordinatorTest {
                 .setResult(456)
                 .build());
 
-        final ActorRef coordinator = makeCoordinatorActor();
-        coordinator.tell(JobCoordinator.AntiEntropyTick.INSTANCE, null);
+        // start the actor which will trigger an initial anti-entropy run.
+        makeCoordinatorActor();
 
         _messageExtractor.expectMsg(new JobExecutorActor.Reload.Builder<Integer>()
                         .setJobRef(makeRef(job1))


### PR DESCRIPTION
It seems that the JobCoordinator will not perform anti-entropy until after the first timer fires 1 hour after startup. This ordinarily isn't a problem because as I understand it the actor system will buffer tick messages to the coordinator between restarts, since it's a cluster singleton. However in the cases where an entirely new coordinator is started or all instances are shut down, the initial wait is unnecessary.