### PR TITLE
Add client side aggregation of telemetry metrics for the same series.

### DIFF
--- a/app/assets/javascripts/classes/GraphVM.ts
+++ b/app/assets/javascripts/classes/GraphVM.ts
@@ -161,7 +161,7 @@ class GraphVM implements StatisticView {
         if (index == undefined) {
             index = this.data.length;
             this.dataStreams[cvm.server] = index;
-            var series = new Series(cvm.server, cvm.color());
+            var series = new Series(cvm.server, cvm.color(), this.spec.statistic);
             series.colorSubscription = cvm.color.subscribe((color: String) => {
                 this.updateColor(cvm);
             });

--- a/app/assets/javascripts/classes/Series.ts
+++ b/app/assets/javascripts/classes/Series.ts
@@ -24,6 +24,19 @@ class Series {
     bars: any = { show: false, stacked: false };
     color: string = "black";
     colorSubscription: KnockoutSubscription;
+    merger: (x: number, y: number) => number;
+
+    static mergeBySum = function(x: number, y: number): number {
+        return x + y;
+    };
+
+    static mergeByMin = function(x: number, y: number): number {
+        return x < y ? x : y;
+    };
+
+    static mergeByMax = function(x: number, y: number): number {
+        return x > y ? x : y;
+    };
 
     static defaultPoints() {
         return  { show: true };
@@ -37,23 +50,43 @@ class Series {
         return { show: false, stacked: false };
     }
 
-    constructor(label: string, color: string) {
+    constructor(label: string, color: string, statistic: string) {
         this.color = color;
         this.label = label;
+        if (statistic == "sum" || statistic == "count") {
+            this.merger = Series.mergeBySum;
+        } else if (statistic == "max") {
+            this.merger = Series.mergeByMax;
+        } else if (statistic == "min") {
+            this.merger = Series.mergeByMin;
+        } else {
+            // Obviously this is very broken for percentiles.
+            this.merger = Series.mergeByMax;
+        }
     }
 
     pushData(timestamp: number, dataValue: number, paused: boolean) {
-        if (this.data.length == 0 || this.data[this.data.length - 1][0] < timestamp) {
-            if (paused) {
-                this.buffer.push([timestamp, dataValue]);
-            } else {
-                if (this.buffer.length > 0) {
-                    this.data = this.data.concat(this.buffer);
-                    this.buffer = [];
-                }
-
-                this.data.push([timestamp, dataValue]);
+        if (paused) {
+            // While paused any values that would merge into data are dropped
+            this.pushInternal(this.buffer, timestamp, dataValue);
+        } else {
+            if (this.buffer.length > 0) {
+                this.data = this.data.concat(this.buffer);
+                this.buffer = [];
             }
+            this.pushInternal(this.data, timestamp, dataValue);
+        }
+    }
+
+    pushInternal(target: number [][], timestamp: number, dataValue: number) {
+        // This only supports in-order merge (for now)
+        if (target.length == 0 || target[target.length - 1][0] < timestamp) {
+            target.push([timestamp, dataValue]);
+        } else if (target[target.length - 1][0] == timestamp) {
+            const currentValue = target[target.length - 1][1]
+            target[target.length - 1][1] = this.merger(currentValue, dataValue);
+        } else {
+            console.log("Received out of order data: " + timestamp + " vs" + target[target.length - 1][0] + " for " + this.label);
         }
     }
 }


### PR DESCRIPTION
This is an incremental improvement.

This addresses the case where MAD sends multiple values for the same metric name because it has tags outside of host, service, and cluster. Even "host" is broken today because the clientside code assume host == connection. This is not always the case.

This obviously does not work for histograms or percentiles. However, these are broken at the protocol level. There is a patch in MAD-2.0 to address histograms, although it still won't provide correct client side aggregation until we send the actual histogram over.