### PR TITLE
stop polling the schedule every tick within JobExecutorActor

### DIFF
--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreator.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreator.java
@@ -303,7 +303,7 @@ public class DailyPartitionCreator extends AbstractActorWithTimers {
         // it still returns a "non-empty" void result and so we can't use the
         // ordinarily more appropriate SqlUpdate type.
         final SqlQuery sql = _ebeanServer.createSqlQuery(
-                "select * from portal.create_daily_partition(?::text, ?::text, ?::date, ?::date)")
+                "select * from create_daily_partition(?::text, ?::text, ?::date, ?::date)")
                 .setParameter(1, schema)
                 .setParameter(2, table)
                 .setParameter(3, startDate)

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreator.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreator.java
@@ -303,7 +303,7 @@ public class DailyPartitionCreator extends AbstractActorWithTimers {
         // it still returns a "non-empty" void result and so we can't use the
         // ordinarily more appropriate SqlUpdate type.
         final SqlQuery sql = _ebeanServer.createSqlQuery(
-                "select * from create_daily_partition(?::text, ?::text, ?::date, ?::date)")
+                "select * from portal.create_daily_partition(?::text, ?::text, ?::date, ?::date)")
                 .setParameter(1, schema)
                 .setParameter(2, table)
                 .setParameter(3, startDate)

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -245,10 +245,11 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                 1);
 
         if (!_nextRun.isPresent()) {
-            // First tick since clearing next run, refresh.
+            // This could be the first time we're running
             _nextRun = cachedJob.getSchedule().nextRun(cachedJob.getLastRun());
         }
         if (!_nextRun.isPresent()) {
+            // The schedule is definitely not present.
             LOGGER.info()
                     .setMessage("job has no more scheduled runs")
                     .addData("cachedJob", cachedJob)
@@ -270,9 +271,8 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                         .log();
                 killSelf();
             } finally {
-                // This run was attempted so we should clear it and recompute
-                // the scheduled time on the next tick.
-                _nextRun = Optional.empty();
+                // This run was attempted so we should reset it
+                _nextRun = cachedJob.getSchedule().nextRun(cachedJob.getLastRun());
             }
         }
     }

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -245,11 +245,9 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                 1);
 
         if (!_nextRun.isPresent()) {
-            // This could be the first time we're running
             _nextRun = cachedJob.getSchedule().nextRun(cachedJob.getLastRun());
         }
         if (!_nextRun.isPresent()) {
-            // The schedule is definitely not present.
             LOGGER.info()
                     .setMessage("job has no more scheduled runs")
                     .addData("cachedJob", cachedJob)

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -270,9 +270,6 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                         .addData("scheduled", _nextRun.get())
                         .log();
                 killSelf();
-            } finally {
-                // This run was attempted so we should reset it
-                _nextRun = cachedJob.getSchedule().nextRun(cachedJob.getLastRun());
             }
         }
     }
@@ -307,6 +304,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
 
     private void jobCompleted(final JobCompleted<?> message) {
         _currentlyExecuting = false;
+        _nextRun = Optional.empty();
         if (!_cachedJob.isPresent()) {
             LOGGER.warn()
                     .setMessage("uninitialized, but got completion message (perhaps from previous life?)")

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -73,6 +73,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
     private final PeriodicMetrics _periodicMetrics;
     private boolean _currentlyExecuting = false;
     private Optional<CachedJob<T>> _cachedJob = Optional.empty();
+    private Optional<Instant> _nextRun = Optional.empty();
 
     /**
      * Props factory.
@@ -243,8 +244,11 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                         + "/tick",
                 1);
 
-        final Optional<Instant> nextRun = cachedJob.getSchedule().nextRun(cachedJob.getLastRun());
-        if (!nextRun.isPresent()) {
+        if (!_nextRun.isPresent()) {
+            // First tick since clearing next run, refresh.
+            _nextRun = cachedJob.getSchedule().nextRun(cachedJob.getLastRun());
+        }
+        if (!_nextRun.isPresent()) {
             LOGGER.info()
                     .setMessage("job has no more scheduled runs")
                     .addData("cachedJob", cachedJob)
@@ -253,18 +257,22 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
             return;
         }
 
-        if (_clock.instant().isBefore(nextRun.get().minus(EXECUTION_SLOP))) {
-            scheduleTickFor(nextRun.get());
+        if (_clock.instant().isBefore(_nextRun.get().minus(EXECUTION_SLOP))) {
+            scheduleTickFor(_nextRun.get());
         } else {
             try {
-                attemptExecuteAndUpdateRepository(nextRun.get());
+                attemptExecuteAndUpdateRepository(_nextRun.get());
             } catch (final NoSuchJobException error) {
                 LOGGER.warn()
                         .setMessage("attempted to start executing job, but job no longer exists in repository")
                         .addData("ref", cachedJob.getRef())
-                        .addData("scheduled", nextRun.get())
+                        .addData("scheduled", _nextRun.get())
                         .log();
                 killSelf();
+            } finally {
+                // This run was attempted so we should clear it and recompute
+                // the scheduled time on the next tick.
+                _nextRun = Optional.empty();
             }
         }
     }


### PR DESCRIPTION
The executor doesn't play well with the UnboundedExecutionSchedule since it recomputes the nextRun time on every tick. I've changed it to cache the computed next run and only recompute it when the execution has been attempted (either succeeds or fails). This should not have different behavior with the scheduling granularity we currently deal with.