### PR TITLE
Stop using Optional in FailableMessage since it's serialized

### DIFF
--- a/app/com/arpnetworking/rollups/FailableMessage.java
+++ b/app/com/arpnetworking/rollups/FailableMessage.java
@@ -35,18 +35,19 @@ public abstract class FailableMessage implements Serializable {
      * @param builder subclass builder
      */
     protected FailableMessage(final Builder<?, ?> builder) {
-        _failure = Optional.ofNullable(builder._failure);
+        _failure = builder._failure;
     }
 
     public boolean isFailure() {
-        return _failure.isPresent();
+        return _failure != null;
     }
 
     public Optional<Throwable> getFailure() {
-        return _failure;
+        return Optional.ofNullable(_failure);
     }
 
-    private final Optional<Throwable> _failure;
+    @Nullable
+    private final Throwable _failure;
     private static final long serialVersionUID = -255159605861224426L;
 
 

--- a/app/com/arpnetworking/rollups/LastDataPointsMessage.java
+++ b/app/com/arpnetworking/rollups/LastDataPointsMessage.java
@@ -72,7 +72,9 @@ public final class LastDataPointsMessage extends FailableMessage {
     private final String _rollupMetricName;
     private final RollupPeriod _period;
     private final ImmutableMultimap<String, String> _tags;
+    @Nullable
     private final Instant _sourceLastDataPointTime;
+    @Nullable
     private final Instant _rollupLastDataPointTime;
     private static final long serialVersionUID = 2800761302248621189L;
 


### PR DESCRIPTION
Relevant excerpt from the stack trace

```json
{
    "message":"Failed to serialize remote message [class com.arpnetworking.rollups.RollupExecutor$FinishRollupMessage] using serializer [class akka.serialization.JavaSerializer]. Transient association error (association remains live)",
    "cause": {
        "type":"java.io.NotSerializableException",
        "message":"java.util.Optional"
    }
}
```