### PR TITLE
Fix bug in batch fetch for last successful evaluation

### DIFF
--- a/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
+++ b/app/com/arpnetworking/metrics/portal/alerts/impl/DatabaseAlertExecutionRepository.java
@@ -222,6 +222,7 @@ public final class DatabaseAlertExecutionRepository implements AlertExecutionRep
                 + " JOIN (SELECT alert_id, max(completed_at) completed_at"
                 + "         FROM portal.alert_executions"
                 + "         WHERE scheduled >= :scheduled"
+                + "           AND state = :state"
                 + "         GROUP BY alert_id) t2"
                 + " ON t1.alert_id = t2.alert_id AND t1.completed_at = t2.completed_at"
                 + " WHERE t1.organization_id = (SELECT id FROM portal.organizations WHERE uuid = :organization_uuid)";
@@ -242,8 +243,8 @@ public final class DatabaseAlertExecutionRepository implements AlertExecutionRep
                     .setRawSql(rawSql)
                     .setParameter("scheduled", maxLookback)
                     .setParameter("organization_uuid", organization.getId())
+                    .setParameter("state", AlertExecution.State.SUCCESS)
                     .where()
-                    .eq("state", AlertExecution.State.SUCCESS)
                     .gt("scheduled", maxLookback)
                     .in("alertId", jobIds)
                     .findList();

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
@@ -362,6 +362,9 @@ public abstract class JobExecutionRepositoryIT<T> {
         ensureJobExists(_organization, failedJobId);
         _repository.jobStarted(extraJobId, _organization, truncatedNow);
         _repository.jobFailed(extraJobId, _organization, truncatedNow, new Throwable("an error"));
+        // Create a failure for one of the requested Job IDs
+        _repository.jobStarted(existingJobIds.get(0), _organization, truncatedNow);
+        _repository.jobFailed(existingJobIds.get(0), _organization, truncatedNow, new Throwable("an error"));
 
         // Request an ID that doesn't exist.
         final UUID nonexistentId = UUID.randomUUID();

--- a/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
+++ b/test/java/com/arpnetworking/metrics/portal/integration/repositories/JobExecutionRepositoryIT.java
@@ -352,19 +352,22 @@ public abstract class JobExecutionRepositoryIT<T> {
                 _repository.jobSucceeded(jobId, _organization, scheduled, result);
             }
         }
+        // Create a failed execution in the "future" for one job id
+        final Instant futureRun = truncatedNow.plus(Duration.ofDays(1));
+        _repository.jobStarted(existingJobIds.get(0), _organization, futureRun);
+        _repository.jobFailed(existingJobIds.get(0), _organization, futureRun, new Throwable("an error"));
+
         // Create an additional job that we don't care about.
         final UUID extraJobId = UUID.randomUUID();
         ensureJobExists(_organization, extraJobId);
         _repository.jobStarted(extraJobId, _organization, truncatedNow);
         _repository.jobSucceeded(extraJobId, _organization, truncatedNow, newResult());
+
         // Create an additional job with a failure.
         final UUID failedJobId = UUID.randomUUID();
         ensureJobExists(_organization, failedJobId);
         _repository.jobStarted(extraJobId, _organization, truncatedNow);
         _repository.jobFailed(extraJobId, _organization, truncatedNow, new Throwable("an error"));
-        // Create a failure for one of the requested Job IDs
-        _repository.jobStarted(existingJobIds.get(0), _organization, truncatedNow);
-        _repository.jobFailed(existingJobIds.get(0), _organization, truncatedNow, new Throwable("an error"));
 
         // Request an ID that doesn't exist.
         final UUID nonexistentId = UUID.randomUUID();


### PR DESCRIPTION
The state filter should occur on the inner query, before the join. This affected alerts that have at least one successful run when the most recent is a failure.