### PR TITLE
separate lookback and period hint, support non-unit periods

### DIFF
--- a/app/com/arpnetworking/metrics/portal/query/QueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/QueryExecutor.java
@@ -19,7 +19,7 @@ import models.internal.BoundedMetricsQuery;
 import models.internal.MetricsQuery;
 import models.internal.MetricsQueryResult;
 
-import java.time.temporal.ChronoUnit;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
@@ -53,7 +53,19 @@ public interface QueryExecutor {
      * @param query The query
      * @return The minimum polling period necessary to avoid missing data.
      */
-    default Optional<ChronoUnit> periodHint(final MetricsQuery query) {
+    default Optional<Duration> evaluationPeriodHint(final MetricsQuery query) {
         return Optional.empty();
     }
+
+    /**
+     * Return a minimum lookback period size for this query, if any.
+     *
+     * This is the minimal range necessary to query starting from the current timestamp
+     * in order to guarantee data for at least one aggregation period is returned,
+     * if it is available.
+     *
+     * @param query The query
+     * @return The minimum lookback period necessary for data.
+     */
+    Duration lookbackPeriod(MetricsQuery query);
 }

--- a/app/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutor.java
@@ -116,7 +116,7 @@ public class KairosDbQueryExecutor implements QueryExecutor {
         } catch (final IOException e) {
             throw new RuntimeException("Could not parse query", e);
         }
-        // The period hint of the query is the smallest of each metric within
+        // The lookback period of the query is the largest of each metric within
         return metricsQuery.getMetrics()
                 .stream()
                 .map(this::lookbackPeriod)
@@ -128,7 +128,7 @@ public class KairosDbQueryExecutor implements QueryExecutor {
     private Optional<Duration> lookbackPeriod(final Metric metric) {
         // NOTE: This makes no assumption on alignment, and so since the actual
         // periods aggregated can change between unaligned queries, the period
-        // hint is the most granular used anywhere in the chain.
+        // hint is the least granular used anywhere in the chain.
         return metric.getAggregators()
                 .stream()
                 .flatMap(agg -> Streams.stream(agg.getSampling()))

--- a/app/com/arpnetworking/metrics/portal/query/impl/NoQueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/impl/NoQueryExecutor.java
@@ -19,9 +19,11 @@ import com.arpnetworking.metrics.portal.query.QueryExecutionException;
 import com.arpnetworking.metrics.portal.query.QueryExecutor;
 import com.google.common.collect.ImmutableList;
 import models.internal.BoundedMetricsQuery;
+import models.internal.MetricsQuery;
 import models.internal.MetricsQueryResult;
 import models.internal.Problem;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Singleton;
@@ -39,5 +41,10 @@ public class NoQueryExecutor implements QueryExecutor {
         final CompletableFuture<MetricsQueryResult> cs = new CompletableFuture<>();
         cs.completeExceptionally(new QueryExecutionException("Queries are not enabled", ImmutableList.of(notEnabledProblem)));
         return cs;
+    }
+
+    @Override
+    public Duration lookbackPeriod(final MetricsQuery query) {
+        return Duration.ZERO;
     }
 }

--- a/test/java/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutorTest.java
@@ -30,7 +30,6 @@ import models.internal.MetricsQueryResult;
 import models.internal.TimeSeriesResult;
 import models.internal.impl.DefaultBoundedMetricsQuery;
 import models.internal.impl.DefaultMetricsQuery;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -42,7 +41,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -251,7 +249,9 @@ public class KairosDbQueryExecutorTest {
                 try {
                     _executor.lookbackPeriod(query);
                     fail("Expected exception to be thrown");
+                    // CHECKSTYLE.OFF: IllegalCatch
                 } catch (final Exception e) {
+                    // CHECKSTYLE.ON: IllegalCatch
                     assertThat(e, instanceOf(IllegalArgumentException.class));
                 }
             }


### PR DESCRIPTION
We use period hint for the lookback window on a query, but they should be considered separate concepts. One is the minimum range necessary for data, and the other is the minimum frequency that we should poll this query (these turn out to be the max and min of the aggregator sampling, respectively). We don't actually use the former right now, as all queries are evaluated every minute.

The second change is due to the incorrect assumption made that aggregators will always be a unit value (e.g. exactly 1 hour). There's no reason they shouldn't be, and by using `Duration` instead of `ChronoUnit` the lookback should be correctly computed for arbitrary aggregations like 12 hours.

`periodHint` is renamed to `evaluationPeriodHint` for clarity.
