### PR TITLE
Fix a metric being logged in JobExecutorActor

### DIFF
--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -352,7 +352,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
             initializeOrEnsureRefMatch(ref);
             _periodicMetrics.recordCounter(
                     "jobs/executor/by_type/"
-                            + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, _cachedJob.getClass().getSimpleName())
+                            + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, _cachedJob.get().getClass().getSimpleName())
                             + "/reload",
                     1);
         } catch (final NoSuchJobException error) {


### PR DESCRIPTION
Now that _cachedJob is an Optional, we're missing a call to Optional#get().