### PR TITLE
don't allow for reloads to start another job execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,7 @@ jobs:
             ~/.sbt
           key: ${{ runner.os }}-m2-sbt-ivy-${{ hashFiles('pom.xml', '**/*.sbt', 'project/build.properties') }}
           restore-keys: ${{ runner.os }}-m2-sbt-ivy-
+      - name: Dump POM (Debug)
+        run: ./jdk-wrapper.sh ./mvnw help:effective-pom
       - name: Maven Verify
         run: ./jdk-wrapper.sh ./mvnw clean verify -P rpm -U -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "disabled"
+}

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -181,6 +181,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
         super.postRestart(reason);
         LOGGER.info()
                 .setMessage("restarting after error")
+                .addData("actorRef", self())
                 .setThrowable(reason)
                 .log();
     }
@@ -210,6 +211,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
 
         LOGGER.info()
                 .setMessage("initializing")
+                .addData("actorRef", self())
                 .addData("ref", ref)
                 .log();
 
@@ -252,6 +254,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                 .addData("job", job)
                 .addData("ref", ref)
                 .addData("lastRun", _lastRun)
+                .addData("actorRef", self())
                 .log();
             return;
         }
@@ -346,6 +349,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .addData("job", _cachedJob)
                     .addData("ref", _ref)
                     .addData("lastRun", _lastRun)
+                    .addData("actorRef", self())
                     .log();
             killSelfPermanently();
             return;
@@ -378,6 +382,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                 .addData("jobRef", _ref)
                 .addData("oldETag", _cachedJob.flatMap(Job::getETag))
                 .addData("newETag", eTag)
+                .addData("actorRef", self())
                 .log();
         _periodicMetrics.recordCounter("jobs/executor/reload", 1);
         final JobRef<T> ref = unsafeJobRefCast(message.getJobRef());
@@ -413,6 +418,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .setMessage("uninitialized, but got completion message (perhaps from previous life?)")
                     .addData("scheduled", message.getScheduled())
                     .addData("error", message.getError())
+                    .addData("actorRef", self())
                     .log();
             return;
         }
@@ -441,6 +447,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .setMessage("marking job as successful")
                     .addData("ref", ref)
                     .addData("scheduled", message.getScheduled())
+                    .addData("actorRef", self())
                     .log();
             updateFut = repo.jobSucceeded(
                     ref.getJobId(),
@@ -453,6 +460,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                     .setMessage("marking job as failed")
                     .addData("ref", ref)
                     .addData("scheduled", message.getScheduled())
+                    .addData("actorRef", self())
                     .setThrowable(message.getError())
                     .log();
             updateFut = repo.jobFailed(
@@ -472,6 +480,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                             .setMessage("tried to mark job as complete, but job no longer exists in repository")
                             .addData("ref", ref)
                             .addData("scheduled", message.getScheduled())
+                            .addData("actorRef", self())
                             .log();
                     return REQUEST_PERMANENT_SHUTDOWN;
                 }
@@ -481,6 +490,7 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
                         .addData("ref", ref)
                         .addData("scheduled", message.getScheduled())
                         .addData("jobError", message.getError())
+                        .addData("actorRef", self())
                         .log();
                 // Propagate the exception.
                 //

--- a/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
+++ b/app/com/arpnetworking/metrics/portal/scheduling/JobExecutorActor.java
@@ -665,7 +665,8 @@ public final class JobExecutorActor<T> extends AbstractActorWithTimers {
     /**
      * Newtype wrapper around a {@link Reload} to mark its origin as the completion
      * of a job, vs an anti-entropy tick or restart tick.
-     * @param <T>
+     *
+     * @param <T> The type of the result computed by the referenced {@link Job}.
      */
     private static final class ExecutionCompleted<T> {
         private final Reload<T> _reload;

--- a/maven/maven-wrapper.properties
+++ b/maven/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #Maven download properties
-#Sat Oct 27 14:16:07 PDT 2018
+#Wed Feb 10 15:52:42 PST 2021
 checksumAlgorithm=SHA1
 verifyDownload=true
-distributionUrl=https\://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https\://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/maven/maven-wrapper.properties
+++ b/maven/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #Maven download properties
-#Wed Feb 10 15:52:42 PST 2021
+#Sat Oct 27 14:16:07 PDT 2018
 checksumAlgorithm=SHA1
 verifyDownload=true
-distributionUrl=https\://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https\://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
 
     <!-- Project Overrides -->
     <buildDirectory>${project.basedir}/target</buildDirectory>
+    <maven.version>3.6.3</maven.version>
 
     <!-- Assembly Overrides -->
     <tgz.finalName>${project.build.finalName}</tgz.finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,7 @@
         </configuration>
       </plugin>
       <!-- Temporarily disable display-dependency-updates which does not work in GitHub Actions -->
-      <!-- TODO(TICKET): Remove this block. -->
+      <!-- See: https://github.com/ArpNetworking/metrics-portal/issues/487 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,19 @@
           <skip>${skipDockerBuild}</skip>
         </configuration>
       </plugin>
+      <!-- Temporarily disable display-dependency-updates which does not work in GitHub Actions -->
+      <!-- TODO(TICKET): Remove this block. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.5</version>
+        <executions>
+          <execution>
+            <id>default-display-dependency-updates</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/settings.xml
+++ b/settings.xml
@@ -15,12 +15,4 @@
       <password>${env.DOCKER_PASSWORD}</password>
     </server>
   </servers>
-  <mirrors>
-    <mirror>
-      <id>maven-central</id>
-      <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2</url>
-      <mirrorOf>central</mirrorOf>
-    </mirror>
-  </mirrors>
 </settings>


### PR DESCRIPTION
Fixes a bug with reloads that occurs as follows:
* Job begins executing and sets the currentlyExecutingFlag
* Anti-entropy kicks in and sends a `Reload` message.
* Reload thinks that it's been triggered by the completion of a job, and so clears the currentlyExecuting flag
* Reload completes and immediately kicks off a second execution (via tick).

This makes it so we only clear the execution flag if we're sure the Reload message occurred internally, otherwise it's ignored since we'll already reload when the execution completes.