### PR TITLE
wait for reload when opening the alert repository

### DIFF
--- a/app/com/arpnetworking/metrics/portal/config/impl/NullConfigProvider.java
+++ b/app/com/arpnetworking/metrics/portal/config/impl/NullConfigProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.metrics.portal.config.impl;
+
+import com.arpnetworking.metrics.portal.config.ConfigProvider;
+
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+/**
+ * An empty config provider that never sends any updates.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public class NullConfigProvider implements ConfigProvider {
+    @Override
+    public void start(final Consumer<InputStream> update) {}
+
+    @Override
+    public void stop() {}
+}

--- a/test/java/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepositoryTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/alerts/impl/PluggableAlertRepositoryTest.java
@@ -19,6 +19,7 @@ package com.arpnetworking.metrics.portal.alerts.impl;
 import com.arpnetworking.metrics.incubator.PeriodicMetrics;
 import com.arpnetworking.metrics.portal.TestBeanFactory;
 import com.arpnetworking.metrics.portal.config.ConfigProvider;
+import com.arpnetworking.metrics.portal.config.impl.NullConfigProvider;
 import com.arpnetworking.metrics.portal.config.impl.StaticFileConfigProvider;
 import com.arpnetworking.testing.SerializationTestUtils;
 import com.arpnetworking.utility.test.ResourceHelper;
@@ -35,6 +36,7 @@ import org.mockito.Mockito;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +81,8 @@ public class PluggableAlertRepositoryTest {
                 SerializationTestUtils.getApiObjectMapper(),
                 Mockito.mock(PeriodicMetrics.class),
                 new StaticFileConfigProvider(resourcePath),
-                _organization.getId()
+                _organization.getId(),
+                Duration.ofSeconds(1)
         );
         _repository.open();
     }
@@ -113,7 +116,8 @@ public class PluggableAlertRepositoryTest {
                 SerializationTestUtils.getApiObjectMapper(),
                 Mockito.mock(PeriodicMetrics.class),
                 mockConfigProvider,
-                _organization.getId()
+                _organization.getId(),
+                Duration.ofSeconds(1)
         );
 
         try {
@@ -201,6 +205,18 @@ public class PluggableAlertRepositoryTest {
     @Test
     public void testGetAlertCount() {
         assertThat(_repository.getAlertCount(_organization), equalTo(6L));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testWaitsForInitialReloadTimeoout() {
+        final PluggableAlertRepository repository = new PluggableAlertRepository(
+                SerializationTestUtils.getApiObjectMapper(),
+                Mockito.mock(PeriodicMetrics.class),
+                new NullConfigProvider(),
+                _organization.getId(),
+                Duration.ofSeconds(1)
+        );
+        repository.open();
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/test/java/controllers/AlertControllerTest.java
+++ b/test/java/controllers/AlertControllerTest.java
@@ -49,6 +49,7 @@ import play.mvc.Result;
 import play.test.Helpers;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +136,8 @@ public final class AlertControllerTest {
                     OBJECT_MAPPER,
                     Mockito.mock(PeriodicMetrics.class),
                     configProvider,
-                    _organization.getId()
+                    _organization.getId(),
+                    Duration.ofSeconds(1)
             );
             alertRepository.open();
 


### PR DESCRIPTION
Now we won't consider a repository open until it receives at least one update from the inner `ConfigProvider`. If that provides an empty stream, we can be confident that the repository is truly empty rather than unloaded.