### PR TITLE
rethrow, don't killSelf()

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -131,7 +131,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .setThrowable(e)
                     .addData("actorName", actorName)
                     .log();
-            killSelf();
+            killSelfPermanently();
         }
     }
 
@@ -149,7 +149,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
         timers().startSingleTimer(EXTRA_TICK_TIMER_NAME, Tick.INSTANCE, delta);
     }
 
-    private void killSelf() {
+    private void killSelfPermanently() {
         getContext().getParent().tell(new ShardRegion.Passivate(PoisonPill.getInstance()), getSelf());
     }
 
@@ -291,7 +291,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .setMessage("job has no more scheduled runs")
                     .addData("cachedJob", cachedJob)
                     .log();
-            killSelf();
+            killSelfPermanently();
             return;
         }
 
@@ -306,7 +306,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                         .addData("ref", cachedJob.getRef())
                         .addData("scheduled", _nextRun.get())
                         .log();
-                killSelf();
+                killSelfPermanently();
             }
         }
     }
@@ -332,7 +332,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .setMessage("tried to reload job, but job no longer exists in repository")
                     .addData("ref", message.getJobRef())
                     .log();
-            killSelf();
+            killSelfPermanently();
             return;
         }
         timers().startPeriodicTimer(PERIODIC_TICK_TIMER_NAME, Tick.INSTANCE, TICK_INTERVAL);
@@ -399,7 +399,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .addData("ref", ref)
                     .addData("scheduled", message.getScheduled())
                     .log();
-            killSelf();
+            killSelfPermanently();
             return;
             // CHECKSTYLE.OFF: IllegalCatch - Without logging we won't know which
             // job was correlated with this exception. We still restart the actor

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -420,7 +420,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
             //
             // We do this instead of reload directly because our supervisor will rate limit
             // the resurrection of our actor, whereas reloading directly could lead to
-            // a tight retry loop.
+            // a tight retry loop if the DB issue is not transient.
             throw e;
         }
 

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -413,8 +413,15 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .addData("scheduled", message.getScheduled())
                     .addData("jobError", message.getError())
                     .log();
-            killSelf();
-            return;
+
+            // Rethrow to crash the actor.
+            //
+            // This will indirectly trigger a reload anyway (see JobExecutorActor#preStart).
+            //
+            // We do this instead of reload directly because our supervisor will rate limit
+            // the resurrection of our actor, whereas reloading directly could lead to
+            // a tight retry loop.
+            throw e;
         }
 
         getSelf().tell(new Reload.Builder<T>().setJobRef(ref).build(), getSelf());


### PR DESCRIPTION
This fixes a regression introduced in #472. killSelf will permanently kill the actor, and it will not be resurrected by the supervisor. We should not do this on DB failure, so instead we rethrow to trigger this behavior.

I've also renamed the method to make it clear it will stop the actor forever.