### PR TITLE
singletons: return a ref to the proxy, not the manager

### DIFF
--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -729,11 +729,15 @@ public class MainModule extends AbstractModule {
             final Cluster cluster = Cluster.get(_system);
             // Start a singleton instance of the scheduler on a "host_indexer" node in the cluster.
             if (cluster.selfRoles().contains(INDEXER_ROLE)) {
-                return _system.actorOf(ClusterSingletonManager.props(
+                final ActorRef managerRef = _system.actorOf(ClusterSingletonManager.props(
                         _hostProviderProps,
                         PoisonPill.getInstance(),
                         ClusterSingletonManagerSettings.create(_system).withRole(INDEXER_ROLE)),
                         "host-provider-scheduler");
+                return _system.actorOf(ClusterSingletonProxy.props(
+                        managerRef.path().toStringWithoutAddress(),
+                        ClusterSingletonProxySettings.create(_system).withRole(INDEXER_ROLE)
+                ));
             }
             return null;
         }
@@ -765,7 +769,7 @@ public class MainModule extends AbstractModule {
             final Cluster cluster = Cluster.get(_system);
             // Start a singleton instance of the scheduler on a "host_indexer" node in the cluster.
             if (cluster.selfRoles().contains(ANTI_ENTROPY_ROLE)) {
-                return _system.actorOf(ClusterSingletonManager.props(
+                final ActorRef managerRef = _system.actorOf(ClusterSingletonManager.props(
                         JobCoordinator.props(_injector,
                                 ReportRepository.class,
                                 ReportExecutionRepository.class,
@@ -775,6 +779,10 @@ public class MainModule extends AbstractModule {
                         PoisonPill.getInstance(),
                         ClusterSingletonManagerSettings.create(_system).withRole(ANTI_ENTROPY_ROLE)),
                         "ReportJobCoordinator");
+                return _system.actorOf(ClusterSingletonProxy.props(
+                        managerRef.path().toStringWithoutAddress(),
+                        ClusterSingletonProxySettings.create(_system).withRole(ANTI_ENTROPY_ROLE)
+                ));
             }
             return null;
         }
@@ -807,9 +815,8 @@ public class MainModule extends AbstractModule {
         @Override
         public ActorRef get() {
             final Cluster cluster = Cluster.get(_system);
-            // Start a singleton instance of the scheduler on a "host_indexer" node in the cluster.
             if (cluster.selfRoles().contains(ANTI_ENTROPY_ROLE)) {
-                return _system.actorOf(ClusterSingletonManager.props(
+                final ActorRef managerRef = _system.actorOf(ClusterSingletonManager.props(
                         JobCoordinator.props(_injector,
                                 AlertJobRepository.class,
                                 AlertExecutionRepository.class,
@@ -819,6 +826,10 @@ public class MainModule extends AbstractModule {
                         PoisonPill.getInstance(),
                         ClusterSingletonManagerSettings.create(_system).withRole(ANTI_ENTROPY_ROLE)),
                         "AlertJobCoordinator");
+                return _system.actorOf(ClusterSingletonProxy.props(
+                        managerRef.path().toStringWithoutAddress(),
+                        ClusterSingletonProxySettings.create(_system).withRole(ANTI_ENTROPY_ROLE)
+                ));
             }
             return null;
         }

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -736,7 +736,7 @@ public class MainModule extends AbstractModule {
                         "host-provider-scheduler");
                 return _system.actorOf(ClusterSingletonProxy.props(
                         managerRef.path().toStringWithoutAddress(),
-                        ClusterSingletonProxySettings.create(_system).withRole(INDEXER_ROLE)
+                        ClusterSingletonProxySettings.create(_system)
                 ));
             }
             return null;
@@ -781,7 +781,7 @@ public class MainModule extends AbstractModule {
                         "ReportJobCoordinator");
                 return _system.actorOf(ClusterSingletonProxy.props(
                         managerRef.path().toStringWithoutAddress(),
-                        ClusterSingletonProxySettings.create(_system).withRole(ANTI_ENTROPY_ROLE)
+                        ClusterSingletonProxySettings.create(_system)
                 ));
             }
             return null;
@@ -828,7 +828,7 @@ public class MainModule extends AbstractModule {
                         "AlertJobCoordinator");
                 return _system.actorOf(ClusterSingletonProxy.props(
                         managerRef.path().toStringWithoutAddress(),
-                        ClusterSingletonProxySettings.create(_system).withRole(ANTI_ENTROPY_ROLE)
+                        ClusterSingletonProxySettings.create(_system)
                 ));
             }
             return null;


### PR DESCRIPTION
Several actor refs handed out in `MainModule` are incorrectly returning the cluster singleton manager, when instead they should be returning a reference to the proxy. 

The proxy **must be used** instead of the manager, otherwise the message won't be routed to the singleton actor. The rollup singletons are correctly implemented and these changes are based on those providers, e.g. ([RollupMetricsDiscoveryProvider](https://github.com/ArpNetworking/metrics-portal/compare/cluster_singleton_proxy?expand=1#diff-cca88e717fceea609a9f29e31e270390R889))

See https://doc.akka.io/docs/akka/2.5/cluster-singleton.html#an-example for details.