### PR TITLE
bugfix: add alert id to where clause when inserting an execution

### DIFF
--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
@@ -115,6 +115,7 @@ public final class DatabaseAlertExecutionRepository implements AlertExecutionRep
                         .where()
                         .eq("organization.uuid", org.get().getUuid())
                         .eq("scheduled", scheduled)
+                        .eq("alert_id", jobId)
                         .findOneOrEmpty()
         );
         final AlertExecution newOrUpdatedExecution = existingExecution.orElseGet(AlertExecution::new);

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseAlertExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseAlertExecutionRepositoryIT.java
@@ -44,12 +44,9 @@ public class DatabaseAlertExecutionRepositoryIT extends JobExecutionRepositoryIT
     private ActorSystem _actorSystem;
 
     @Override
-    public JobExecutionRepository<AlertEvaluationResult> setUpRepository(final Organization organization, final UUID jobId) {
+    public JobExecutionRepository<AlertEvaluationResult> setUpRepository(final Organization organization) {
         final EbeanServer server = EbeanServerHelper.getMetricsDatabase();
         final EbeanServer adminServer = EbeanServerHelper.getAdminMetricsDatabase();
-
-        // DatabaseAlertExecutionRepository does not validate that the JobID is a valid AlertID since those
-        // references are not constrained in the underlying execution table.
 
         final models.ebean.Organization ebeanOrganization = TestBeanFactory.createEbeanOrganization();
         ebeanOrganization.setUuid(organization.getId());
@@ -69,6 +66,12 @@ public class DatabaseAlertExecutionRepositoryIT extends JobExecutionRepositoryIT
     }
 
     @Override
+    public void ensureJobExists(final Organization organization, final UUID jobId) {
+        // DatabaseAlertExecutionRepository does not validate that the JobID is a valid AlertID since those
+        // references are not constrained in the underlying execution table.
+    }
+
+    @Override
     public void tearDown() {
         super.tearDown();
         TestKit.shutdownActorSystem(_actorSystem);
@@ -79,7 +82,7 @@ public class DatabaseAlertExecutionRepositoryIT extends JobExecutionRepositoryIT
         final Instant queryEnd = Instant.now();
         return new DefaultAlertEvaluationResult.Builder()
                 .setSeriesName("example-series")
-                .setFiringTags(ImmutableList.of(ImmutableMap.of("tag-name", "tag-value")))
+                .setFiringTags(ImmutableList.of(ImmutableMap.of("tag-name", UUID.randomUUID().toString())))
                 .setGroupBys(ImmutableList.of("tag-name"))
                 .setQueryStartTime(queryEnd.minus(Duration.ofMinutes(1)))
                 .setQueryEndTime(queryEnd)

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/DatabaseReportExecutionRepositoryIT.java
@@ -34,12 +34,23 @@ import java.util.UUID;
  */
 public class DatabaseReportExecutionRepositoryIT extends JobExecutionRepositoryIT<Report.Result> {
     @Override
-    JobExecutionRepository<Report.Result> setUpRepository(final Organization organization, final UUID jobId) {
+    JobExecutionRepository<Report.Result> setUpRepository(final Organization organization) {
         final EbeanServer server = EbeanServerHelper.getMetricsDatabase();
         final DatabaseReportExecutionRepository repository = new DatabaseReportExecutionRepository(server);
         final models.ebean.Organization ebeanOrganization = TestBeanFactory.createEbeanOrganization();
         ebeanOrganization.setUuid(organization.getId());
         server.save(ebeanOrganization);
+
+        return repository;
+    }
+
+    @Override
+    void ensureJobExists(final Organization organization, final UUID jobId) {
+        final EbeanServer server = EbeanServerHelper.getMetricsDatabase();
+        final models.ebean.Organization ebeanOrganization = models.ebean.Organization.findByOrganization(
+                server,
+                organization
+        ).orElseThrow(() -> new IllegalStateException("developer error: test organization must exist"));
 
         final models.ebean.Report ebeanReport = TestBeanFactory.createEbeanReport(ebeanOrganization);
         ebeanReport.setUuid(jobId);
@@ -48,8 +59,6 @@ public class DatabaseReportExecutionRepositoryIT extends JobExecutionRepositoryI
         server.save(ebeanReport.getSchedule());
         server.save(ebeanReport.getReportSource());
         server.save(ebeanReport);
-
-        return repository;
     }
 
     @Override


### PR DESCRIPTION
A silly bug, but it's happened nonetheless.

## Expectation
We want to update an alert execution, so we first check it exists by querying for the most recent execution _for this particular ID_.

## Reality
We want to update an alert execution, so we first check it exists by querying for the most recent execution. 

Notice that the above never involves Alert ID.

---

Fortunately, this blows up because we only expect to ever retrieve a single result, instead of several.
The fix is straightforward: add the missing where clause. I've also included a sanity check test that I used to reproduce and identify the issue.