### PR TITLE
run anti-entropy when the pluggable alert repository reloads

### DIFF
--- a/app/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepository.java
@@ -290,7 +290,7 @@ public class PluggableAlertRepository implements AlertRepository {
         //
         // NOTE: Since nodes have their own copy of this repository, this will
         // effectively kick the coordinator N times on every reload, where N is
-        // the number of coordinators in the cluster.
+        // the number of nodes in the cluster.
         _alertJobCoordinator.ifPresent(ref -> {
             JobCoordinator.runAntiEntropy(ref, Duration.ofSeconds(5));
         });

--- a/test/java/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepositoryTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepositoryTest.java
@@ -90,7 +90,7 @@ public class PluggableAlertRepositoryTest {
                 new StaticFileConfigProvider(resourcePath),
                 _organization.getId(),
                 Duration.ofSeconds(1),
-                Optional.of(_probe.getRef())
+                _probe.getRef()
         );
         _repository.open();
 
@@ -130,7 +130,7 @@ public class PluggableAlertRepositoryTest {
                 mockConfigProvider,
                 _organization.getId(),
                 Duration.ofSeconds(1),
-                Optional.of(_probe.getRef())
+                _probe.getRef()
         );
 
         try {
@@ -229,9 +229,9 @@ public class PluggableAlertRepositoryTest {
                 new NullConfigProvider(),
                 _organization.getId(),
                 Duration.ofSeconds(1),
-                Optional.of(_probe.getRef())
+                _probe.getRef()
         );
-        repository.open();
+        repository.open(); // should trigger a timeout.
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/test/java/controllers/AlertControllerTest.java
+++ b/test/java/controllers/AlertControllerTest.java
@@ -15,6 +15,8 @@
  */
 package controllers;
 
+import akka.actor.ActorSystem;
+import akka.testkit.javadsl.TestKit;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.alerts.AlertExecutionRepository;
 import com.arpnetworking.metrics.portal.alerts.AlertRepository;
@@ -40,6 +42,7 @@ import models.internal.impl.DefaultAlert;
 import models.internal.impl.DefaultAlertEvaluationResult;
 import models.internal.impl.DefaultMetricsQuery;
 import models.view.alerts.AlertFiringState;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -53,7 +56,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -115,9 +117,13 @@ public final class AlertControllerTest {
     public abstract static class SharedSetup {
         protected Organization _organization;
         protected AlertController _controller;
+        private ActorSystem _actorSystem;
 
         @Before
         public void setUp() {
+            _actorSystem = ActorSystem.create();
+            final TestKit probe = new TestKit(_actorSystem);
+
             final OrganizationRepository organizationRepository = new DefaultOrganizationRepository();
             organizationRepository.open();
             final QueryResult<Organization> queryResult = organizationRepository.query(organizationRepository.createQuery().limit(
@@ -139,7 +145,7 @@ public final class AlertControllerTest {
                     configProvider,
                     _organization.getId(),
                     Duration.ofSeconds(1),
-                    Optional.empty()
+                    probe.getRef()
             );
             alertRepository.open();
 
@@ -151,6 +157,11 @@ public final class AlertControllerTest {
                     alertExecutionRepository,
                     organizationRepository
             );
+        }
+
+        @After
+        public void tearDown() {
+            TestKit.shutdownActorSystem(_actorSystem);
         }
 
         private ImmutableList<Alert> populateAlertExecutions(final AlertExecutionRepository alertExecutionRepository) {

--- a/test/java/controllers/AlertControllerTest.java
+++ b/test/java/controllers/AlertControllerTest.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -135,7 +136,8 @@ public final class AlertControllerTest {
                     OBJECT_MAPPER,
                     Mockito.mock(PeriodicMetrics.class),
                     configProvider,
-                    _organization.getId()
+                    _organization.getId(),
+                    Optional.empty()
             );
             alertRepository.open();
 


### PR DESCRIPTION
This is intended to solve the following problem:

1. Metrics portal is operating in a clustered state, with N > 1 nodes.
2. The entire fleet is restarted, perhaps during a deployment
3. The JobCoordinator for alerts restarts and then attempts to run anti-entropy to reconcile jobs
4. The anti-entropy job runs on a node that has not yet loaded its alert definitions, and so it sees an empty repository
5. Anti-entropy "succeeds" and there are no alerts until the next tick occurs in one hour.