### PR TITLE
Use JDBC conn directly within DailyPartitionCreator

### DIFF
--- a/app/models/internal/impl/DefaultAlertEvaluationResult.java
+++ b/app/models/internal/impl/DefaultAlertEvaluationResult.java
@@ -84,19 +84,26 @@ public final class DefaultAlertEvaluationResult implements AlertEvaluationResult
             return false;
         }
         final DefaultAlertEvaluationResult that = (DefaultAlertEvaluationResult) o;
-        return Objects.equal(_firingTags, that._firingTags);
+        return Objects.equal(_seriesName, that._seriesName)
+                && Objects.equal(_firingTags, that._firingTags)
+                && Objects.equal(_groupBys, that._groupBys)
+                && Objects.equal(_queryEndTime, that._queryEndTime)
+                && Objects.equal(_queryStartTime, that._queryStartTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_firingTags);
+        return Objects.hashCode(_seriesName, _firingTags, _groupBys, _queryEndTime, _queryStartTime);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("seriesName", _seriesName)
-                .add("firingTags", _firingTags)
+                .add("_seriesName", _seriesName)
+                .add("_firingTags", _firingTags)
+                .add("_groupBys", _groupBys)
+                .add("_queryEndTime", _queryEndTime)
+                .add("_queryStartTime", _queryStartTime)
                 .toString();
     }
 

--- a/app/models/internal/impl/DefaultReportResult.java
+++ b/app/models/internal/impl/DefaultReportResult.java
@@ -17,6 +17,7 @@
 package models.internal.impl;
 
 import com.arpnetworking.logback.annotations.Loggable;
+import com.google.common.base.MoreObjects;
 import models.internal.reports.Report;
 
 
@@ -31,4 +32,23 @@ public final class DefaultReportResult implements Report.Result {
      * Default Constructor.
      */
     public DefaultReportResult() {}
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .toString();
+    }
 }

--- a/test/java/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreatorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreatorTest.java
@@ -127,7 +127,7 @@ public class DailyPartitionCreatorTest {
         final ActorRef ref = createActor();
 
         // The actor will tick on startup.
-        ExecuteCall call = _probe.expectMsgClass(Duration.ofMinutes(5), ExecuteCall.class);
+        ExecuteCall call = _probe.expectMsgClass(ExecuteCall.class);
         long clockDifference = ChronoUnit.DAYS.between(
                 call.getStart(),
                 ZonedDateTime.ofInstant(_clock.instant(), _clock.getZone())
@@ -144,7 +144,7 @@ public class DailyPartitionCreatorTest {
             // Clock moved 1 day
             _clock.tick();
             ref.tell(DailyPartitionCreator.TICK, _probe.getRef());
-            call = _probe.expectMsgClass(Duration.ofMinutes(5), ExecuteCall.class);
+            call = _probe.expectMsgClass(ExecuteCall.class);
 
             assertThat(call.getSchema(), equalTo(TEST_SCHEMA));
             assertThat(call.getTable(), equalTo(TEST_TABLE));
@@ -238,4 +238,4 @@ public class DailyPartitionCreatorTest {
                     .toString();
         }
     }
-}
+

--- a/test/java/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreatorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/alerts/impl/DailyPartitionCreatorTest.java
@@ -238,4 +238,4 @@ public class DailyPartitionCreatorTest {
                     .toString();
         }
     }
-
+}

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -172,6 +173,22 @@ public abstract class JobExecutionRepositoryIT<T> {
                 return 0;
             }
         }).apply(lastRun.get());
+    }
+
+    @Test
+    public void testJobScheduledInThePast() {
+        final T result = newResult();
+        final Instant scheduled = Instant.parse("2019-01-01T00:00:00Z");
+
+        _repository.jobStarted(_jobId, _organization, scheduled);
+        _repository.jobSucceeded(_jobId, _organization, scheduled, result);
+
+        final Optional<JobExecution.Success<T>> lastRun = _repository.getLastSuccess(_jobId, _organization);
+        if (!lastRun.isPresent()) {
+            fail("Expected a non-empty success to be returned.");
+        }
+        assertThat(lastRun.get().getScheduled(), is(scheduled));
+        assertThat(lastRun.get().getResult(), is(result));
     }
 
     @Test


### PR DESCRIPTION
Ebean's SQLQuery doesn't appear to be working, and SQLUpdate does not
support SELECT statements (which is necessary to call the function).

The existing test suite didn't catch this issue because it created the
partitions for the current date during migrations, and so the partition
creation would silently fail while the tests would still pass. I've
added a new test which creates a scheduled event in the past, which
catches this oversight.

I've verified this locally by running the container separately and then executing the test suite. The expected partitions exist in the database.