### PR TITLE
default to empty values for version/enabled

### DIFF
--- a/app/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepository.java
@@ -214,7 +214,11 @@ public class PluggableAlertRepository implements AlertRepository {
         try {
             group = _objectMapper.readValue(bufferedStream, AlertGroup.class);
         } catch (final IOException e) {
-            throw new RuntimeException("Could not load alerts", e);
+            LOGGER.error()
+                .setMessage("Could not load alert definitions")
+                .setThrowable(e)
+                .log();
+            return;
         }
         final ImmutableMap.Builder<UUID, Alert> mapBuilder = ImmutableMap.builder();
         for (final SerializedAlert fsAlert : group.getAlerts()) {
@@ -323,7 +327,7 @@ public class PluggableAlertRepository implements AlertRepository {
             private List<SerializedAlert> _alerts;
             @NotNull
             @NotNegative
-            private Long _version;
+            private Long _version = 0L;
 
             /**
              * Default constructor.
@@ -413,7 +417,7 @@ public class PluggableAlertRepository implements AlertRepository {
 
             @NotNull
             @Nullable
-            private Boolean _enabled;
+            private Boolean _enabled = false;
 
             private ImmutableMap<String, Object> _additionalMetadata = ImmutableMap.of();
 

--- a/test/java/com/arpnetworking/metrics/portal/alerts/AlertExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/alerts/AlertExecutionContextTest.java
@@ -308,6 +308,20 @@ public class AlertExecutionContextTest {
         assertThat(result.getGroupBys(), equalTo(ImmutableList.of("os")));
     }
 
+    @Test
+    public void testEmptyResult() throws Exception {
+        final MetricsQueryResult mockResult = getTestcase("emptyResult");
+        when(_executor.executeQuery(any())).thenReturn(CompletableFuture.completedFuture(mockResult));
+        final AlertEvaluationResult result =
+                _context.execute(_alert, Instant.now())
+                        .toCompletableFuture()
+                        .get(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        assertThat(result.getSeriesName(), equalTo(TEST_METRIC));
+        assertThat(result.getFiringTags(), is(empty()));
+        assertThat(result.getGroupBys(), is(empty()));
+    }
+
     @Test(expected = ExecutionException.class)
     public void testQueryExecuteError() throws Exception {
         final Throwable queryError = new RuntimeException("Something went wrong");

--- a/test/java/com/arpnetworking/metrics/portal/alerts/AlertExecutionContextTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/alerts/AlertExecutionContextTest.java
@@ -308,20 +308,6 @@ public class AlertExecutionContextTest {
         assertThat(result.getGroupBys(), equalTo(ImmutableList.of("os")));
     }
 
-    @Test
-    public void testEmptyResult() throws Exception {
-        final MetricsQueryResult mockResult = getTestcase("emptyResult");
-        when(_executor.executeQuery(any())).thenReturn(CompletableFuture.completedFuture(mockResult));
-        final AlertEvaluationResult result =
-                _context.execute(_alert, Instant.now())
-                        .toCompletableFuture()
-                        .get(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-
-        assertThat(result.getSeriesName(), equalTo(TEST_METRIC));
-        assertThat(result.getFiringTags(), is(empty()));
-        assertThat(result.getGroupBys(), is(empty()));
-    }
-
     @Test(expected = ExecutionException.class)
     public void testQueryExecuteError() throws Exception {
         final Throwable queryError = new RuntimeException("Something went wrong");

--- a/test/java/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepositoryTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepositoryTest.java
@@ -16,6 +16,7 @@
 
 package com.arpnetworking.metrics.portal.alerts.impl;
 
+import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.arpnetworking.metrics.portal.config.ConfigProvider;
 import com.arpnetworking.metrics.portal.config.impl.StaticFileConfigProvider;
@@ -76,6 +77,7 @@ public class PluggableAlertRepositoryTest {
                 .build();
         _repository = new PluggableAlertRepository(
                 SerializationTestUtils.getApiObjectMapper(),
+                Mockito.mock(PeriodicMetrics.class),
                 new StaticFileConfigProvider(resourcePath),
                 _organization.getId()
         );
@@ -109,6 +111,7 @@ public class PluggableAlertRepositoryTest {
 
         final PluggableAlertRepository badRepository = new PluggableAlertRepository(
                 SerializationTestUtils.getApiObjectMapper(),
+                Mockito.mock(PeriodicMetrics.class),
                 mockConfigProvider,
                 _organization.getId()
         );

--- a/test/java/controllers/AlertControllerTest.java
+++ b/test/java/controllers/AlertControllerTest.java
@@ -15,6 +15,7 @@
  */
 package controllers;
 
+import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.alerts.AlertExecutionRepository;
 import com.arpnetworking.metrics.portal.alerts.AlertRepository;
 import com.arpnetworking.metrics.portal.alerts.impl.PluggableAlertRepository;
@@ -43,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import play.mvc.Result;
 import play.test.Helpers;
 
@@ -131,6 +133,7 @@ public final class AlertControllerTest {
             );
             final AlertRepository alertRepository = new PluggableAlertRepository(
                     OBJECT_MAPPER,
+                    Mockito.mock(PeriodicMetrics.class),
                     configProvider,
                     _organization.getId()
             );


### PR DESCRIPTION
These are not required fields, and on the serialization end they are
dropped when they are considered "zero values" e.g. 0 for long. Let's
just explicitly default to these.

Additionally we log the config error instead of completely failing to start up.