### PR TITLE
Do not use rollups when evaluating alerts

### DIFF
--- a/app/com/arpnetworking/kairos/service/DefaultQueryContext.java
+++ b/app/com/arpnetworking/kairos/service/DefaultQueryContext.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.kairos.service;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import net.sf.oval.constraint.NotNull;
+
+/**
+ * Default implementation for QueryContext.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public final class DefaultQueryContext implements QueryContext {
+    private final QueryOrigin _origin;
+
+    private DefaultQueryContext(final Builder builder) {
+        _origin = builder._origin;
+    }
+
+    @Override
+    public QueryOrigin getOrigin() {
+        return _origin;
+    }
+
+    /**
+     * Builder for instances of {@link DefaultQueryContext}.
+     */
+    public static final class Builder extends OvalBuilder<DefaultQueryContext> {
+        @NotNull
+        private QueryOrigin _origin;
+
+        /**
+         * Construct a new Builder instance.
+         */
+        public Builder() {
+            super(DefaultQueryContext::new);
+        }
+
+        /**
+         * Set the origin of this query context. Required. Cannot be null.
+         *
+         * @param value the origin
+         * @return this Builder instance for chaining
+         */
+        public Builder setOrigin(final QueryOrigin value) {
+            _origin = value;
+            return this;
+        }
+    }
+}

--- a/app/com/arpnetworking/kairos/service/KairosDbService.java
+++ b/app/com/arpnetworking/kairos/service/KairosDbService.java
@@ -42,10 +42,11 @@ public interface KairosDbService {
     /**
      * Executes a query for datapoints from KairosDB.
      *
+     * @param context the context associated with this query
      * @param query the metrics query
      * @return the response
      */
-    CompletionStage<MetricsQueryResponse> queryMetrics(MetricsQuery query);
+    CompletionStage<MetricsQueryResponse> queryMetrics(QueryContext context, MetricsQuery query);
 
     /**
      * Queries KairosDB for metric names.

--- a/app/com/arpnetworking/kairos/service/QueryContext.java
+++ b/app/com/arpnetworking/kairos/service/QueryContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.kairos.service;
+
+/**
+ * QueryContext specifies information about the current query.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public interface QueryContext {
+    /**
+     * Return the origin of the current query.
+     *
+     * @return the origin of the current query.
+     */
+    QueryOrigin getOrigin();
+}

--- a/app/com/arpnetworking/kairos/service/QueryOrigin.java
+++ b/app/com/arpnetworking/kairos/service/QueryOrigin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Dropbox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.kairos.service;
+
+/**
+ * The origin of a query specifies if it was the result of external traffic
+ * or some internal service or process.
+ *
+ * @author Christian Briones (cbriones at dropbox dot com)
+ */
+public enum QueryOrigin {
+    /**
+     * Queries which originated via the public REST API.
+     */
+    EXTERNAL_REQUEST,
+    /**
+     * Queries which originated from evaluating alert definitions.
+     */
+    ALERT_EVALUATION
+}

--- a/app/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutor.java
@@ -16,10 +16,10 @@
 
 package com.arpnetworking.metrics.portal.query.impl;
 
+import com.arpnetworking.kairos.client.KairosDbClient;
 import com.arpnetworking.kairos.client.models.Metric;
 import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
 import com.arpnetworking.kairos.client.models.SamplingUnit;
-import com.arpnetworking.kairos.service.KairosDbService;
 import com.arpnetworking.metrics.portal.query.QueryExecutor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -46,18 +46,18 @@ import javax.inject.Inject;
  * @author Christian Briones (cbriones at dropbox dot com)
  */
 public class KairosDbQueryExecutor implements QueryExecutor {
-    private final KairosDbService _service;
+    private final KairosDbClient _client;
     private final ObjectMapper _objectMapper;
 
     /**
      * Default Constructor.
      *
-     * @param service The KairosDBService used to execute queries.
+     * @param client The KairosDBService used to execute queries.
      * @param objectMapper The objectMapper used to parse queries.
      */
     @Inject
-    public KairosDbQueryExecutor(final KairosDbService service, final ObjectMapper objectMapper) {
-        _service = service;
+    public KairosDbQueryExecutor(final KairosDbClient client, final ObjectMapper objectMapper) {
+        _client = client;
         _objectMapper = objectMapper;
     }
 
@@ -159,7 +159,7 @@ public class KairosDbQueryExecutor implements QueryExecutor {
         //
         // However, since the service call will still resolve with an exception
         // this is mostly an issue of debuggability.
-        return _service.queryMetrics(metricsQuery).thenApply(this::toInternal);
+        return _client.queryMetrics(metricsQuery).thenApply(this::toInternal);
     }
 
     private MetricsQueryResult toInternal(final MetricsQueryResponse kairosDbResult) {

--- a/app/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutor.java
+++ b/app/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutor.java
@@ -52,7 +52,7 @@ public class KairosDbQueryExecutor implements QueryExecutor {
     /**
      * Default Constructor.
      *
-     * @param client The KairosDBService used to execute queries.
+     * @param client The KairosDB client used to execute queries.
      * @param objectMapper The objectMapper used to parse queries.
      */
     @Inject
@@ -155,9 +155,9 @@ public class KairosDbQueryExecutor implements QueryExecutor {
         final com.arpnetworking.kairos.client.models.MetricsQuery metricsQuery = metricsQueryBuilder.build();
         // TODO(cbriones):
         // This will not propagate the structured error information from KairosDB
-        // until _service provides that capability.
+        // until the client provides that capability.
         //
-        // However, since the service call will still resolve with an exception
+        // However, since the client call will still resolve with an exception
         // this is mostly an issue of debuggability.
         return _client.queryMetrics(metricsQuery).thenApply(this::toInternal);
     }

--- a/app/controllers/KairosDbProxyController.java
+++ b/app/controllers/KairosDbProxyController.java
@@ -21,7 +21,10 @@ import com.arpnetworking.kairos.client.models.Aggregator;
 import com.arpnetworking.kairos.client.models.Metric;
 import com.arpnetworking.kairos.client.models.MetricsQuery;
 import com.arpnetworking.kairos.client.models.TagsQuery;
+import com.arpnetworking.kairos.service.DefaultQueryContext;
 import com.arpnetworking.kairos.service.KairosDbService;
+import com.arpnetworking.kairos.service.QueryContext;
+import com.arpnetworking.kairos.service.QueryOrigin;
 import com.arpnetworking.play.ProxyClient;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
@@ -179,7 +182,11 @@ public class KairosDbProxyController extends Controller {
                 metricsQuery = checkAndAddMergeAggregator(metricsQuery);
             }
 
-            return _kairosService.queryMetrics(metricsQuery)
+            final QueryContext context = new DefaultQueryContext.Builder()
+                    .setOrigin(QueryOrigin.EXTERNAL_REQUEST)
+                    .build();
+
+            return _kairosService.queryMetrics(context, metricsQuery)
                     .<JsonNode>thenApply(_mapper::valueToTree)
                     .thenApply(Results::ok);
         } catch (final IOException e) {

--- a/app/global/MainModule.java
+++ b/app/global/MainModule.java
@@ -44,6 +44,7 @@ import com.arpnetworking.kairos.config.MetricsQueryConfig;
 import com.arpnetworking.kairos.config.MetricsQueryConfigImpl;
 import com.arpnetworking.kairos.service.KairosDbService;
 import com.arpnetworking.kairos.service.KairosDbServiceImpl;
+import com.arpnetworking.kairos.service.QueryOrigin;
 import com.arpnetworking.metrics.MetricsFactory;
 import com.arpnetworking.metrics.Sink;
 import com.arpnetworking.metrics.impl.ApacheHttpSink;
@@ -120,6 +121,7 @@ import java.net.URI;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -534,12 +536,19 @@ public class MainModule extends AbstractModule {
         final ImmutableSet<String> excludedTagNames = ImmutableSet.copyOf(
                 configuration.getStringList("kairosdb.proxy.excludedTagNames"));
 
+        final ImmutableSet<QueryOrigin> rollupEnabledOrigins =
+                configuration.getStringList("kairosdb.proxy.rollups.enabledOrigins")
+                    .stream()
+                    .map(QueryOrigin::valueOf)
+                    .collect(ImmutableSet.toImmutableSet());
+
         return new KairosDbServiceImpl.Builder()
                 .setKairosDbClient(kairosDbClient)
                 .setMetricsFactory(metricsFactory)
                 .setExcludedTagNames(excludedTagNames)
                 .setMetricsQueryConfig(metricsQueryConfig)
                 .setRewrittenQueryConsumer(rewrittenQueryConsumer)
+                .setRollupEnabledOrigins(EnumSet.copyOf(rollupEnabledOrigins))
                 .build();
     }
 

--- a/conf/portal.application.conf
+++ b/conf/portal.application.conf
@@ -203,6 +203,9 @@ kairosdb.proxy {
          pattern = ".*",
       }
   ]
+  rollups.enabledOrigins = [
+    EXTERNAL_REQUEST
+  ]
 }
 
 # Reporting

--- a/test/java/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutorTest.java
+++ b/test/java/com/arpnetworking/metrics/portal/query/impl/KairosDbQueryExecutorTest.java
@@ -16,8 +16,8 @@
 
 package com.arpnetworking.metrics.portal.query.impl;
 
+import com.arpnetworking.kairos.client.KairosDbClient;
 import com.arpnetworking.kairos.client.models.MetricsQueryResponse;
-import com.arpnetworking.kairos.service.KairosDbService;
 import com.arpnetworking.testing.SerializationTestUtils;
 import com.arpnetworking.utility.test.ResourceHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -69,16 +69,16 @@ public class KairosDbQueryExecutorTest {
      * Shared test setup.
      */
     public abstract static class BaseTests {
-        protected KairosDbService _service;
+        protected KairosDbClient _client;
         protected KairosDbQueryExecutor _executor;
         protected ObjectMapper _objectMapper;
 
         @Before
         public void setUp() {
-            _service = Mockito.mock(KairosDbService.class);
+            _client = Mockito.mock(KairosDbClient.class);
             _objectMapper = SerializationTestUtils.getApiObjectMapper();
             _executor = new KairosDbQueryExecutor(
-                    _service,
+                    _client,
                     _objectMapper
             );
         }
@@ -102,7 +102,7 @@ public class KairosDbQueryExecutorTest {
 
             final ArgumentCaptor<com.arpnetworking.kairos.client.models.MetricsQuery> captor = ArgumentCaptor.forClass(
                     com.arpnetworking.kairos.client.models.MetricsQuery.class);
-            when(_service.queryMetrics(captor.capture())).thenReturn(CompletableFuture.completedFuture(response));
+            when(_client.queryMetrics(captor.capture())).thenReturn(CompletableFuture.completedFuture(response));
 
             final BoundedMetricsQuery query = loadTestQuery();
             final com.arpnetworking.kairos.client.models.MetricsQuery parsedQuery =
@@ -142,7 +142,7 @@ public class KairosDbQueryExecutorTest {
 
         @Test(expected = ExecutionException.class)
         public void testKairosDBReturnsError() throws Exception {
-            when(_service.queryMetrics(any())).thenThrow(new RuntimeException("boom"));
+            when(_client.queryMetrics(any())).thenThrow(new RuntimeException("boom"));
             final BoundedMetricsQuery query = loadTestQuery();
             _executor.executeQuery(query).toCompletableFuture().get();
         }


### PR DESCRIPTION
We want to avoid the use of rollups in alert evaluation, which could potentially affect correctness. For example, if rollups were continually an hour behind, an hourly sample-aligned query would never see any data.

This adds per-origin (alerts, rest API) controls for enabling rollups. By default rollups are disabled for alerts. If we build sufficient confidence we can re-enable these for alerts in the future.