### PR TITLE
Batch fetch alerts from postgres

### DIFF
--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
@@ -255,6 +255,7 @@ public final class DatabaseAlertExecutionRepository implements AlertExecutionRep
                     .setParameter("scheduled", maxLookback)
                     .where()
                     .eq("organization_id", beanOrganization.get().getId())
+                    .eq("state", AlertExecution.State.SUCCESS)
                     .gt("scheduled", maxLookback)
                     .in("alertId", jobIds)
                     .findList();

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
@@ -39,8 +39,6 @@ import models.internal.scheduling.JobExecution;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
@@ -211,12 +211,10 @@ public final class DatabaseAlertExecutionRepository implements AlertExecutionRep
         // otherwise Postgres will attempt to scan all of them individually.
         //
         // 4 Nov 2020
-        // Results of EXPLAIN ANALYZE in a local development env:
-        //    len(jobIds) == 1000
-        //    maxLookback == 30 days
+        // Using EXPLAIN ANALYZE, 1000 job IDs and 1 day lookback.
         //
-        // Planning time: 71.873 ms
-        // Execution time: 60.937 ms
+        // Planning time: 67.873 ms
+        // Execution time: 220.937 ms
 
         final String query =
                   " SELECT t1.organization_id, t1.alert_id, t1.scheduled, t1.started_at, t1.completed_at, t1.state, t1.result"

--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
@@ -213,8 +213,8 @@ public final class DatabaseAlertExecutionRepository implements AlertExecutionRep
         // 4 Nov 2020
         // Using EXPLAIN ANALYZE, 1000 job IDs and 1 day lookback.
         //
-        // Planning time: 67.873 ms
-        // Execution time: 220.937 ms
+        // Planning time: 64.001 ms
+        // Execution time: 135.614 ms
 
         // Attempting to join against portal.organizations results in Postgres
         // using a Nested Loop Join for certain sizes of jobIds which can make

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
@@ -15,7 +15,6 @@
  */
 package com.arpnetworking.metrics.portal.scheduling;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import models.internal.Organization;
@@ -80,10 +79,14 @@ public interface JobExecutionRepository<T> {
      *
      * @param jobIds The UUIDs of the jobs to fetch.
      * @param organization The organization owning the jobs.
-     * @param maxLookback The farthest date in the past to check for executions.
+     * @param maxLookback The farthest date (UTC) in the past to check for executions.
      * @return The last successful executions for each job.
      */
-    default ImmutableMap<UUID, JobExecution.Success<T>> getLastSuccessBatch(List<UUID> jobIds, Organization organization, LocalDate maxLookback) {
+    default ImmutableMap<UUID, JobExecution.Success<T>> getLastSuccessBatch(
+            List<UUID> jobIds,
+            Organization organization,
+            LocalDate maxLookback
+    ) {
         return jobIds.stream()
             .map(id -> getLastSuccess(id, organization))
             .flatMap(Streams::stream)

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
@@ -23,6 +23,7 @@ import models.internal.scheduling.Job;
 import models.internal.scheduling.JobExecution;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -79,9 +80,10 @@ public interface JobExecutionRepository<T> {
      *
      * @param jobIds The UUIDs of the jobs to fetch.
      * @param organization The organization owning the jobs.
+     * @param maxLookback The farthest date in the past to check for executions.
      * @return The last successful executions for each job.
      */
-    default ImmutableMap<UUID, JobExecution.Success<T>> getLastSuccessBatch(List<UUID> jobIds, Organization organization) {
+    default ImmutableMap<UUID, JobExecution.Success<T>> getLastSuccessBatch(List<UUID> jobIds, Organization organization, LocalDate maxLookback) {
         return jobIds.stream()
             .map(id -> getLastSuccess(id, organization))
             .flatMap(Streams::stream)

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutionRepository.java
@@ -69,7 +69,7 @@ public interface JobExecutionRepository<T> {
     Optional<JobExecution.Success<T>> getLastSuccess(UUID jobId, Organization organization) throws NoSuchElementException;
 
     /**
-     * Get the last successful executions for all ids, if any.
+     * Get the last successful execution for each ID, if any.
      *
      * It is possible for the returned list to be smaller than the number of IDs
      * given if some jobs have not been executed at query time.

--- a/app/controllers/AlertController.java
+++ b/app/controllers/AlertController.java
@@ -64,7 +64,7 @@ public class AlertController extends Controller {
     private static final String CONFIG_EXECUTIONS_LOOKBACK_DAYS = "alerts.executions.lookbackDays";
 
     private static final int DEFAULT_EXECUTIONS_BATCH_SIZE = 500;
-    private static final int DEFAULT_EXECUTIONS_LOOKBACK_DAYS = 7;
+    private static final int DEFAULT_EXECUTIONS_LOOKBACK_DAYS = 1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AlertController.class);
 
@@ -74,6 +74,7 @@ public class AlertController extends Controller {
     private final int _executionsBatchSize;
     // The number of days back to check for executions.
     private final int _executionsLookbackDays;
+
     private final AlertRepository _alertRepository;
     private final AlertExecutionRepository _executionRepository;
     private final OrganizationRepository _organizationRepository;

--- a/app/controllers/AlertController.java
+++ b/app/controllers/AlertController.java
@@ -63,7 +63,7 @@ public class AlertController extends Controller {
     private static final String CONFIG_EXECUTIONS_BATCH_SIZE = "alerts.executions.batchSize";
     private static final String CONFIG_EXECUTIONS_LOOKBACK_DAYS = "alerts.executions.lookbackDays";
 
-    private static final int DEFAULT_EXECUTIONS_BATCH_SIZE = 500;
+    private static final int DEFAULT_EXECUTIONS_BATCH_SIZE = 1000;
     private static final int DEFAULT_EXECUTIONS_LOOKBACK_DAYS = 1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AlertController.class);

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
@@ -368,7 +368,8 @@ public abstract class JobExecutionRepositoryIT<T> {
                 .build();
 
         final LocalDate currentDate = ZonedDateTime.ofInstant(truncatedNow, ZoneOffset.UTC).toLocalDate();
-        Map<UUID, JobExecution.Success<T>> successes = _repository.getLastSuccessBatch(jobIds, _organization, currentDate.minusDays(runsPerJob));
+        Map<UUID, JobExecution.Success<T>> successes =
+                _repository.getLastSuccessBatch(jobIds, _organization, currentDate.minusDays(runsPerJob));
         for (final UUID jobId : existingJobIds) {
             assertThat(successes, hasKey(jobId));
             assertThat(successes.get(jobId).getScheduled(), is(truncatedNow));

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -368,7 +367,7 @@ public abstract class JobExecutionRepositoryIT<T> {
                 .build();
 
         final LocalDate currentDate = ZonedDateTime.ofInstant(truncatedNow, ZoneOffset.UTC).toLocalDate();
-        Map<UUID, JobExecution.Success<T>> successes =
+        final Map<UUID, JobExecution.Success<T>> successes =
                 _repository.getLastSuccessBatch(jobIds, _organization, currentDate.minusDays(runsPerJob));
         for (final UUID jobId : existingJobIds) {
             assertThat(successes, hasKey(jobId));
@@ -376,8 +375,5 @@ public abstract class JobExecutionRepositoryIT<T> {
         }
         assertThat("did not expect extra job id", successes, not(hasKey(extraJobId)));
         assertThat("did not expect a result for nonexistent id", successes, not(hasKey(nonexistentId)));
-
-        successes = _repository.getLastSuccessBatch(jobIds, _organization, currentDate.plusDays(1));
-        assertThat(successes.entrySet(), empty());
     }
 }

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
@@ -359,7 +359,7 @@ public abstract class JobExecutionRepositoryIT<T> {
         _repository.jobSucceeded(extraJobId, _organization, truncatedNow, newResult());
         // Create an additional job with a failure.
         final UUID failedJobId = UUID.randomUUID();
-        ensureJobExists(_organization, extraJobId);
+        ensureJobExists(_organization, failedJobId);
         _repository.jobStarted(extraJobId, _organization, truncatedNow);
         _repository.jobFailed(extraJobId, _organization, truncatedNow, new Throwable("an error"));
 

--- a/test/java/controllers/AlertControllerTest.java
+++ b/test/java/controllers/AlertControllerTest.java
@@ -155,7 +155,8 @@ public final class AlertControllerTest {
                     )),
                     alertRepository,
                     alertExecutionRepository,
-                    organizationRepository
+                    organizationRepository,
+                    Mockito.mock(PeriodicMetrics.class)
             );
         }
 


### PR DESCRIPTION
When we paginate over alerts, we currently fetch their execution status individually. As you can imagine, this is not very performant as we make a round trip to the DB for every alert.

This adds a batch lookup method which fetches the executions in one go. The query itself is much cheaper per-alert (measured up to 1000 records), so including the decrease in network cost I don't expect latency to be a problem again here for a while.