### PR TITLE
Unbounded periodic schedule

### DIFF
--- a/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
+++ b/app/com/arpnetworking/metrics/portal/reports/ReportExecutionContext.java
@@ -20,6 +20,7 @@ import com.arpnetworking.metrics.portal.scheduling.Schedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.NeverSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.PeriodicSchedule;
+import com.arpnetworking.metrics.portal.scheduling.impl.UnboundedPeriodicSchedule;
 import com.arpnetworking.play.configuration.ConfigurationHelper;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
@@ -315,6 +316,11 @@ public final class ReportExecutionContext {
 
         public static TimeRangeVisitor getInstance() {
             return INSTANCE;
+        }
+
+        @Override
+        public ChronoUnit visitUnboundedPeriodic(final UnboundedPeriodicSchedule schedule) {
+            throw new UnsupportedOperationException("Schedule type is unsupported by reporting");
         }
 
         @Override

--- a/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
+++ b/app/com/arpnetworking/metrics/portal/reports/impl/DatabaseReportRepository.java
@@ -342,10 +342,9 @@ public final class DatabaseReportRepository implements ReportRepository {
             beanOneOff.setRunUntil(internalOneOff.getRunUntil().orElse(null));
             return beanOneOff;
         } else if (internalSchedule instanceof NeverSchedule) {
-            final NeverSchedule internalNever = (NeverSchedule) internalSchedule;
             final ReportSchedule beanNever = new NeverReportSchedule();
             beanNever.setRunAt(Instant.ofEpochSecond(0));
-            beanNever.setRunUntil(internalNever.getRunUntil().orElse(null));
+            beanNever.setRunUntil(null);
             return beanNever;
         }
         throw new IllegalArgumentException("Unsupported internal model: " + internalSchedule.getClass());

--- a/app/com/arpnetworking/metrics/portal/scheduling/Schedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/Schedule.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.portal.scheduling;
 import com.arpnetworking.metrics.portal.scheduling.impl.NeverSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.OneOffSchedule;
 import com.arpnetworking.metrics.portal.scheduling.impl.PeriodicSchedule;
+import com.arpnetworking.metrics.portal.scheduling.impl.UnboundedPeriodicSchedule;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -59,6 +60,14 @@ public interface Schedule {
          * @return The result of applying the visitor.
          */
         public abstract T visitPeriodic(PeriodicSchedule schedule);
+
+        /**
+         * Visit a {@link UnboundedPeriodicSchedule}.
+         *
+         * @param schedule The schedule to visit.
+         * @return The result of applying the visitor.
+         */
+        public abstract T visitUnboundedPeriodic(UnboundedPeriodicSchedule schedule);
 
         /**
          * Visit a {@link OneOffSchedule}.

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/BoundedSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/BoundedSchedule.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /**
- * Abstract base class for {@link Schedule}s.
+ * Abstract base class for {@link Schedule}s whose scheduled run times are bounded on either end.
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
@@ -56,7 +56,7 @@ public abstract class BoundedSchedule implements Schedule {
     }
 
     @Override
-    public Optional<Instant> nextRun(final Optional<Instant> lastRun) {
+    public final Optional<Instant> nextRun(final Optional<Instant> lastRun) {
         Optional<Instant> result = unboundedNextRun(lastRun);
         while (result.isPresent() && result.get().isBefore(_runAtAndAfter)) {
             result = unboundedNextRun(result);

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/BoundedSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/BoundedSchedule.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
-public abstract class BaseSchedule implements Schedule {
+public abstract class BoundedSchedule implements Schedule {
 
     private final Instant _runAtAndAfter;
     private final Optional<Instant> _runUntil;
@@ -42,7 +42,7 @@ public abstract class BaseSchedule implements Schedule {
      *
      * @param builder Instance of {@link Builder}.
      */
-    protected BaseSchedule(final Builder<?, ?> builder) {
+    protected BoundedSchedule(final Builder<?, ?> builder) {
         _runAtAndAfter = builder._runAtAndAfter;
         _runUntil = Optional.ofNullable(builder._runUntil);
     }
@@ -84,7 +84,7 @@ public abstract class BaseSchedule implements Schedule {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final BaseSchedule that = (BaseSchedule) o;
+        final BoundedSchedule that = (BoundedSchedule) o;
         return Objects.equals(getRunAtAndAfter(), that.getRunAtAndAfter())
                 && Objects.equals(getRunUntil(), that.getRunUntil());
     }
@@ -95,14 +95,14 @@ public abstract class BaseSchedule implements Schedule {
     }
 
     /**
-     * Builder implementation for {@link BaseSchedule} subclasses.
+     * Builder implementation for {@link BoundedSchedule} subclasses.
      *
      * @param <B> type of the builder
      * @param <S> type of the object to be built
      *
      * @author Spencer Pearson (spencerpearson at dropbox dot com)
      */
-    protected abstract static class Builder<B extends Builder<B, S>, S extends BaseSchedule> extends OvalBuilder<S> {
+    protected abstract static class Builder<B extends Builder<B, S>, S extends BoundedSchedule> extends OvalBuilder<S> {
         @NotNull
         @ValidateWithMethod(methodName = "validateRunAtAndAfter", parameterType = Instant.class)
         protected Instant _runAtAndAfter;

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
 @Loggable
-public final class NeverSchedule extends BaseSchedule {
+public final class NeverSchedule extends BoundedSchedule {
 
     /**
      * The only instance of {@code NeverSchedule}, since they're all identical.
@@ -61,7 +61,7 @@ public final class NeverSchedule extends BaseSchedule {
      *
      * @author Spencer Pearson (spencerpearson at dropbox dot com)
      */
-    private static final class Builder extends BaseSchedule.Builder<Builder, NeverSchedule> {
+    private static final class Builder extends BoundedSchedule.Builder<Builder, NeverSchedule> {
 
         private static final Builder INSTANCE = new Builder();
         private Builder() {

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/NeverSchedule.java
@@ -16,6 +16,7 @@
 package com.arpnetworking.metrics.portal.scheduling.impl;
 
 import com.arpnetworking.logback.annotations.Loggable;
+import com.arpnetworking.metrics.portal.scheduling.Schedule;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -26,16 +27,13 @@ import java.util.Optional;
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
 @Loggable
-public final class NeverSchedule extends BoundedSchedule {
-
+public final class NeverSchedule implements Schedule {
     /**
      * The only instance of {@code NeverSchedule}, since they're all identical.
      */
-    private static final NeverSchedule INSTANCE = new NeverSchedule(Builder.INSTANCE);
+    private static final NeverSchedule INSTANCE = new NeverSchedule();
 
-    private NeverSchedule(final Builder builder) {
-        super(builder);
-    }
+    private NeverSchedule() {}
 
     public static NeverSchedule getInstance() {
         return INSTANCE;
@@ -47,30 +45,12 @@ public final class NeverSchedule extends BoundedSchedule {
     }
 
     @Override
-    protected Optional<Instant> unboundedNextRun(final Optional<Instant> lastRun) {
+    public Optional<Instant> nextRun(final Optional<Instant> lastRun) {
         return Optional.empty();
     }
 
     @Override
     public <T> T accept(final Visitor<T> visitor) {
         return visitor.visitNever(this);
-    }
-
-    /**
-     * Implementation of builder pattern for {@link NeverSchedule}.
-     *
-     * @author Spencer Pearson (spencerpearson at dropbox dot com)
-     */
-    private static final class Builder extends BoundedSchedule.Builder<Builder, NeverSchedule> {
-
-        private static final Builder INSTANCE = new Builder();
-        private Builder() {
-            super(NeverSchedule::new);
-        }
-
-        @Override
-        protected Builder self() {
-            return this;
-        }
     }
 }

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/OneOffSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/OneOffSchedule.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
 @Loggable
-public final class OneOffSchedule extends BaseSchedule {
+public final class OneOffSchedule extends BoundedSchedule {
 
     private OneOffSchedule(final Builder builder) {
         super(builder);
@@ -62,7 +62,7 @@ public final class OneOffSchedule extends BaseSchedule {
      *
      * @author Spencer Pearson (spencerpearson at dropbox dot com)
      */
-    public static final class Builder extends BaseSchedule.Builder<Builder, OneOffSchedule> {
+    public static final class Builder extends BoundedSchedule.Builder<Builder, OneOffSchedule> {
         /**
          * Public constructor.
          */

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
 @Loggable
-public final class PeriodicSchedule extends BaseSchedule {
+public final class PeriodicSchedule extends BoundedSchedule {
 
     private final ChronoUnit _period;
     private final long _periodCount;
@@ -126,7 +126,7 @@ public final class PeriodicSchedule extends BaseSchedule {
      *
      * @author Spencer Pearson (spencerpearson at dropbox dot com)
      */
-    public static final class Builder extends BaseSchedule.Builder<Builder, PeriodicSchedule> {
+    public static final class Builder extends BoundedSchedule.Builder<Builder, PeriodicSchedule> {
         private long _periodCount = 1;
         @NotNull
         private ChronoUnit _period;

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/PeriodicSchedule.java
@@ -30,8 +30,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Schedule for a job that repeats periodically.
+ * Schedule for a job that repeats periodically within some bounded window of time.
+ * <p>
+ * This schedule respects backfills. If the lastRun is not the most recent period,
+ * the schedule will yield all periods since until it is caught up.
+ * <p>
+ * If this behavior is not required and you only care that a job attempts to execute
+ * periodically, you should instead use a {@code UnboundedPeriodicSchedule}.
  *
+ * @see UnboundedPeriodicSchedule
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
 @Loggable

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicSchedule.java
@@ -39,49 +39,37 @@ import java.util.Optional;
  * <p>
  * <b>WARNING:</b>
  * This behavior means that jobs with this schedule will ignore previously missed runs
- * - if you need backfills you should instead use a standard {@link PeriodicSchedule}.
+ * - if you need backfills you should instead use a standard {@code PeriodicSchedule}.
  *
+ * @see PeriodicSchedule
  * @author Christian Briones (cbriones at dropbox dot com)
  */
 @Loggable
 public final class UnboundedPeriodicSchedule implements Schedule {
 
-    private final ChronoUnit _period;
-    private final long _periodCount;
+    private final Duration _fullPeriod;
     private final Clock _clock;
 
     private UnboundedPeriodicSchedule(final Builder builder) {
-        _period = builder._period;
-        _periodCount = builder._periodCount;
+        _fullPeriod = Duration.of(builder._periodCount, builder._period);
         _clock = builder._clock;
     }
 
     @Override
     public Optional<Instant> nextRun(final Optional<Instant> lastRun) {
-        final Duration fullPeriod = Duration.of(_periodCount, _period);
-
         final Instant now = _clock.instant();
         final Instant start = lastRun
                 .filter(run -> run.compareTo(now) >= 0)
-                .map(run -> run.plus(fullPeriod)) // Avoid repeating the same period.
+                .map(run -> run.plus(_fullPeriod)) // Avoid repeating the same period.
                 .orElse(now);
 
-        final long epochMillis = start.toEpochMilli();
-        final Instant nextRun = Instant.ofEpochMilli((epochMillis / fullPeriod.toMillis()) * fullPeriod.toMillis());
-        return Optional.of(nextRun);
+        final long excessMillis = start.toEpochMilli() % _fullPeriod.toMillis();
+        return Optional.of(start.minusMillis(excessMillis));
     }
 
     @Override
     public <T> T accept(final Visitor<T> visitor) {
         return visitor.visitUnboundedPeriodic(this);
-    }
-
-    public ChronoUnit getPeriod() {
-        return _period;
-    }
-
-    public long getPeriodCount() {
-        return _periodCount;
     }
 
     @Override
@@ -93,21 +81,19 @@ public final class UnboundedPeriodicSchedule implements Schedule {
             return false;
         }
         final UnboundedPeriodicSchedule that = (UnboundedPeriodicSchedule) o;
-        return _periodCount == that._periodCount
-                && _period == that._period
+        return Objects.equal(_fullPeriod, that._fullPeriod)
                 && Objects.equal(_clock, that._clock);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_period, _periodCount, _clock);
+        return Objects.hashCode(_fullPeriod, _clock);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("_period", _period)
-                .add("_periodCount", _periodCount)
+                .add("_fullPeriod", _fullPeriod)
                 .add("_clock", _clock)
                 .toString();
     }
@@ -119,7 +105,8 @@ public final class UnboundedPeriodicSchedule implements Schedule {
      */
     public static final class Builder extends OvalBuilder<UnboundedPeriodicSchedule> {
         @Min(1)
-        private long _periodCount = 1;
+        @NotNull
+        private Long _periodCount = 1L; // This must be boxed or else codegen fails.
         @NotNull
         private ChronoUnit _period;
         @NotNull

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicSchedule.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.portal.scheduling.impl;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import com.arpnetworking.logback.annotations.Loggable;
+import com.arpnetworking.metrics.portal.scheduling.Schedule;
+import com.google.common.annotations.VisibleForTesting;
+import net.sf.oval.constraint.Min;
+import net.sf.oval.constraint.NotNull;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+/**
+ * A schedule for a job that repeats periodically, without any bounds or regard
+ * for the last completed time.
+ * <p>
+ * The next run for a unbounded periodic schedule is always the start of the
+ * most recent period of the schedule, as aligned with the start of the epoch.
+ * <p>
+ * <b>WARNING:</b>
+ * This behavior means that jobs with this schedule will ignore previously missed runs
+ * - if you need backfills you should instead use a standard {@link PeriodicSchedule}.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+@Loggable
+public final class UnboundedPeriodicSchedule implements Schedule {
+
+    private final ChronoUnit _period;
+    private final long _periodCount;
+    private final Clock _clock;
+
+    private UnboundedPeriodicSchedule(final Builder builder) {
+        _period = builder._period;
+        _periodCount = builder._periodCount;
+        _clock = builder._clock;
+    }
+
+    @Override
+    public Optional<Instant> nextRun(final Optional<Instant> lastRun) {
+        final Duration fullPeriod = Duration.of(_periodCount, _period);
+
+        final Instant now = _clock.instant();
+        final Instant start = lastRun
+                .filter(run -> run.compareTo(now) >= 0)
+                .map(run -> run.plus(fullPeriod)) // Avoid repeating the same period.
+                .orElse(now);
+
+        final long epochMillis = start.toEpochMilli();
+        final Instant nextRun = Instant.ofEpochMilli((epochMillis / fullPeriod.toMillis()) * fullPeriod.toMillis());
+        return Optional.of(nextRun);
+    }
+
+    @Override
+    public <T> T accept(final Visitor<T> visitor) {
+        return visitor.visitUnboundedPeriodic(this);
+    }
+
+    public ChronoUnit getPeriod() {
+        return _period;
+    }
+
+    public long getPeriodCount() {
+        return _periodCount;
+    }
+
+    /**
+     * Implementation of builder pattern for {@link UnboundedPeriodicSchedule}.
+     *
+     * @author Christian Briones (cbriones at dropbox dot com)
+     */
+    public static final class Builder extends OvalBuilder<UnboundedPeriodicSchedule> {
+        @Min(1)
+        private long _periodCount = 1;
+        @NotNull
+        private ChronoUnit _period;
+        @NotNull
+        private Clock _clock = Clock.systemUTC();
+
+        /**
+         * Default constructor.
+         */
+        public Builder() {
+            super(UnboundedPeriodicSchedule::new);
+        }
+
+        /**
+         * The period with which the schedule fires. Required. Cannot be null.
+         *
+         * @param period The period.
+         * @return This instance of Builder.
+         */
+        public Builder setPeriod(final ChronoUnit period) {
+            _period = period;
+            return this;
+        }
+
+        /**
+         * The number of periods with which the schedule fires. Defaults to 1.
+         *
+         * @param periodCount The period count.
+         * @return This instance of Builder.
+         */
+        public Builder setPeriodCount(final long periodCount) {
+            _periodCount = periodCount;
+            return this;
+        }
+
+        /**
+         * The clock to use. Defaults to {@link Clock#systemUTC()}.
+         *
+         * Should only be used for testing purposes.
+         *
+         * @param clock The clock to use.
+         * @return This instance of Builder.
+         */
+        @VisibleForTesting
+        protected Builder setClock(final Clock clock) {
+            _clock = clock;
+            return this;
+        }
+    }
+}

--- a/app/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicSchedule.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicSchedule.java
@@ -19,6 +19,8 @@ import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.arpnetworking.metrics.portal.scheduling.Schedule;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import net.sf.oval.constraint.Min;
 import net.sf.oval.constraint.NotNull;
 
@@ -80,6 +82,34 @@ public final class UnboundedPeriodicSchedule implements Schedule {
 
     public long getPeriodCount() {
         return _periodCount;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final UnboundedPeriodicSchedule that = (UnboundedPeriodicSchedule) o;
+        return _periodCount == that._periodCount
+                && _period == that._period
+                && Objects.equal(_clock, that._clock);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(_period, _periodCount, _clock);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("_period", _period)
+                .add("_periodCount", _periodCount)
+                .add("_clock", _clock)
+                .toString();
     }
 
     /**

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -70,7 +70,7 @@ import com.arpnetworking.metrics.portal.scheduling.JobCoordinator;
 import com.arpnetworking.metrics.portal.scheduling.JobExecutorActor;
 import com.arpnetworking.metrics.portal.scheduling.JobMessageExtractor;
 import com.arpnetworking.metrics.portal.scheduling.Schedule;
-import com.arpnetworking.metrics.portal.scheduling.impl.PeriodicSchedule;
+import com.arpnetworking.metrics.portal.scheduling.impl.UnboundedPeriodicSchedule;
 import com.arpnetworking.play.configuration.ConfigurationHelper;
 import com.arpnetworking.rollups.ConsistencyChecker;
 import com.arpnetworking.rollups.MetricsDiscovery;
@@ -112,8 +112,6 @@ import scala.concurrent.duration.FiniteDuration;
 
 import java.net.URI;
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -232,16 +230,9 @@ public class MainModule extends AbstractModule {
         final FiniteDuration interval = ConfigurationHelper.getFiniteDuration(config, "alerting.execution.defaultInterval");
         final java.time.Duration queryOffset = ConfigurationHelper.getJavaDuration(config, "alerting.execution.queryOffset");
 
-        // The Epoch start is arbitrary - we can't use Instant.MIN since a ZonedDateTime
-        // cannot be constructed from it.
-        //
-        // All alerts should be unconditionally valid for periodic execution after
-        // some arbitrary point in the past, so the epoch is as good as any.
-        final Schedule defaultAlertSchedule = new PeriodicSchedule.Builder()
+        final Schedule defaultAlertSchedule = new UnboundedPeriodicSchedule.Builder()
                 .setPeriod(TimeAdapters.toChronoUnit(interval.unit()))
                 .setPeriodCount(interval.length())
-                .setZone(ZoneOffset.UTC)
-                .setRunAtAndAfter(Instant.EPOCH)
                 .build();
         return new AlertExecutionContext(defaultAlertSchedule, executor, queryOffset);
     }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/BaseScheduleTest.java
@@ -23,7 +23,7 @@ import java.time.Instant;
 import java.util.Optional;
 
 /**
- * Tests for {@link BaseSchedule}.
+ * Tests for {@link BoundedSchedule}.
  *
  * @author Spencer Pearson (spencerpearson at dropbox dot com)
  */
@@ -46,7 +46,7 @@ public final class BaseScheduleTest {
 
     private static final Instant T0 = Instant.parse("2018-01-01T00:00:00Z");
 
-    private static final class MinimalSchedule extends BaseSchedule {
+    private static final class MinimalSchedule extends BoundedSchedule {
 
         private MinimalSchedule(final Builder builder) {
             super(builder);
@@ -67,7 +67,7 @@ public final class BaseScheduleTest {
          *
          * @author Spencer Pearson (spencerpearson at dropbox dot com)
          */
-        private static final class Builder extends BaseSchedule.Builder<Builder, MinimalSchedule> {
+        private static final class Builder extends BoundedSchedule.Builder<Builder, MinimalSchedule> {
             private Builder() {
                 super(MinimalSchedule::new);
             }

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicScheduleTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicScheduleTest.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.portal.scheduling.impl;
 
 import com.arpnetworking.commons.java.time.ManualClock;
 import com.arpnetworking.metrics.portal.scheduling.Schedule;
+import net.sf.oval.exception.ConstraintsViolatedException;
 import org.junit.Test;
 
 import java.time.Clock;
@@ -38,6 +39,14 @@ import static org.junit.Assert.assertThat;
  */
 public final class UnboundedPeriodicScheduleTest {
     private static final Instant CLOCK_START = Instant.parse("2020-07-30T10:00:00Z");
+
+    @Test(expected = ConstraintsViolatedException.class)
+    public void testItDisallowsZeroPeriod() {
+        new UnboundedPeriodicSchedule.Builder()
+                .setPeriodCount(0)
+                .setPeriod(ChronoUnit.MINUTES)
+                .build();
+    }
 
     @Test
     public void testLastRunEmptyOrInThePast() {

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicScheduleTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicScheduleTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.scheduling.impl;
+
+import com.arpnetworking.commons.java.time.ManualClock;
+import com.arpnetworking.metrics.portal.scheduling.Schedule;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests for {@link UnboundedPeriodicSchedule}.
+ */
+public class UnboundedPeriodicScheduleTest {
+    private final static Instant CLOCK_START = Instant.parse("2020-07-30T10:00:00Z");
+
+    @Test
+    public void testLastRunEmptyOrInThePast() {
+        final Clock clock = Clock.fixed(CLOCK_START, ZoneOffset.UTC);
+        final Schedule schedule =
+                new UnboundedPeriodicSchedule.Builder()
+                    .setClock(clock)
+                    .setPeriodCount(30)
+                    .setPeriod(ChronoUnit.MINUTES)
+                    .build();
+
+        Optional<Instant> nextScheduled = schedule.nextRun(Optional.empty());
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START));
+
+        nextScheduled = schedule.nextRun(Optional.of(CLOCK_START.minus(1, ChronoUnit.DAYS)));
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START));
+
+        nextScheduled = schedule.nextRun(Optional.of(Instant.EPOCH));
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START));
+    }
+
+    @Test
+    public void testLaggingJobIgnoresThePast() {
+        final Duration fullPeriod = Duration.of(30, ChronoUnit.MINUTES);
+        final ManualClock clock = new ManualClock(CLOCK_START, fullPeriod, ZoneOffset.UTC);
+        final Schedule schedule =
+                new UnboundedPeriodicSchedule.Builder()
+                        .setClock(clock)
+                        .setPeriodCount(30)
+                        .setPeriod(ChronoUnit.MINUTES)
+                        .build();
+
+        clock.tick();
+        Optional<Instant> nextScheduled = schedule.nextRun(Optional.of(CLOCK_START));
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START.plus(fullPeriod)));
+
+        clock.tick();
+        nextScheduled = schedule.nextRun(Optional.empty());
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START.plus(fullPeriod.multipliedBy(2))));
+    }
+
+    @Test
+    public void testWhenLastRunIsAlreadyAfterNextScheduled() {
+        final Clock clock = Clock.fixed(CLOCK_START, ZoneOffset.UTC);
+        final Schedule schedule =
+                new UnboundedPeriodicSchedule.Builder()
+                        .setClock(clock)
+                        .setPeriodCount(30)
+                        .setPeriod(ChronoUnit.MINUTES)
+                        .build();
+        final Duration fullPeriod = Duration.of(30, ChronoUnit.MINUTES);
+
+        Optional<Instant> nextScheduled = schedule.nextRun(Optional.of(CLOCK_START));
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START.plus(fullPeriod)));
+
+        nextScheduled = schedule.nextRun(Optional.of(CLOCK_START.plus(1, ChronoUnit.SECONDS)));
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START.plus(fullPeriod)));
+
+        final Duration fivePeriods = fullPeriod.multipliedBy(5);
+        nextScheduled = schedule.nextRun(Optional.of(CLOCK_START.plus(fivePeriods)));
+        assertThat(nextScheduled.isPresent(), is(true));
+        assertThat(nextScheduled.get(), equalTo(CLOCK_START.plus(fivePeriods).plus(fullPeriod)));
+    }
+}

--- a/test/java/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicScheduleTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/scheduling/impl/UnboundedPeriodicScheduleTest.java
@@ -33,9 +33,11 @@ import static org.junit.Assert.assertThat;
 
 /**
  * Unit tests for {@link UnboundedPeriodicSchedule}.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
  */
-public class UnboundedPeriodicScheduleTest {
-    private final static Instant CLOCK_START = Instant.parse("2020-07-30T10:00:00Z");
+public final class UnboundedPeriodicScheduleTest {
+    private static final Instant CLOCK_START = Instant.parse("2020-07-30T10:00:00Z");
 
     @Test
     public void testLastRunEmptyOrInThePast() {


### PR DESCRIPTION
Introduce an unbounded periodic schedule, motivated by the alerting use case since alerts do not need backfilling behavior.

By analogy I've also renamed the `BaseSchedule` class to `BoundedSchedule` to make it clear that it makes certain assumptions about the subtype behavior. I've also refactored `NeverSchedule` to no longer be bounded since that didn't make much sense.

EDITED: This was originally just to collect feedback but I decided to mark this as a proper PR.